### PR TITLE
change position of default block

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -300,13 +300,14 @@ format
    Data type
          keyword /:ref:`stdWrap <stdwrap>`
 
+   Default
+         html
+
    Description
          :ts:`format` sets the format of the current request. It can be
          something like "html", "xml", "png", "json". And it can even come in the
          form of "rss.xml" or alike.
 
-   Default
-         html
 
 
 .. _cobj-fluidtemplate-properties-extbase-pluginname:


### PR DESCRIPTION
"default" values block is rendered in the wrong position;
[NOTE] I don't know if it sufficient to solve this issue: the title of section "extbase.pluginName" floats (see https://docs.typo3.org/typo3cms/TyposcriptReference/ContentObjects/Fluidtemplate/Index.html#extbase-pluginname)