### PR TITLE
[CLEANUP] Remove obsolete note on allowed class prefixes

### DIFF
--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -49,11 +49,6 @@ outside the main page-rendering.
          .preUserFunc). The second parameter is an array with the properties of
          this cObject, if any.
 
-         **Note:** When using a function, the name of the *function* has to
-         start with "user\_". When using a class, the name of the *class* must
-         start with "user\_" (there are no conditions on the name of the
-         method).
-
 
 .. container:: table-row
 


### PR DESCRIPTION
The option was removed in 2012 with commit
fb0b7724ed692ac458f97426f80bb2553d52c269 in TYPO3.CMS repository.

Change-Id: I6fce23b4bf379cc78e8d5e9ece79cfee99130897
Releases: master, 6.2