### PR TITLE
IMAGE params should be shown as string

### DIFF
--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -67,7 +67,10 @@ for.
          params
 
    Data type
-         <IMG>-params /:ref:`stdWrap <stdwrap>`
+         string /:ref:`stdWrap <stdwrap>`
+
+   Description
+         HTML <IMG> parameters
 
 
 .. container:: table-row


### PR DESCRIPTION
A description has been given instead of showing the type of it.