### PR TITLE
Rename im_useStripProfileByDefault to processor_stripColorProfileByDe…

### DIFF
--- a/Documentation/Functions/Imgresource/Index.rst
+++ b/Documentation/Functions/Imgresource/Index.rst
@@ -300,7 +300,7 @@ imgResource.
          stripProfile-command which shrinks the generated thumbnails. See the
          Install Tool for options and details.
 
-         If im\_useStripProfileByDefault is set in the Install Tool, you can
+         If processor\_stripColorProfileByDefault is set in the Install Tool, you can
          deactivate it by setting stripProfile=0.
 
          **Example:** ::


### PR DESCRIPTION
…fault

see https://docs.typo3.org/typo3cms/extensions/core/8-dev/Changelog/8.0/Breaking-43085-RenamedGraphicsProcessorSettings.html