### PR TITLE
fix 1 one-letterTypo

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -355,7 +355,7 @@ defaultGetVars
          
          ::
          
-            config.defaultgetVars {
+            config.defaultGetVars {
                 test.var1.var2.p3 = 15
                 L = 3
             }


### PR DESCRIPTION
the Property name is shown as 
  Property
         defaultGetVars


but the code example has it in weird mixed lowercase/uppercase mix