### PR TITLE
Change default value of removeDefaultJs

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2175,7 +2175,7 @@ removeDefaultJS
             config.removeDefaultJS = 1
 
    Default
-         1
+         external
 
 
 


### PR DESCRIPTION
As mentioned in the `TypoScriptFrontendController.php` (line 2522) the default value would be `external` instead of `1`

```
// Set default values for removeDefaultJS and inlineStyle2TempFile so CSS and JS are externalized if compatversion is higher than 4.0
if (!isset($this->config['config']['removeDefaultJS'])) {
    $this->config['config']['removeDefaultJS'] = 'external';
}
```