### PR TITLE
[TASK] Add gettext field flexform

### DIFF
--- a/Documentation/DataTypes/Gettext/Index.rst
+++ b/Documentation/DataTypes/Gettext/Index.rst
@@ -556,3 +556,16 @@ global:
 
 global: [GLOBAL variable, split with \| if you want to get from an
 array! Deprecated, use GP, TSFE or getenv!]
+
+flexform:
+---------
+
+**Syntax**
+
+flexform: [field containing flexform data].[property of this flexform]
+
+**Example**::
+
+    foo = flexform: pi_flexform:settings.categories
+
+* returns the flexform value of given name


### PR DESCRIPTION
With https://forge.typo3.org/issues/17309 the new gettext
option 'flexform' has been added. It allows for the access
of flexform properties using TypoScript.