### PR TITLE
Use "Table" layout for properties

### DIFF
--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -117,28 +117,30 @@ See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`, :ref:
 
 select
 ------
+.. container:: table-row
 
-:aspect:`Property`
-      select
+   Property
+         select
 
-:aspect:`Data type`
-      :ref:`select`
+   Data type
+         :ref:`select`
 
-:aspect:`Description`
+   Description
       The SQL-statement, a SELECT query, is set here,
       including automatic visibility control.
 
 
 table
 -----
+.. container:: table-row
 
-:aspect:`Property`
+   Property
       table
 
-:aspect:`Data type`
+   Data type
       *table name* /:ref:`stdwrap`
 
-:aspect:`Description`
+   Description
       The table, the content should come from. Any table can be used;
       a check for a table prefix is not done.
 
@@ -147,14 +149,18 @@ table
 
 renderObj
 ---------
+.. container:: table-row
 
-:aspect:`Property`
+   Property
       renderObj
 
-:aspect:`Data type`
+   Data type
       :ref:`data-type-cObject`
 
-:aspect:`Description`
+   Default
+      :ts:`< [table name]`
+
+   Description
       The cObject used for rendering the records resulting from the query in
       .select.
 
@@ -162,20 +168,19 @@ renderObj
       in this case the configuration of the according table is being copied.
       See the notes on the example below.
 
-:aspect:`Default`
-      :ts:`< [table name]`
 
 
 slide
 -----
+.. container:: table-row
 
-:aspect:`Property`
+   Property
       slide
 
-:aspect:`Data type`
+   Data type
       integer /:ref:`stdWrap`
 
-:aspect:`Description`
+   Description
       If set and no content element is found by the select command, the
       rootLine will be traversed back until some content is found.
 
@@ -206,27 +211,29 @@ slide
 
 wrap
 ----
+.. container:: table-row
 
-:aspect:`Property`
+   Property
       wrap
 
-:aspect:`Data type`
+   Data type
       :ref:`wrap <data-type-wrap>` /:ref:`stdWrap`
 
-:aspect:`Description`
+   Description
       Wrap the whole content.
 
 
 stdWrap
 -------
+.. container:: table-row
 
-:aspect:`Property`
+   Property
       stdWrap
 
-:aspect:`Data type`
+   Data type
       :ref:`stdwrap`
 
-:aspect:`Description`
+   Description
       Apply `stdWrap` functionality.
 
 

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -22,7 +22,8 @@ is raised to the maximum timestamp value of the respective records.
 Comprehensive example
 ---------------------
 
-See PHP source code for :ref:`TYPO3 \\ CMS \\ Frontend \\ Controller \\ TypoScriptFrontendController \\ ContentContentObject
+See PHP source code for :ref:`TYPO3 \\ CMS \\ Frontend \\ Controller \\ 
+TypoScriptFrontendController \\ ContentContentObject
 <t3api:typo3\\cms\\frontend\\contentobject\\contentcontentobject>`.
 
 Preamble::
@@ -109,14 +110,17 @@ Expanded form::
    // STEP 6: Return 'totalResult'
 
 
-See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`, :ref:`data-type-cobject`
+See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`, 
+:ref:`data-type-cobject`
 
 
-
-.. ### BEGIN~OF~TABLE ###
+.. _cobj-content-select:
 
 select
 ------
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -129,9 +133,16 @@ select
       The SQL-statement, a SELECT query, is set here,
       including automatic visibility control.
 
+.. ###### END~OF~TABLE ######
+
+
+.. _cobj-content-table:
 
 table
 -----
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -146,9 +157,16 @@ table
 
       In standard configuration this will be `tt_content`.
 
+.. ###### END~OF~TABLE ######
+
+
+.. _cobj-content-renderObj:
 
 renderObj
 ---------
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -168,10 +186,16 @@ renderObj
       in this case the configuration of the according table is being copied.
       See the notes on the example below.
 
+.. ###### END~OF~TABLE ######
 
+
+.. _cobj-content-slide:
 
 slide
 -----
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -208,9 +232,16 @@ slide
       **Note:** The sliding will stop when reaching a folder.
       See :php:`$cObj->checkPid_badDoktypeList`.
 
+.. ###### END~OF~TABLE ######
+
+
+.. _cobj-content-wrap:
 
 wrap
 ----
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -222,9 +253,16 @@ wrap
    Description
       Wrap the whole content.
 
+.. ###### END~OF~TABLE ######
+
+
+.. _cobj-content-stdWrap:
 
 stdWrap
 -------
+
+.. ### BEGIN~OF~TABLE ###
+
 .. container:: table-row
 
    Property
@@ -236,13 +274,13 @@ stdWrap
    Description
       Apply `stdWrap` functionality.
 
-
 .. ###### END~OF~TABLE ######
+
 
 .. _cobj-content-examples:
 
-Example 1
----------
+CONTENT object example 1
+------------------------
 
 Here is an example of the CONTENT object::
 
@@ -259,8 +297,8 @@ will reference the TypoScript configuration of `tt_content`. The
 according TypoScript configuration will be copied to `renderObj`.
 
 
-Example 2
----------
+CONTENT object example 2
+------------------------
 
 Here is an example of record-rendering objects::
 
@@ -291,4 +329,3 @@ Here is an example of record-rendering objects::
    tt_content.default.default {
       # ...
    }
-

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -113,7 +113,7 @@ See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`, :ref:
 
 
 
-
+.. ### BEGIN~OF~TABLE ###
 
 select
 ------
@@ -237,7 +237,7 @@ stdWrap
       Apply `stdWrap` functionality.
 
 
-
+.. ###### END~OF~TABLE ######
 
 .. _cobj-content-examples:
 


### PR DESCRIPTION
Modified layout for properties to make them consistent with the other parts of documentation; please review and check the title formatting (I am not sure that they are correct)