### PR TITLE
[TASK] Mention parsetime output for config.debug

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -775,7 +775,7 @@ debug
 
    Description
          If set any debug-information in the TypoScript code is output.
-         Currently this applies only to the menu objects.
+         This applies e.g. to menu objects and the parsetime output.
 
 
 


### PR DESCRIPTION
config.debug does not only affect menu content objects but also parsetime output.