### PR TITLE
Mention config.moveJsFromHeaderToFooter in includeJS

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -588,6 +588,9 @@ includeJS.[array]
          The file definition must be a valid "resource" data type, otherwise
          nothing is inserted. This means that remote files cannot be referenced
          (i.e. using "http://..."), except by using the ".external" property.
+         
+         **Please note:** Having :ref:`config.moveJsFromHeaderToFooter <setup-config-movejsfromheadertofooter>`
+         activated moves all files to the footer.
 
          Each file has *optional properties*:
 


### PR DESCRIPTION
Mention the TypoScript config moveJsFromHeaderToFooter in page.includeJS to avoid confusion why JS files are rendered into the footer.