### PR TITLE
Update example for <source srcset= according to latest bugfix

### DIFF
--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -189,7 +189,7 @@ layoutKey
            .. code-block:: html
 
               <picture>
-                 <source src="###SRC###"
+                 <source srcset="###SRC###"
                          media="###MEDIAQUERY###"###SELFCLOSINGTAGSLASH###>
                  <img src="###SRC###" ###PARAMS### ###ALTPARAMS######SELFCLOSINGTAGSLASH###>
               </picture>


### PR DESCRIPTION
Master patch: https://review.typo3.org/34405
Backport to 6.2
