### PR TITLE
Update Index.rst, make working example for "variables" property of FLUIDTEMPLATE

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -56,7 +56,8 @@ templateName
                     20 = EXT:sitemodification/Resources/Private/Templates
                 }
                 variables {
-                    foo = bar
+                    foo = TEXT
+                    foo.value = bar
                 }
             }
 


### PR DESCRIPTION
In the example using "variables.foo = bar" seems irritating to me. The user expects to be able to call "foo" in the template then via {foo}. But that does not work because you have to use a CObject.