### PR TITLE
update example

### DIFF
--- a/Documentation/Functions/Select/Index.rst
+++ b/Documentation/Functions/Select/Index.rst
@@ -75,6 +75,7 @@ Always secure input from outside, for example with intval!
                 where.intval = 1
                 where.wrap = sys_category_record_mm.uid_foreign=|
                 orderBy = sys_category_record_mm.sorting_foreign
+                languageField = 0 # disable translation handling of sys_category
               }
             }
 


### PR DESCRIPTION
disable translation handling of sys_category, otherwise only translated records of categories are retrieved instead of all actually selected.