### PR TITLE
Declare align deprecated with IMGTEXT and CTABLE

### DIFF
--- a/Documentation/DataTypes/Align/Index.rst
+++ b/Documentation/DataTypes/Align/Index.rst
@@ -7,6 +7,11 @@
 align
 =====
 
+.. note::
+
+   This data-type has been deprecated with the deprecation of CTABLE and IMGTEXT in TYPO3 CMS 7.1.
+   This part of the documentatin shall be removed with those parts.
+
 :aspect:`Data type:`
    align
 


### PR DESCRIPTION
It's not needed any more. Style should not be part of HTML.