### PR TITLE
fix example for Condition "dayofyear"

### DIFF
--- a/Documentation/Conditions/Reference/Index.rst
+++ b/Documentation/Conditions/Reference/Index.rst
@@ -746,7 +746,7 @@ Comparison:
 
 Day of year, 0-364 (or 365 in leap years). That this condition begins
 with 0 for the first day of the year means that e.g. [dayofyear =
-7]will be true on the 6 :sup:`th` of January.
+5] will be true on the 6 :sup:`th` of January.
 
 Apart from that this condition uses the same way of comparison as
 hour.


### PR DESCRIPTION
fixed a small error in Conditions-Reference for "dayofyear" example. If the first day of the year (January, 1st) is 0 than [dayofyear = 5] will be true on January 6th, not [dayofyear = 7]