### PR TITLE
add information about format

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -302,6 +302,7 @@ format
 
    Description
          Sets the format of the current request.
+         Something like "html", "xml", "png", "json" or the like. Can even be something like "rss.xml".
 
    Default
          html

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -301,8 +301,9 @@ format
          keyword /:ref:`stdWrap <stdwrap>`
 
    Description
-         Sets the format of the current request.
-         Something like "html", "xml", "png", "json" or the like. Can even be something like "rss.xml".
+         :ts:`format` sets the format of the current request. It can be
+         something like "html", "xml", "png", "json". And it can even come in the
+         form of "rss.xml" or alike.
 
    Default
          html


### PR DESCRIPTION
@marble is there anything more we could add about the FLUIDTEMPLATE format property?
where is it used? what can we do with it?
I just copied the text found at 
https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/extbase/Classes/Mvc/Request.php#L465

From the path resolution in 
https://github.com/TYPO3/Fluid/blob/master/src/View/TemplatePaths.php#L253
it looks like this is the file suffix for the template file that will be used.