### PR TITLE
prefixLocalAnchors requires compatibility6 extension

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2228,7 +2228,7 @@ prefixLocalAnchors
          **output:** The content is processed just before it is echoed out.
 
          **Note:** This property is deprecated since TYPO3 7! Use absolute links
-         with config.absRefPrefix instead.
+         with config.absRefPrefix instead. If you want to use this property you have to install and activate the compatibility6 extention.  
 
 
 .. _setup-config-removedefaultcss:


### PR DESCRIPTION
add hint to the mandatory compatibility6 extension if prefixLocalAnchors is required.