### PR TITLE
Update description of the language related settings

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2595,7 +2595,7 @@ sys\_language\_mode
          the page is not translated and there's no content available in this
          language, so you can handle that situation on your own then.
          System will render the page and the content as this translation would exist.
-         Internally $GLOBALS['TSFE']->sys_language_content` is set to the value of the
+         Internally `$GLOBALS['TSFE']->sys_language_content` is set to the value of the
          `$GLOBALS['TSFE']->sys_language_uid`.
 
          An in-depth discussion is found in the

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -5,15 +5,9 @@
 config
 ======
 
-In typo3/sysext/frontend/Classes/ this is known as
-$GLOBALS['TSFE']->config['config'], thus the property "debug" below is
-accessible as $GLOBALS['TSFE']->config['config']['debug'].
-
-.. only:: html
-
-   .. contents::
-      :local:
-      :depth: 1
+In :file:`typo3/sysext/frontend/Classes/` this is known as
+:php:`$GLOBALS['TSFE']->config['config']`, thus the property :ts:`debug` below is
+accessible as :php:`$GLOBALS['TSFE']->config['config']['debug']`.
 
 Properties
 ^^^^^^^^^^
@@ -126,11 +120,6 @@ Properties
 Property details
 ^^^^^^^^^^^^^^^^
 
-.. only:: html
-
-   .. contents::
-      :local:
-      :depth: 1
 
 .. ### BEGIN~OF~TABLE ###
 
@@ -2557,49 +2546,57 @@ sys\_language\_mode
          string
 
    Description
-         Configures what system should do when a page is not translated
+         Configures what the system should do when a page is not translated
          to the requested language.
-         It is only evaluated when `sys_language_uid` is greater than `0`,
+         It is only evaluated when :ts:`sys_language_uid` is greater than `0`
          and the requested page translation is NOT available.
-         Internally this setting influences the value set to the 
-         `$GLOBALS['TSFE']->sys_language_content`.
+         Internally this setting corresponds to 
+         :php:`$GLOBALS['TSFE']->sys_language_content`.
          
          The syntax is "[keyword] ; [value]".
 
          **Possible keywords are:**
 
-         [empty] - If not set, and the page is not translated, the system will
-         behave as if the default language was requested.
-         Internally both `$GLOBALS['TSFE']->sys_language_content`
-         and `$GLOBALS['TSFE']->sys_language_uid` whill be set to 0;
+         [empty] (not set)
+            If not set and the page is not translated, the system will
+            behave as if the default language was requested.
+            Internally both :php:`$GLOBALS['TSFE']->sys_language_content`
+            and :phpp:`$GLOBALS['TSFE']->sys_language_uid` whill be set to `0`.
 
-         **content\_fallback** - Recommended. The system will always operate
-         with the selected language even if the page is not translated with a
-         page overlay record. This will keep menus etc. translated. However,
-         the *content* on the page can still fall back to another language,
-         defined by the value of this keyword, e.g. :ts:`content_fallback;1,3,0`
-         to fall back to the content of sys\_language\_uid 1 and if that is not
-         present either, to default (0).
-         Note that the fallback is on the page level, not on the content level.
-         This means that once a translated page record is found in the fallback
-         chain, system will try to use this language for the rendering even
-         if there is no content translated.
+         content\_fallback
+            Recommended. The system will always operate
+            with the selected language even if the page is not translated and has no
+            page overlay record. This will keep menus etc. translated. However,
+            the *content* on the page can still fall back to another language,
+            defined by the value of this keyword, e.g. :ts:`content_fallback;1,3,0`
+            to fall back to the content of sys\_language\_uid 1 and if that is not
+            present either, to default (0).
+            
+            Note that the fallback affects all content of the page.
+            This means that once a translated page record is found in the fallback
+            chain, the system will try to use this language for the rendering even
+            if there is no properly translated content.
 
-         **strict** -  If the requested translation does not exist the system
-         will report a Page Not Found (404) error. Basically this means that all pages with
-         gray background in the Web > Info / Localization overview module will
-         fail (they would otherwise fall back to default language in one way
-         or another).
+         strict
+            If the requested translation does not exist the system
+            will report a *Page Not Found (404)* error. 
+            Basically this means that all pages with
+            gray background in the Web > Info / Localization overview module will
+            fail (they would otherwise fall back to default language in one way
+            or another).
 
-         **ignore** - The system will stay with the selected language even if
-         the page is not translated and there's no content available in this
-         language, so you can handle that situation on your own then.
-         System will render the page and the content as this translation would exist.
-         Internally `$GLOBALS['TSFE']->sys_language_content` is set to the value of the
-         `$GLOBALS['TSFE']->sys_language_uid`.
+         ignore
+            The system will stay with the selected language even if
+            the page is not translated and there is no content available for this
+            language, so you can handle that situation on your own then.
+            The system will render the page and the content as if the translation would exist.
+            Internally :php:`$GLOBALS['TSFE']->sys_language_content` is set to the value of 
+            :php:`$GLOBALS['TSFE']->sys_language_uid`.
 
-         An in-depth discussion is found in the
-         :ref:`Frontend Localization Guide <t3l10n:localization-modes>`.
+         Refer to the 
+         :ref:`Frontend Localization Guide <t3l10n:localization-modes>`
+         for an in-depth discussion.
+         
 
 
 .. _setup-config-sys-language-overlay:
@@ -2617,15 +2614,15 @@ sys\_language\_overlay
 
    Description
          
-         Defines whether TYPO3 should use content overlay technique when
-         fetching translated content. Content overlay means fetching records
-         from the default language first and then replacing them with translated
-         versions if available.
+         Defines whether TYPO3 should use the *content overlay* technique when
+         fetching translated content. *Content overlay* means fetching records
+         from the default language first and then replacing specific fields
+         with the translation if that is found.
          
-         It is only evaluated when `$TSFE->sys_language_content` is `> 0`.
-         Internally it sets the property `$TSFE->sys_language_contentOL` at a request.
-         Further calls via `$TSFE->sys_page->getRecordOverlay` receive this value 
-         to see if an overlay should happen.
+         It is only evaluated when :php:`$TSFE->sys_language_content > 0`.
+         Internally it sets the property :php:`$TSFE->sys_language_contentOL` at a request.
+         Further calls via :php:`$TSFE->sys_page->getRecordOverlay` receive this value 
+         to see if overlaying should take place.
 
          The requirements for this is that the table is configured with
          "languageField" and "transOrigPointerField" in the [ctrl] section of
@@ -2640,17 +2637,24 @@ sys\_language\_overlay
 
          **Possible values:**
          
-         **0** - Just fetch records from selected (`$TSFE->sys_language_content`) language,
-         no overlay will happen, no fetching of the records from the default language.
-         This boils down to "free mode" language handling. This is the only mode which shows
-         records without default language parent (with small exception to cases when you manually set
-         `select.includeRecordsWithoutDefaultTranslation = 1` for CONTENT TS object).
+         0
+            Just fetch records from the selected language as given by
+            :php:`$TSFE->sys_language_content`.
+            No overlay will happen, no fetching of the records from the default language.
+            This boils down to "free mode" language handling. This is the only mode which shows
+            records without a default language parent.
+            
+            An exception to this rule can be made with the TypoScript CONTENT object
+            if you manually set
+            :ts:`select.includeRecordsWithoutDefaultTranslation = 1`.
          
-         **1** - Fetch records from the default language and overlay them with translations.
-         If a record is not translated default language version will be shown.
+         1
+            Fetch records from the default language and overlay them with translations.
+            If a record is not translated the default language will be used.
 
-         **hideNonTranslated** -  Fetch records from the default language and overlay
-         them with translations. If some record is not translated it will not be shown.
+         hideNonTranslated
+            Fetch records from the default language and overlay
+            them with translations. If some record is not translated it will not be shown.
 
 
 
@@ -2690,22 +2694,20 @@ sys\_language\_uid
          integer
 
    Description
-         This value points to the uid of a record from the "sys\_language".
+         This property holds the value of the field "uid" of a record of table "sys\_language".
          Various parts of the frontend rendering code will select records 
          which are assigned to this language.
          See ->SELECT
 
          Internally this value is used to initialize the TypoScriptFrontendController
-         `$GLOBALS['TSFE']->sys_language_uid` property.
-         The `$GLOBALS['TSFE']->sys_language_content` property is set based
-         on the value of the `sys_language_uid` and other settings like 
-         `sys_language_mode`.
+         :php:`$GLOBALS['TSFE']->sys_language_uid` property.
+         The :php:`$GLOBALS['TSFE']->sys_language_content` property is set based
+         on the value of the :ts:`sys_language_uid` and other settings like 
+         :ts:`sys_language_mode`.
 
-         It is usually set to the value of the &L request parameter,
-         using TypoScript condition like:
+         It is usually set to the value of the `&L` request parameter,
+         using a TypoScript condition like in this example::
          
-         **Example**::
-
             config.sys_language_uid = 0
 
             [globalVar = GP:L = 1]


### PR DESCRIPTION
Make description of the sys_language_uid, sys_language_overlay and sys_language_mode more verbose and precise.
See typo3/sysext/frontend/Tests/Functional/Rendering/LocalizedContentRenderingTest.php
for a test covering different configuration combinations.