### PR TITLE
Changed "lastImageInfo" documentation

### DIFF
--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -21,9 +21,9 @@ typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
 The array $GLOBALS['TSFE']->lastImageInfo is set with the info-array
 of the returning image (if any) and contains width, height and so on:
 
-=============================  ==========================================
+=============================  =============================================
 Name of the getText property   Content
-=============================  ==========================================
+=============================  =============================================
 0                              width
 1                              height
 2                              file extension
@@ -32,7 +32,7 @@ origFile                       relative URL pointing to the original file
 _mtime                         modification time of the original file
 originalFile                   The FAL object referencing the original file
 processedFile                  The FAL object referencing the processed file
-=============================  ==========================================
+=============================  =============================================
 
 **Note:** Gifbuilder also has an :ref:`IMAGE object <gifbuilder-image>` -
 do not mix that one up with the cObject described here; both are


### PR DESCRIPTION
This makes the following gerrit review unnecessary as the API has changed in 6.2:
https://review.typo3.org/#/c/30631/4,publish
