### PR TITLE
Remove documentation of non-existent property "wrapItemAndSub" in GMENU

### DIFF
--- a/Documentation/MenuObjects/Gmenu/Index.rst
+++ b/Documentation/MenuObjects/Gmenu/Index.rst
@@ -484,18 +484,6 @@ been for a long time.
 .. container:: table-row
 
    Property
-         wrapItemAndSub
-
-   Data type
-         wrap /:ref:`stdWrap <stdwrap>`
-
-   Description
-         Wraps the whole item and any submenu concatenated to it.
-
-
-.. container:: table-row
-
-   Property
          subst\_elementUid
 
    Data type


### PR DESCRIPTION
Remove documentation of non-existent property "wrapItemAndSub" in GMENU. Corrected documentation according to this change: https://review.typo3.org/#/c/36806/1