### PR TITLE
Link the Form Framework documentation

### DIFF
--- a/Documentation/ContentObjects/Form/Index.rst
+++ b/Documentation/ContentObjects/Form/Index.rst
@@ -10,7 +10,7 @@ FORM
 
    The following only applies, if the system extension "form" is *not*
    installed. **If sysext:form is installed**, stop reading here and continue with
-   `sysext:form's own documentation <https://docs.typo3.org/typo3cms/extensions/form/>`__.
+   `sysext:form's own documentation <https://docs.typo3.org/typo3cms/drafts/code.tritum.de/TYPO3.CMS/Form_Documentation/>`__.
 
 .. note::
 


### PR DESCRIPTION
Add a link to the form framework documentation draft as
the current link references the old form extension that does not
exist anymore in TYPO3 8 LTS