### PR TITLE
TASK: Fix small issues

### DIFF
--- a/Documentation/AppendixA/Index.rst
+++ b/Documentation/AppendixA/Index.rst
@@ -16,7 +16,7 @@ This section should give you some pointers on what you can process in
 your script and which functions and variables you can access.
 
 Your script is included inside the class "ContentObjectRenderer" in the
-typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php
+:file:`typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php`
 script. Thereby your file is a part of this object
 (ContentObjectRenderer). This is why you must return all
 content in the variable "$content" and any TypoScript configuration is
@@ -51,7 +51,7 @@ White spaces
 """"""""""""
 
 Because nothing is sent off to the browser before everything is
-rendered and returned to \\TYPO3\\CMS\\Frontend\\Http\\RequestHandler
+rendered and returned to :php:`\TYPO3\CMS\Frontend\Http\RequestHandler`
 (which originally set off the rendering process), you must ensure
 that there's no whitespace before and after your <?php...?> tags
 in your include or library scripts!
@@ -62,22 +62,22 @@ in your include or library scripts!
 $GLOBALS['TSFE']->set\_no\_cache()
 """"""""""""""""""""""""""""""""""
 
-Call the function $GLOBALS['TSFE']->set\_no\_cache(), if you want to
+Call the function :php:`$GLOBALS['TSFE']->set_no_cache()`, if you want to
 disable caching of the page. Call this during development only! And
 call it, if the content you create may not be cached.
 
 **Note:** If you make a syntax error in your script that keeps PHP
-from executing it, then the $GLOBALS['TSFE']->set\_no\_cache()
+from executing it, then the :php:`$GLOBALS['TSFE']->set_no_cache()`
 function is not executed and the page *is* cached! So in these
 situations, correct the error, clear the page-cache and try again.
-This is true only for USER and not for USER\_INT, which is
+This is true only for :ts:`USER` and not for :ts:`USER_INT`, which is
 rendered *after* the cached page!
 
 
 Example:
 ~~~~~~~~
 
-::
+.. code-block:: php
 
    $GLOBALS['TSFE']->set_no_cache();
 
@@ -93,7 +93,7 @@ Gets a content object from the $conf array.
 Example:
 ~~~~~~~~
 
-::
+.. code-block:: php
 
    $content = $this->cObjGetSingle($conf['image'], $conf['image.']);
 
@@ -113,7 +113,7 @@ process it according to the configuration of the array "properties".
 Example:
 ~~~~~~~~
 
-::
+.. code-block:: php
 
    $content = $this->stdWrap($content, $conf['stdWrap.']);
 
@@ -128,11 +128,11 @@ Internal variables in the main frontend object, TSFE
 
 There are some variables in the global object, TSFE (TypoScript
 Frontend), you might need to know about. These ARE ALL READ-ONLY!
-(Read: Don't change them!) See the class TypoScriptFrontendController
+(Read: Don't change them!) See the class :php:`TypoScriptFrontendController`
 for the full descriptions.
 
 If you for instance want to access the variable "id", you can do so by
-writing: $GLOBALS['TSFE']->id
+writing: :php:`$GLOBALS['TSFE']->id`
 
 .. ### BEGIN~OF~TABLE ###
 
@@ -183,7 +183,7 @@ writing: $GLOBALS['TSFE']->id
    Description
          The current front-end user.
 
-         User record in $GLOBALS['TSFE']->fe\_user->user, if any login.
+         User record in :php:`$GLOBALS['TSFE']->fe_user->user`, if any login.
 
 
 .. container:: table-row
@@ -211,7 +211,7 @@ writing: $GLOBALS['TSFE']->id
 
    Description
          The rootLine (all the way to tree root, not only the current site!).
-         Current site root line is in $GLOBALS['TSFE']->tmpl->rootLine
+         Current site root line is in :php:`$GLOBALS['TSFE']->tmpl->rootLine`
 
 
 .. container:: table-row
@@ -224,7 +224,7 @@ writing: $GLOBALS['TSFE']->id
 
    Description
          The object with page functions (object) See
-         typo3/sysext/frontend/Classes/Page/PageRepository.php.
+         :file:`typo3/sysext/frontend/Classes/Page/PageRepository.php`.
 
 
 .. container:: table-row

--- a/Documentation/Conditions/Reference/Index.rst
+++ b/Documentation/Conditions/Reference/Index.rst
@@ -3,6 +3,7 @@
 
 .. _condition-reference:
 
+===================
 Condition reference
 ===================
 
@@ -10,7 +11,7 @@ Condition reference
 .. _condition-language:
 
 language
-""""""""
+========
 
 
 Syntax:
@@ -22,14 +23,14 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Comparison with the website visitor's preferred languages.
 
 The values must be a straight match with the value of
-getenv('HTTP\_ACCEPT\_LANGUAGE') from PHP. Alternatively, if the value
+:php:`getenv('HTTP_ACCEPT_LANGUAGE')` from PHP. Alternatively, if the value
 is wrapped in "\*" (e.g. "\*en-us\*") then it will split all languages
-found in the HTTP\_ACCEPT\_LANGUAGE string and try to match the value
+found in the :php:`HTTP_ACCEPT_LANGUAGE` string and try to match the value
 with any of those parts of the string. Such a string normally looks
 like "de,en-us;q=0.7,en;q=0.3" and "\*en-us\*" would match with this
 string.
@@ -38,7 +39,7 @@ string.
 .. _condition-ip:
 
 IP
-""
+==
 
 
 Syntax:
@@ -50,11 +51,11 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Comparison with the IP address, which the website visitor uses.
 
-The values are compared with getenv('REMOTE\_ADDR') from PHP.
+The values are compared with :php`getenv('REMOTE_ADDR')` from PHP.
 
 You may include "\*" instead of one of the parts in values. You may
 also list the first one, two or three parts and only they will be
@@ -63,7 +64,7 @@ tested.
 The IP condition also supports the special keyword "devIP". If - instead
 of using an actual IP address or range - you use this keyword, the IP
 address, which the visitor uses, will be compared to
-:php:`$TYPO3_CONF_VARS['SYS']['devIPmask']` as set in the Install Tool.
+:php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']` as set in the Install Tool.
 
 Examples:
 ~~~~~~~~~
@@ -82,7 +83,7 @@ These examples will match any IP address ending with "123" or being
    [IP = *.*.*.123][IP = 192.168.1.34]
 
 This example will match the IP address or range defined in
-:php:`$TYPO3_CONF_VARS['SYS']['devIPmask']`::
+:php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask']`::
 
    [IP = devIP]
 
@@ -90,7 +91,7 @@ This example will match the IP address or range defined in
 .. _condition-hostname:
 
 hostname
-""""""""
+========
 
 
 Syntax:
@@ -102,12 +103,12 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Comparison with the hostname, which the website visitor uses.
 
 The values are compared to the fully qualified hostname, which is
-retrieved by PHP based on getenv('REMOTE\_HOST').
+retrieved by PHP based on :php:`getenv('REMOTE_HOST')`.
 
 Value is comma-list of domain names to match with. \*-wildcard allowed
 but cannot be part of a string, so it must match the full host name
@@ -117,7 +118,7 @@ but cannot be part of a string, so it must match the full host name
 .. _condition-applicationcontext:
 
 applicationContext
-""""""""""""""""""
+==================
 
 
 Syntax:
@@ -129,7 +130,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Comparison with the application context, in which TYPO3 is running.
 
@@ -164,7 +165,7 @@ and ending with one digit, for example "Production/Staging/Server3"::
 .. _condition-hour:
 
 hour
-""""
+====
 
 
 Syntax:
@@ -180,7 +181,7 @@ hour.
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Possible values are 0 to 23 (24-hours-format). The values in floating
 point are compared with the current hour of the server time.
@@ -259,7 +260,7 @@ In contrast a condition matching for 8 until 16 o'clock would be::
 .. _condition-minute:
 
 minute
-""""""
+======
 
 See "Hour" above. Uses the same syntax!
 
@@ -273,7 +274,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Minute of hour, possible values are 0-59.
 
@@ -284,7 +285,7 @@ hour.
 .. _condition-month:
 
 month
-"""""
+=====
 
 See "Hour" above. Uses the same syntax!
 
@@ -298,7 +299,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Month, from January being 1 until December being 12.
 
@@ -309,7 +310,7 @@ hour.
 .. _condition-year:
 
 year
-""""
+====
 
 See "Hour" above. Uses the same syntax!For further information look at
 the date() function in the PHP manual, format string Y.
@@ -324,7 +325,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Year, as a 4-digit number.
 
@@ -335,7 +336,7 @@ hour.
 .. _condition-dayofweek:
 
 dayofweek
-"""""""""
+=========
 
 See "Hour" above. Uses the same syntax!
 
@@ -349,7 +350,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Day of week, starting with Sunday being 0 until Saturday being 6.
 
@@ -360,7 +361,7 @@ hour.
 .. _condition-dayofmonth:
 
 dayofmonth
-""""""""""
+==========
 
 See "Hour" above. Uses the same syntax!
 
@@ -374,7 +375,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Day of month, possible values are 1-31.
 
@@ -385,10 +386,10 @@ hour.
 .. _condition-dayofyear:
 
 dayofyear
-"""""""""
+=========
 
-See "Hour" above. Uses the same syntax!For further information look at
-the date() function in the PHP manual, format string z.
+See "Hour" above. Uses the same syntax! For further information look at
+the :php`date()` function in the PHP manual, format string z.
 
 
 Syntax:
@@ -400,7 +401,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Day of year, 0-364 (or 365 in leap years). That this condition begins
 with 0 for the first day of the year means that e.g. [dayofyear =
@@ -413,7 +414,7 @@ hour.
 .. _condition-usergroup:
 
 usergroup
-"""""""""
+=========
 
 
 Syntax:
@@ -425,7 +426,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 This matches on the uid of a usergroup of a logged in frontend user.
 
@@ -452,7 +453,7 @@ user groups with uid's 1 and/or 2::
 .. _condition-loginuser:
 
 loginUser
-"""""""""
+=========
 
 
 Syntax:
@@ -464,7 +465,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Matches on the uid of a logged in frontend user. Works like
 'usergroup' above including the \* wildcard to select ANY user.
@@ -492,7 +493,7 @@ This matches when no FE user is logged in::
 .. _condition-page:
 
 page
-""""
+====
 
 
 Syntax:
@@ -504,7 +505,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 This condition checks values of the current page record. While you can
 achieve the same with TSFE:[field] conditions in the frontend, this
@@ -522,7 +523,7 @@ This condition matches, if the layout field is set to 1::
 .. _condition-treelevel:
 
 treeLevel
-"""""""""
+=========
 
 
 Syntax:
@@ -534,7 +535,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 This checks if the last element of the rootLine is at a level
 corresponding to one of the figures in "treeLevel". Level = 0 is the
@@ -553,7 +554,7 @@ or on level 2 ::
 .. _condition-pidinrootline:
 
 PIDinRootline
-"""""""""""""
+=============
 
 
 Syntax:
@@ -565,7 +566,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 This checks if one of the figures in "treeLevel" is a PID (pages-uid)
 in the rootline.
@@ -583,7 +584,7 @@ This condition matches, if the page viewed is or is a subpage to page
 .. _condition-pidupinrootline:
 
 PIDupinRootline
-"""""""""""""""
+===============
 
 
 Syntax:
@@ -595,7 +596,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Does the same as PIDinRootline, except the current page-uid is excluded
 from check.
@@ -604,7 +605,7 @@ from check.
 .. _condition-compatversion:
 
 compatVersion
-"""""""""""""
+=============
 
 
 Syntax:
@@ -616,7 +617,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 Comparison with the compatibility version of the TYPO3 installation.
 
@@ -634,7 +635,7 @@ of TYPO3.
 .. _condition-globalvar:
 
 globalVar
-"""""""""
+=========
 
 
 Syntax:
@@ -646,7 +647,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 The values in floating point are compared to the global variables
 "var1", "var2" ... from above.
@@ -733,7 +734,7 @@ This will only check GET parameters::
 
    [globalVar = _GET|tx_myext_pi1|showUid > 0]
 
-If the constant {$constant\_to\_turnSomethingOn} is "1" then this
+If the constant :ts:`{$constant_to_turnSomethingOn}` is "1" then this
 matches::
 
    [globalVar = LIT:1 = {$constant_to_turnSomethingOn}]
@@ -750,7 +751,7 @@ This will match only with the backend user with UID 13::
 .. _condition-globalstring:
 
 globalString
-""""""""""""
+============
 
 
 Syntax:
@@ -762,7 +763,7 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 This is a direct match on global strings.
 
@@ -773,7 +774,7 @@ style regular expression (must be wrapped in "/") to the value.
 Examples:
 ~~~~~~~~~
 
-If the HTTP\_HOST is "www.typo3.org" this will match with::
+If the :php:`HTTP_HOST` is "www.typo3.org" this will match with::
 
    [globalString = IENV:HTTP_HOST = www.typo3.org]
 
@@ -781,10 +782,10 @@ This will also match with it::
 
    [globalString = IENV:HTTP_HOST = *typo3.org]
 
-... but this will also match with an HTTP\_HOST like this:
+... but this will also match with an :php:`HTTP_HOST` like this:
 "demo.typo3.org"
 
-If HTTP\_REFERER is set to an empty value, this will match with it::
+If :php:`HTTP_REFERER` is set to an empty value, this will match with it::
 
    [globalString = IENV:HTTP_REFERER = /^$/]
 
@@ -794,7 +795,7 @@ In contrast this will match with a non-empty value::
 
 
 Important note on globalVar and globalString
-''''''''''''''''''''''''''''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can use values from global arrays and objects by dividing the
 variable name with a "\|" (vertical line).
@@ -803,16 +804,16 @@ variable name with a "\|" (vertical line).
 Examples:
 ~~~~~~~~~
 
-The global variable $HTTP\_POST\_VARS['key']['levels'] would be
+The global variable :php:`$HTTP_POST_VARS['key']['levels']` would be
 retrieved by "HTTP\_POST\_VARS\|key\|levels".
 
 Also note that it's recommended to program your scripts in compliance
-with the php.ini-optimized settings. Please see that file (from your
+with the :file:`php.ini`-optimized settings. Please see that file (from your
 distribution) for details.
 
-Caring about this means that you would get values like HTTP\_HOST by
-getenv() and you would retrieve GET/POST values with
-TYPO3\CMS\Core\Utility\GeneralUtility::\_GP().
+Caring about this means that you would get values like :php:`HTTP_HOST` by
+:php:`getenv()` and you would retrieve GET/POST values with
+:php:`\TYPO3\CMS\Core\Utility\GeneralUtility::_GP()`.
 Finally a lot of values from the TSFE object are
 useful. In order to get those values for comparison with "globalVar"
 and "globalString" conditions, you prefix that variable's name with
@@ -824,9 +825,9 @@ returned as the value (without being divided by "\|" or anything)
 **Note:** Using the "IENV:" prefix is highly recommended to get
 server/environment variables which are system-independent. Basically
 this will get the value using
-TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv().
+:php:`TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv()`.
 With "ENV:" you get the raw output from
-getenv() which is **not** always the same on all systems!
+:php:`getenv()` which is **not** always the same on all systems!
 
 
 Examples:
@@ -844,7 +845,7 @@ This will match with the frontend user whose username is "test"::
 .. _condition-custom-conditions:
 
 Custom Conditions
-"""""""""""""""""
+=================
 
 You can add own TypoScript conditions via a separate API.
 
@@ -860,13 +861,13 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
 An extension / package can ship an implementation of the abstract
-class :code:`AbstractCondition`. Via the existing TypoScript condition
+class :php:`AbstractCondition`. Via the existing TypoScript condition
 syntax the class is called by the simple full namespaced class name.
 
-The main function :code:`matchCondition` of this class can then
+The main function :php:`matchCondition` of this class can then
 evaluate any parameters given after the class name. The parameters
 will be given in form of a numeric array, each entry containing the
 strings that are split by the commas, e.g. array('= var1 = value1',
@@ -880,61 +881,61 @@ This example shows how to write own TypoScript conditions and how to
 evaluate their parameters in PHP. With the PHP code following below,
 these three conditions will match:
 
-.. code-block:: typoscript
+::
 
-	[Documentation\Examples\TypoScript\ExampleCondition]
-	    Your TypoScript code here
-	[global]
+    [Documentation\Examples\TypoScript\ExampleCondition]
+        Your TypoScript code here
+    [global]
 
-	[Documentation\Examples\TypoScript\ExampleCondition TYPO3]
-	    Your TypoScript code here
-	[global]
+    [Documentation\Examples\TypoScript\ExampleCondition TYPO3]
+        Your TypoScript code here
+    [global]
 
-	[Documentation\Examples\TypoScript\ExampleCondition = 42]
-	    Your TypoScript code here
-	[global]
+    [Documentation\Examples\TypoScript\ExampleCondition = 42]
+        Your TypoScript code here
+    [global]
 
 
 .. code-block:: php
 
-	<?php
-	namespace Documentation\Examples\TypoScript;
+    <?php
+    namespace Documentation\Examples\TypoScript;
 
-	/**
-	 * Example condition
-	 */
-	class ExampleCondition extends \TYPO3\CMS\Core\Configuration\TypoScript\ConditionMatching\AbstractCondition {
+    use \TYPO3\CMS\Core\Configuration\TypoScript\ConditionMatching\AbstractCondition;
 
-		/**
-		 * Evaluate condition
-		 *
-		 * @param array $conditionParameters
-		 * @return bool
-		 */
-		public function matchCondition(array $conditionParameters) {
-			$result = FALSE;
-			if (empty($conditionParameters)) {
-				$result = TRUE;
-			}
-			if (!empty($conditionParameters) && $conditionParameters[0] === 'TYPO3') {
-				$result = TRUE;
-			}
-			if (!empty($conditionParameters) && substr($conditionParameters[0], 0, 1) === '=') {
-				$conditionParameters[0] = trim(substr($conditionParameters[0], 1));
-				if ($conditionParameters[0] == '42') {
-					$result = TRUE;
-				}
-			}
+    class ExampleCondition extends AbstractCondition
+    {
+        /**
+         * Evaluate condition
+         *
+         * @param array $conditionParameters
+         * @return bool
+         */
+        public function matchCondition(array $conditionParameters)
+        {
+            $result = FALSE;
+            if (empty($conditionParameters)) {
+                $result = TRUE;
+            }
+            if (!empty($conditionParameters) && $conditionParameters[0] === 'TYPO3') {
+                $result = TRUE;
+            }
+            if (!empty($conditionParameters) && substr($conditionParameters[0], 0, 1) === '=') {
+                $conditionParameters[0] = trim(substr($conditionParameters[0], 1));
+                if ($conditionParameters[0] == '42') {
+                    $result = TRUE;
+                }
+            }
 
-			return $result;
-		}
-	}
+            return $result;
+        }
+    }
 
 
 .. _condition-userfunc:
 
 userFunc
-""""""""
+========
 
 
 Syntax:
@@ -946,9 +947,9 @@ Syntax:
 
 
 Comparison:
-'''''''''''
+~~~~~~~~~~~
 
-This calls a user-defined function (above called "user\_function") and
+This calls a user-defined function (above called :php:`user_function`) and
 passes the provided parameters to that function (e.g. the two
 parameters "argument1" and "argument2"). Parameters can be enclosed
 with quotes so that leading and trailing spaces and commas inside a
@@ -969,20 +970,23 @@ It will call the function "user_match" with "checkLocalIP" as first
 argument and "192.168" as second argument. Whether the condition
 returns true or false depends on what that function returns.
 
-Put this function in your AdditionalConfiguration.php file::
+Put this function in your AdditionalConfiguration.php file:
 
-   function user_match($command, $subnet) {
-           switch($command) {
-                   case 'checkLocalIP':
-                           if (strstr(getenv('REMOTE_ADDR'), $subnet)) {
-                                   return TRUE;
-                           }
-                   break;
-                   case 'checkSomethingElse':
-                           // ....
-                   break;
-           }
-           return FALSE;
+.. code-block:: php
+
+   function user_match($command, $subnet)
+   {
+        switch($command) {
+            case 'checkLocalIP':
+                if (strstr(getenv('REMOTE_ADDR'), $subnet)) {
+                    return TRUE;
+                }
+            break;
+            case 'checkSomethingElse':
+                // ....
+            break;
+        }
+        return FALSE;
    }
 
 If the remote address contains "192.168", the condition will return

--- a/Documentation/Conditions/Syntax/Index.rst
+++ b/Documentation/Conditions/Syntax/Index.rst
@@ -22,26 +22,26 @@ General syntax
 Each condition is encapsulated by square brackets. For a list of
 available conditions see below.
 
-`[ELSE]` is available as else operator. It is a condition, which will
+:ts:`[ELSE]` is available as else operator. It is a condition, which will
 return TRUE, if the previous condition returned FALSE.
 
-Each condition block is ended with `[END]`.
+Each condition block is ended with :ts:`[END]`.
 
 
-`[GLOBAL]` is a condition by itself that always returns "true".
+:ts:`[GLOBAL]` is a condition by itself that always returns "true".
 It ensures that the following TypoScript code is located in the
 global scope. So you can be sure that it's not affected by previous
 TypoScript, for example if a closing bracket is missing.
 The *Template Analyzer* shows this very well: TYPO3 places a
-`[GLOBAL]` condition at the beginning of each TypoScript file.
+:ts:`[GLOBAL]` condition at the beginning of each TypoScript file.
 
-As a developer you can use `[GLOBAL]` for testing purposes
+As a developer you can use :ts:`[GLOBAL]` for testing purposes
 to ensure that your own condition works as expected.
 See :ref:`t3tssyntax:The-Global-Condition` for additional documentation.
 
 
 Example
--------
+~~~~~~~
 
 Test day of month::
 
@@ -69,24 +69,24 @@ operator has been specified, it will default to OR.
 
 
 Examples
---------
+~~~~~~~~
 
 Test day of month and month
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""""""""""""""""""""""""""
 
 This condition will match on May 9th::
 
    [dayofmonth = 9] && [month = 5]
 
 Test day of month
-~~~~~~~~~~~~~~~~~
+"""""""""""""""""
 
 This will match on either the ninth or the tenth of a month::
 
    [dayofmonth = 9] || [dayofmonth = 10]
 
 Test month and day of month
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+"""""""""""""""""""""""""""
 
 This will match in either June or May. In case of
 May, the day of the month must be above 8::

--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -1530,62 +1530,65 @@ the same page id in TYPO3 but where the difference would be in some
 parameter value.
 
 First, this listing creates a menu in three levels where the first two
-are graphical items::
+are graphical items:
 
-      0: # ************************
-      1: # MENU LEFT
-      2: # ************************
-      3: lib.leftmenu.20 = HMENU
-      4: lib.leftmenu.20.special = userfunction
-      5: lib.leftmenu.20.special.userFunc = user_3dsplm_pi2->makeMenuArray
-      6: lib.leftmenu.20.1 = GMENU
-      7: lib.leftmenu.20.1.NO {
-      8:   wrap = <tr><td>|</td></tr><tr><td class="bckgdgrey1" height="1"></td></tr>
-      9:   XY = 163,19
-     10:   backColor = white
-     11:   10 = TEXT
-     12:   10.text.field = title
-     13:   10.text.case = upper
-     14:   10.fontColor = red
-     15:   10.fontFile = fileadmin/fonts/ARIALNB.TTF
-     16:   10.niceText = 1
-     17:   10.offset = 14,12
-     18:   10.fontSize = 10
-     19: }
-     20: lib.leftmenu.20.2 = GMENU
-     21: lib.leftmenu.20.2.wrap = | <tr><td></td></tr><tr><td></td></tr>
-     22: lib.leftmenu.20.2.NO {
-     23:   wrap = <tr><td class="bckgdwhite" height="4"></td></tr><tr><td>|</td></tr>
-     24:   XY = 163,16
-     25:   backColor = white
-     26:   10 = TEXT
-     27:   10.text.field = title
-     28:   10.text.case = upper
-     29:   10.fontColor = #666666
-     30:   10.fontFile = fileadmin/fonts/ARIALNB.TTF
-     31:   10.niceText = 1
-     32:   10.offset = 14,12
-     33:   10.fontSize = 11
-     34: }
-     35: lib.leftmenu.20.2.RO < lib.leftmenu.20.2.NO
-     36: lib.leftmenu.20.2.RO = 1
-     37: lib.leftmenu.20.2.RO.backColor = #eeeeee
-     38: lib.leftmenu.20.2.ACT < lib.leftmenu.20.2.NO
-     39: lib.leftmenu.20.2.ACT = 1
-     40: lib.leftmenu.20.2.ACT.10.fontColor = red
-     41: lib.leftmenu.20.3 = TMENU
-     42: lib.leftmenu.20.3.NO {
-     43:   allWrap = <tr><td>|</td></tr>
-     44:   linkWrap (
-     45:    <table border="0" cellpadding="0" cellspacing="0">
-     46:       <tr>
-     47:         <td><img src="clear.gif" width="15" height="1" /></td>
-     48:         <td><img src="fileadmin/arrow_gray.gif" height="9" width="9" /></td>
-     49:         <td>|</td>
-     50:       </tr>
-     51:    </table>
-     52:   )
-     53: }
+.. code-block:: typoscript
+   :linenos:
+
+   # ************************
+   # MENU LEFT
+   # ************************
+   lib.leftmenu.20 = HMENU
+   lib.leftmenu.20.special = userfunction
+   lib.leftmenu.20.special.userFunc = user_3dsplm_pi2->makeMenuArray
+   lib.leftmenu.20.1 = GMENU
+   lib.leftmenu.20.1.NO {
+     wrap = <tr><td>|</td></tr><tr><td class="bckgdgrey1" height="1"></td></tr>
+     XY = 163,19
+     backColor = white
+     10 = TEXT
+     10.text.field = title
+     10.text.case = upper
+     10.fontColor = red
+     10.fontFile = fileadmin/fonts/ARIALNB.TTF
+     10.niceText = 1
+     10.offset = 14,12
+     10.fontSize = 10
+   }
+   lib.leftmenu.20.2 = GMENU
+   lib.leftmenu.20.2.wrap = | <tr><td></td></tr><tr><td></td></tr>
+   lib.leftmenu.20.2.NO {
+     wrap = <tr><td class="bckgdwhite" height="4"></td></tr><tr><td>|</td></tr>
+     XY = 163,16
+     backColor = white
+     10 = TEXT
+     10.text.field = title
+     10.text.case = upper
+     10.fontColor = #666666
+     10.fontFile = fileadmin/fonts/ARIALNB.TTF
+     10.niceText = 1
+     10.offset = 14,12
+     10.fontSize = 11
+   }
+   lib.leftmenu.20.2.RO < lib.leftmenu.20.2.NO
+   lib.leftmenu.20.2.RO = 1
+   lib.leftmenu.20.2.RO.backColor = #eeeeee
+   lib.leftmenu.20.2.ACT < lib.leftmenu.20.2.NO
+   lib.leftmenu.20.2.ACT = 1
+   lib.leftmenu.20.2.ACT.10.fontColor = red
+   lib.leftmenu.20.3 = TMENU
+   lib.leftmenu.20.3.NO {
+     allWrap = <tr><td>|</td></tr>
+     linkWrap (
+      <table border="0" cellpadding="0" cellspacing="0">
+         <tr>
+           <td><img src="clear.gif" width="15" height="1" /></td>
+           <td><img src="fileadmin/arrow_gray.gif" height="9" width="9" /></td>
+           <td>|</td>
+         </tr>
+      </table>
+     )
+   }
 
 The menu looks like this on a web page:
 
@@ -1595,51 +1598,54 @@ The menu looks like this on a web page:
 The TypoScript code above generates this menu, but the items do not
 link straight to pages as usual. This is because the *whole* menu is
 generated from this array, which was returned from the function
-"menuMenuArray" called in TypoScript line 4+5 ::
+"menuMenuArray" called in TypoScript line 4+5 :
 
-      1:  function makeMenuArray($content, $conf) {
-      2:    return array(
-      3:      array(
-      4:          'title' => 'Contact',
-      5:          '_OVERRIDE_HREF' => 'index.php?id=10',
-      6:          '_SUB_MENU' => array(
-      7:              array(
-      8:                  'title' => 'Offices',
-      9:                  '_OVERRIDE_HREF' => 'index.php?id=11',
-     10:                  '_OVERRIDE_TARGET' => '_top',
-     11:                  'ITEM_STATE' => 'ACT',
-     12:                  '_SUB_MENU' => array(
-     13:                      array(
-     14:                          'title' => 'Copenhagen Office',
-     15:                          '_OVERRIDE_HREF' => 'index.php?id=11&officeId=cph',
-     16:                      ),
-     17:                      array(
-     18:                          'title' => 'Paris Office',
-     19:                          '_OVERRIDE_HREF' => 'index.php?id=11&officeId=paris',
-     20:                      ),
-     21:                      array(
-     22:                          'title' => 'New York Office',
-     23:                          '_OVERRIDE_HREF' => 'http://www.example.com',
-     24:                          '_OVERRIDE_TARGET' => '_blank',
-     25:                      )
-     26:                  )
-     27:              ),
-     28:              array(
-     29:                  'title' => 'Form',
-     30:                  '_OVERRIDE_HREF' => 'index.php?id=10&cmd=showform',
-     31:              ),
-     32:              array(
-     33:                  'title' => 'Thank you',
-     34:                  '_OVERRIDE_HREF' => 'index.php?id=10&cmd=thankyou',
-     35:              ),
-     36:          ),
-     37:      ),
-     38:      array(
-     39:          'title' => 'Products',
-     40:          '_OVERRIDE_HREF' => 'index.php?id=14',
-     41:      )
-     42:    );
-     43:  }
+.. code-block:: php
+   :linenos:
+
+   function makeMenuArray($content, $conf) {
+     return array(
+       array(
+           'title' => 'Contact',
+           '_OVERRIDE_HREF' => 'index.php?id=10',
+           '_SUB_MENU' => array(
+               array(
+                   'title' => 'Offices',
+                   '_OVERRIDE_HREF' => 'index.php?id=11',
+                   '_OVERRIDE_TARGET' => '_top',
+                   'ITEM_STATE' => 'ACT',
+                   '_SUB_MENU' => array(
+                       array(
+                           'title' => 'Copenhagen Office',
+                           '_OVERRIDE_HREF' => 'index.php?id=11&officeId=cph',
+                       ),
+                       array(
+                           'title' => 'Paris Office',
+                           '_OVERRIDE_HREF' => 'index.php?id=11&officeId=paris',
+                       ),
+                       array(
+                           'title' => 'New York Office',
+                           '_OVERRIDE_HREF' => 'http://www.example.com',
+                           '_OVERRIDE_TARGET' => '_blank',
+                       )
+                   )
+               ),
+               array(
+                   'title' => 'Form',
+                   '_OVERRIDE_HREF' => 'index.php?id=10&cmd=showform',
+               ),
+               array(
+                   'title' => 'Thank you',
+                   '_OVERRIDE_HREF' => 'index.php?id=10&cmd=thankyou',
+               ),
+           ),
+       ),
+       array(
+           'title' => 'Products',
+           '_OVERRIDE_HREF' => 'index.php?id=14',
+       )
+     );
+   }
 
 Notice how the array contains "fake" page-records which has *no* uid
 field, only a "title" and "\_OVERRIDE\_HREF" as required and some

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -12,7 +12,7 @@ Returns an image tag with the image file defined in the property
 Defined as PHP function cImage() in
 typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php.
 
-The array $GLOBALS['TSFE']->lastImageInfo is set with the info-array
+The array :php:`$GLOBALS['TSFE']->lastImageInfo` is set with the info-array
 of the returning image (if any) and contains width, height and so on:
 
 =============================  =============================================

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -255,7 +255,7 @@ Contents of :file:`fileadmin/gethostname.php`:
 
 .. code-block:: php
 
-   <?php namespace MyVendorName;
+   namespace MyVendorName;
       class Hostname {
          /**
           * Return standard host name for the local machine

--- a/Documentation/DataTypes/Align/Index.rst
+++ b/Documentation/DataTypes/Align/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-align:
 
+=====
 align
 =====
 

--- a/Documentation/DataTypes/Boolean/Index.rst
+++ b/Documentation/DataTypes/Boolean/Index.rst
@@ -4,6 +4,7 @@
 .. _data-type-boolean:
 .. _data-type-bool:
 
+=======
 boolean
 =======
 

--- a/Documentation/DataTypes/Case/Index.rst
+++ b/Documentation/DataTypes/Case/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-case:
 
+====
 case
 ====
 

--- a/Documentation/DataTypes/Dateconf/Index.rst
+++ b/Documentation/DataTypes/Dateconf/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-date-conf:
 
+=========
 date-conf
 =========
 
@@ -40,5 +41,3 @@ date-conf
          y   year, numeric, 2 digits, like "13"
          z   day of the year, numeric, like "299"
          === ===========================================================
-
-

--- a/Documentation/DataTypes/Degree/Index.rst
+++ b/Documentation/DataTypes/Degree/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-degree:
 
+======
 degree
 ======
 
@@ -16,6 +17,3 @@ degree
 
    Comment
          -90 to 90, integers
-
-
-

--- a/Documentation/DataTypes/Dir/Index.rst
+++ b/Documentation/DataTypes/Dir/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-dir:
 
+===
 dir
 ===
 
@@ -24,5 +25,3 @@ dir
          [return full path: boolean]
 
          Files matching are returned in a comma-separated string.
-
-

--- a/Documentation/DataTypes/Functionname/Index.rst
+++ b/Documentation/DataTypes/Functionname/Index.rst
@@ -1,8 +1,10 @@
 .. include:: ../../Includes.txt
 
+.. highlight:: php
 
 .. _data-type-function-name:
 
+=============
 function name
 =============
 
@@ -30,14 +32,12 @@ function name
 
          Depending on implementation the class or function name (but not the
          method name) should probably be prefixed with "user\_". The prefix
-         can be changed in the $TYPO3\_CONF\_VARS config though. The function /
+         can be changed in the :php:`$GLOBALS['TYPO3_CONF_VARS']` config though. The function /
          method is normally called with 2 parameters, $conf (TS configuration)
          and $content (some content to be processed and returned).
 
          Also if you call a method in a class, it is checked (when using the
-         USER/USER\_INT objects) whether a class with the same name, but
+         :ts:`USER`/:ts:`USER_INT` objects) whether a class with the same name, but
          prefixed with "ux\_" is present and if so, *this* class is
          instantiated instead. See the document "Inside TYPO3" for more
          information on extending classes in TYPO3!
-
-

--- a/Documentation/DataTypes/Gettext/Index.rst
+++ b/Documentation/DataTypes/Gettext/Index.rst
@@ -1,10 +1,8 @@
 .. include:: ../../Includes.txt
 
-
-.. highlight:: typoscript
-
 .. _data-type-gettext:
 
+=======
 getText
 =======
 
@@ -63,7 +61,7 @@ getText
 .. _data-type-gettext-field:
 
 field:
-------
+======
 
 **Syntax**
 
@@ -78,15 +76,13 @@ field: [field name from the current :php:`$cObj->data` array in the cObject, mul
 - In :ref:`GIFBUILDER <gifbuilder>` :php:`$cObj->data` is set to the data
   :ref:`GIFBUILDER <gifbuilder>` is supplied with.
 
-**Examples**
-
-.. code-block:: typoscript
+**Examples**::
 
    foo = field : header
 
 *gets content from $cObj->data['header']*
 
-.. code-block:: typoscript
+::
 
    foo = field : fieldname|level1|level2
 
@@ -96,11 +92,11 @@ field: [field name from the current :php:`$cObj->data` array in the cObject, mul
 .. _data-type-gettext-parameters:
 
 parameters:
------------
+===========
 
 **Syntax**
 
-parameters: [field name from the current `$cObj->parameters` array in the cObject.]
+parameters: [field name from the current :php:`$cObj->parameters` array in the cObject.]
 
 See :ref:`parseFunc <parsefunc>`.
 
@@ -115,11 +111,11 @@ See :ref:`parseFunc <parsefunc>`.
 .. _data-type-gettext-register:
 
 register:
----------
+=========
 
 **Syntax**
 
-register: [field name from the $GLOBALS['TSFE']->register]
+register: [field name from the :php:`$GLOBALS['TSFE']->register`]
 
 See :ref:`LOAD_REGISTER <cobj-load-register>`.
 
@@ -136,7 +132,7 @@ See :ref:`LOAD_REGISTER <cobj-load-register>`.
 .. _data-type-gettext-leveltitle:
 
 leveltitle, leveluid, levelmedia:
----------------------------------
+=================================
 
 **Syntax**
 
@@ -148,15 +144,13 @@ return. Useful with levelmedia.]
 Returns values from up or down the page tree.
 
 
-**Examples**
-
-.. code-block:: typoscript
+**Examples**::
 
    foo = leveltitle : 1
 
 *gets the title of the page on the first level of the rootline*
 
-.. code-block:: typoscript
+::
 
    foo = leveltitle : -2 , slide
 
@@ -164,7 +158,7 @@ Returns values from up or down the page tree.
 AND if that is not present, walk to the bottom of the rootline until
 there's a title*
 
-.. code-block:: typoscript
+::
 
    foo = leveluid : 0
 
@@ -174,7 +168,7 @@ there's a title*
 .. _data-type-gettext-levelfield:
 
 levelfield:
------------
+===========
 
 **Syntax**
 
@@ -188,13 +182,13 @@ integer], [field name], ["slide"]
    foo = levelfield : -1 , user_myExtField , slide
 
 *gets the value of the user defined field user_myExtField in the root
-line (requires additional configuration in :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields']` to include field!)*
+line (requires additional configuration in $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] to include field!)*
 
 
 .. _data-type-gettext-date:
 
 date:
------
+=====
 
 **Syntax**
 
@@ -212,7 +206,7 @@ configuration. Then the date will be formatted as "d/m Y".
 .. _data-type-gettext-page:
 
 page:
------
+=====
 
 **Syntax**
 
@@ -228,7 +222,7 @@ page: [field in the current page record]
 .. _data-type-gettext-pagelayout:
 
 pagelayout:
------------
+===========
 
 **Syntax**
 
@@ -244,7 +238,7 @@ pagelayout
 .. _data-type-gettext-current:
 
 current:
---------
+========
 
 **Syntax**
 
@@ -260,7 +254,7 @@ current (gets the "current" value)
 .. _data-type-gettext-level:
 
 level:
-------
+======
 
 **Syntax**
 
@@ -276,7 +270,7 @@ level (gets the rootline level of the current page)
 .. _data-type-gettext-gp:
 
 GP:
----
+===
 
 **Syntax**
 
@@ -304,7 +298,7 @@ GP: Value from GET or POST method.
 .. _data-type-gettext-getenv:
 
 getenv:
--------
+=======
 
 **Syntax**
 
@@ -320,7 +314,7 @@ getenv: Value from environment variables
 .. _data-type-gettext-getindpenv:
 
 getIndpEnv:
------------
+===========
 
 *getIndpEnv* returns the value of a *System Environment Variable*
 denoted by *name* regardless of server OS, CGI/MODULE version etc. The
@@ -349,19 +343,19 @@ situations. The internal processing is handled by
 Name                  Definition                                                           Example or result
 ===================== ==================================================================== ===============
 HTTP_ACCEPT_LANGUAGE  language(s) accepted by client
-HTTP_HOST             [host][:[port]]                                                      192.168.1.4:8080
+HTTP_HOST             [host][:[port]]                                                      `192.168.1.4:8080`
 HTTP_REFERER          [scheme]://[host][:[port]][path]                                     `http://192.168.1.4:8080/typo3/32/temp/phpcheck/index.php/arg1/arg2/arg3/?arg1,arg2,arg3&p1=parameter1&p2[key]=value`
 HTTP_USER_AGENT       client user agent
-PATH_INFO             [path_info]                                                          /arg1/arg2/arg3/
-QUERY_STRING          [query]                                                              arg1,arg2,arg3&p1=parameter1&p2[key]=value
+PATH_INFO             [path_info]                                                          `/arg1/arg2/arg3/`
+QUERY_STRING          [query]                                                              `arg1,arg2,arg3&p1=parameter1&p2[key]=value`
 REMOTE_ADDR           client IP
 REMOTE_HOST           client host
-REQUEST_URI           [path]?[query]                                                       /typo3/32/temp/phpcheck/index.php/arg1/arg2/arg3/?arg1,arg2,arg3&p1=parameter1&p2[key]=value
+REQUEST_URI           [path]?[query]                                                       `/typo3/32/temp/phpcheck/index.php/arg1/arg2/arg3/?arg1,arg2,arg3&p1=parameter1&p2[key]=value`
 SCRIPT_FILENAME       absolute filename of script
-SCRIPT_NAME           [path_script]                                                        /typo3/32/temp/phpcheck/[index.php]
+SCRIPT_NAME           [path_script]                                                        `/typo3/32/temp/phpcheck/[index.php]`
 TYPO3_DOCUMENT_ROOT   absolute path of root of documents
-TYPO3_HOST_ONLY       [host]                                                               192.168.1.4
-TYPO3_PORT            [port]                                                               8080
+TYPO3_HOST_ONLY       [host]                                                               `192.168.1.4`
+TYPO3_PORT            [port]                                                               `8080`
 TYPO3_REQUEST_DIR     [scheme]://[host][:[port]][path_dir]
 TYPO3_REQUEST_HOST    [scheme]://[host][:[port]]
 TYPO3_REQUEST_SCRIPT  [scheme]://[host][:[port]][path_script]
@@ -378,7 +372,7 @@ TYPO3_SSL             TRUE if this session uses SSL/TLS (https)
 .. _data-type-gettext-tsfe:
 
 TSFE:
------
+=====
 
 **Syntax**
 
@@ -394,7 +388,7 @@ TSFE: [value from the :php:`$GLOBALS['TSFE']` array, multi-dimensional]
 .. _data-type-gettext-db:
 
 DB:
----
+===
 
 **Syntax**
 
@@ -412,7 +406,7 @@ marked as deleted will not return any value.
 .. _data-type-gettext-file:
 
 file:
------
+=====
 
 **Syntax**
 
@@ -446,7 +440,7 @@ See the :ref:`FILES cObject for usage examples <cobj-files-examples>`.
 .. _data-type-gettext-fullrootline:
 
 fullRootLine:
--------------
+=============
 
 **Syntax**
 
@@ -479,7 +473,7 @@ above.
 .. _data-type-gettext-lll:
 
 LLL:
-----
+====
 
 **Syntax**
 
@@ -495,7 +489,7 @@ Reference consists of [fileref]:[labelkey]
 .. _data-type-gettext-path:
 
 path:
------
+=====
 
 **Syntax**
 
@@ -511,7 +505,7 @@ empty if the file does not exist.
 .. _data-type-gettext-cobj:
 
 cObj:
------
+=====
 
 **Syntax**
 
@@ -533,7 +527,7 @@ current cObject record.
 .. _data-type-gettext-session:
 
 session:
---------
+========
 
 **Syntax**
 
@@ -551,7 +545,7 @@ The :ts:`key` refers to the session key used to store the value. Subelements may
 .. _data-type-gettext-debug:
 
 debug:
-------
+======
 
 **Syntax**
 
@@ -569,7 +563,7 @@ by the keyword. Available keywords are "rootLine", "fullRootLine",
 .. _data-type-gettext-global:
 
 global:
--------
+=======
 
 **Syntax**
 
@@ -577,7 +571,7 @@ global: [GLOBAL variable, split with \| if you want to get from an
 array! Deprecated, use GP, TSFE or getenv!]
 
 flexform:
----------
+=========
 
 **Syntax**
 

--- a/Documentation/DataTypes/Graphiccolor/Index.rst
+++ b/Documentation/DataTypes/Graphiccolor/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-graphiccolor:
 
+============
 GraphicColor
 ============
 
@@ -38,6 +39,3 @@ GraphicColor
          where modifier can be an integer which is added/subtracted to the
          three RGB-channels or a floating point with an "\*" before, which will
          then multiply the values with that factor.
-
-
-

--- a/Documentation/DataTypes/Htmlcode/Index.rst
+++ b/Documentation/DataTypes/Htmlcode/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-html-code:
 
+=========
 HTML code
 =========
 
@@ -18,6 +19,3 @@ HTML code
 
    Comment
          pure HTML code
-
-
-

--- a/Documentation/DataTypes/Htmlcolor/Index.rst
+++ b/Documentation/DataTypes/Htmlcolor/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-html-color:
 
+==========
 HTML-color
 ==========
 
@@ -41,6 +42,3 @@ HTML-color
          Teal              #008080
          Aqua              #00FFFF
          =============  ================
-
-
-

--- a/Documentation/DataTypes/Imageextension/Index.rst
+++ b/Documentation/DataTypes/Imageextension/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-imageextension:
 
+==============
 imageExtension
 ==============
 
@@ -18,12 +19,9 @@ imageExtension
 
    Comment
          Image extensions can be anything among the allowed types defined in
-         the global variable $TYPO3\_CONF\_VARS['GFX']['imagefile\_ext'].
+         the global variable :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.
          Standard is pdf, gif, jpg, jpeg, tif, bmp, ai, pcx, tga, png.
 
          The value **"web"** is special. This will just ensure that an image is
          converted to a web image format (gif or jpg) if it happens not to be
          already!
-
-
-

--- a/Documentation/DataTypes/Imgresource/Index.rst
+++ b/Documentation/DataTypes/Imgresource/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-imgresource:
 
+===========
 imgResource
 ===========
 
@@ -15,15 +16,17 @@ imgResource
          Here "file" is an imgResource::
 
             10 = IMAGE
-            10.file = fileadmin/toplogo.gif
-            10.file.width = 200
+            10 {
+                file = fileadmin/toplogo.gif
+                file.width = 200
+            }
 
          GIFBUILDER::
 
             10 = IMAGE
             10.file = GIFBUILDER
             10.file {
-               # GIFBUILDER properties here...
+                 # GIFBUILDER properties here...
             }
 
    Comment
@@ -31,10 +34,7 @@ imgResource
             and the object reference for imgResource below).
 
             Filetypes can be anything among the allowed types defined in the
-            configuration variable $TYPO3\_CONF\_VARS['GFX']['imagefile\_ext'].
+            configuration variable :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.
             Standard is pdf, gif, jpg, jpeg, tif, bmp, ai, pcx, tga, png.
 
-         #. A GIFBUILDER object. See the object reference for GIFBUILDER below.
-
-
-
+         #. A GIFBUILDER object. See the object reference for :ref:`gifbuilder` below.

--- a/Documentation/DataTypes/Integer/Index.rst
+++ b/Documentation/DataTypes/Integer/Index.rst
@@ -4,6 +4,7 @@
 .. _data-type-integer:
 .. _data-type-int:
 
+=======
 integer
 =======
 
@@ -20,6 +21,3 @@ integer
 
          (This data type is sometimes used generally though another type would
          have been more appropriate, like "pixels".)
-
-
-

--- a/Documentation/DataTypes/Linkwrap/Index.rst
+++ b/Documentation/DataTypes/Linkwrap/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-linkwrap:
 
+========
 linkWrap
 ========
 
@@ -27,6 +28,3 @@ linkWrap
          instead of {x}.
 
          Thus we can insert page\_ids from previous levels.
-
-
-

--- a/Documentation/DataTypes/List/Index.rst
+++ b/Documentation/DataTypes/List/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-list:
 
+====
 list
 ====
 
@@ -16,4 +17,3 @@ list
 
    Comment
          list of values
-

--- a/Documentation/DataTypes/Margins/Index.rst
+++ b/Documentation/DataTypes/Margins/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-margins:
 
+=======
 margins
 =======
 
@@ -21,6 +22,3 @@ margins
          l,t,r,b
 
          left, top, right, bottom
-
-
-

--- a/Documentation/DataTypes/Objecttypes/Cobject/Index.rst
+++ b/Documentation/DataTypes/Objecttypes/Cobject/Index.rst
@@ -3,15 +3,12 @@
 
 .. _data-type-cobject:
 
+=======
 cObject
 =======
 
-"cObjects" are also called "Content Objects". See the section "Content
-Objects" later in this manual.
+"cObjects" are also called "Content Objects". See the section ":ref:`cobjects`" later in this manual.
 
 **Examples:** ::
 
     TEXT / IMAGE / TEMPLATE ....
-
-
-

--- a/Documentation/DataTypes/Objecttypes/Frameobject/Index.rst
+++ b/Documentation/DataTypes/Objecttypes/Frameobject/Index.rst
@@ -3,10 +3,8 @@
 
 .. _data-type-frameobj:
 
+========
 frameObj
 ========
 
 FRAMESET / FRAME
-
-
-

--- a/Documentation/DataTypes/Objecttypes/Gifbuilderobject/Index.rst
+++ b/Documentation/DataTypes/Objecttypes/Gifbuilderobject/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-gifbuilderobj:
 
+=================
 Gifbuilder Object
 =================
 
@@ -11,4 +12,3 @@ See section :ref:`GIFBUILDER` in this manual.
 **Examples:** ::
 
     TEXT / SHADOW / OUTLINE / EMBOSS / BOX / IMAGE / EFFECT
-

--- a/Documentation/DataTypes/Objecttypes/Index.rst
+++ b/Documentation/DataTypes/Objecttypes/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-types-object-types:
 
+========================
 Data types: Object types
 ========================
 

--- a/Documentation/DataTypes/Objecttypes/Menuobject/Index.rst
+++ b/Documentation/DataTypes/Objecttypes/Menuobject/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-menuobj:
 
+===========
 menu object
 ===========
 
@@ -11,5 +12,3 @@ See the section :ref:`"Menu Objects" <menu-objects>` later in this manual.
 **Examples:** ::
 
     GMENU / TMENU / IMGMENU
-
-

--- a/Documentation/DataTypes/Pageid/Index.rst
+++ b/Documentation/DataTypes/Pageid/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-page-id:
 
+========
 page\_id
 ========
 
@@ -18,6 +19,3 @@ page\_id
 
    Comment
          A page id (integer) or "this" (=current page id).
-
-
-

--- a/Documentation/DataTypes/Path/Index.rst
+++ b/Documentation/DataTypes/Path/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-path:
 
+====
 path
 ====
 
@@ -12,10 +13,7 @@ path
          path
 
    Examples
-         *fileadmin/stuff/*
+         :file:`fileadmin/stuff/`
 
    Comment
          Path relative to the root directory from which we operate.
-
-
-

--- a/Documentation/DataTypes/Pixels/Index.rst
+++ b/Documentation/DataTypes/Pixels/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-pixels:
 
+======
 pixels
 ======
 
@@ -16,6 +17,3 @@ pixels
 
    Comment
          pixel-distance
-
-
-

--- a/Documentation/DataTypes/Positiveinteger/Index.rst
+++ b/Documentation/DataTypes/Positiveinteger/Index.rst
@@ -5,6 +5,7 @@
 .. _data-type-posint:
 .. _data-type-intplus:
 
+================
 positive integer
 ================
 
@@ -18,6 +19,3 @@ positive integer
 
    Comment
          Positive integer
-
-
-

--- a/Documentation/DataTypes/Resource/Index.rst
+++ b/Documentation/DataTypes/Resource/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-resource:
 
+========
 resource
 ========
 
@@ -20,6 +21,3 @@ resource
          If the value contains a "/", it is expected to be a reference
          (absolute or relative) to a file in the file system. There is no
          support for wildcard characters in the name of the reference.
-
-
-

--- a/Documentation/DataTypes/Rotation/Index.rst
+++ b/Documentation/DataTypes/Rotation/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-rotation:
 
+========
 rotation
 ========
 
@@ -16,6 +17,3 @@ rotation
 
    Comment
          integer, degrees from 0 - 360
-
-
-

--- a/Documentation/DataTypes/Space/Index.rst
+++ b/Documentation/DataTypes/Space/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-space:
 
+=====
 space
 =====
 
@@ -19,6 +20,3 @@ space
 
          Used for content and sets the according number of pixels space
          "before \| after".
-
-
-

--- a/Documentation/DataTypes/Strftimeconf/Index.rst
+++ b/Documentation/DataTypes/Strftimeconf/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-strftime-conf:
 
+=============
 strftime-conf
 =============
 
@@ -62,6 +63,3 @@ strftime-conf
          %Z   time zone or name or abbreviation
          %%   a literal \`%' character
          ==== ==========================================================
-
-
-

--- a/Documentation/DataTypes/String/Index.rst
+++ b/Documentation/DataTypes/String/Index.rst
@@ -5,6 +5,7 @@
 .. _data-type-str:
 .. _data-type-value:
 
+======
 string
 ======
 
@@ -21,6 +22,3 @@ string
 
          (sometimes used generally though another type would have been more
          appropriate, like "align")
-
-
-

--- a/Documentation/DataTypes/Tag/Index.rst
+++ b/Documentation/DataTypes/Tag/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-tag:
 
+=====
 <tag>
 =====
 
@@ -18,6 +19,3 @@
 
    Comment
          An HTML tag.
-
-
-

--- a/Documentation/DataTypes/Tagdata/Index.rst
+++ b/Documentation/DataTypes/Tagdata/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-tag-data:
 
+============
 < tag >-data
 ============
 
@@ -17,6 +18,3 @@
          *could be '150,\*'*
 
    Comment
-
-
-

--- a/Documentation/DataTypes/Tagparams/Index.rst
+++ b/Documentation/DataTypes/Tagparams/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-tag-params:
 
+==============
 < tag >-params
 ==============
 
@@ -18,5 +19,3 @@
 
    Comment
          Parameters for a tag.
-
-

--- a/Documentation/DataTypes/Target/Index.rst
+++ b/Documentation/DataTypes/Target/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-target:
 
+======
 target
 ======
 
@@ -23,5 +24,3 @@ target
 
          This is normally the same value as the name of the root-level object
          that defines the frame.
-
-

--- a/Documentation/DataTypes/Unixtime/Index.rst
+++ b/Documentation/DataTypes/Unixtime/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-unix-time:
 
+=========
 UNIX-time
 =========
 
@@ -18,6 +19,3 @@ UNIX-time
 
    Comment
          Seconds since January 1st 1970.
-
-
-

--- a/Documentation/DataTypes/Vhalign/Index.rst
+++ b/Documentation/DataTypes/Vhalign/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-vhalign:
 
+=======
 VHalign
 =======
 
@@ -30,6 +31,3 @@ VHalign
 
    Default
          l , t
-
-
-

--- a/Documentation/DataTypes/Wrap/Index.rst
+++ b/Documentation/DataTypes/Wrap/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-wrap:
 
+====
 wrap
 ====
 
@@ -26,5 +27,3 @@ wrap
 
          Spaces between the wrap-parts and the divider ("|") are trimmed off
          from each part of the wrap.
-
-

--- a/Documentation/DataTypes/Xywh/Index.rst
+++ b/Documentation/DataTypes/Xywh/Index.rst
@@ -3,6 +3,7 @@
 
 .. _data-type-xywh:
 
+=======
 x,y,w,h
 =======
 
@@ -18,4 +19,3 @@ x,y,w,h
          x,y is the offset from the upper left corner.
 
          w,h is the width and height
-

--- a/Documentation/Functions/Addparams/Index.rst
+++ b/Documentation/Functions/Addparams/Index.rst
@@ -3,12 +3,18 @@
 
 .. _addparams:
 
+=========
 addParams
-^^^^^^^^^
+=========
 
 Adds parameters to an HTML tag.
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _addParams-\_offset:
+
+\_offset
+========
 
 .. container:: table-row
 
@@ -16,7 +22,7 @@ Adds parameters to an HTML tag.
          \_offset
 
    Data type
-         integer
+         :ref:`data-type-integer`
 
    Description
          Use this to define which tag you want to manipulate.
@@ -27,6 +33,10 @@ Adds parameters to an HTML tag.
    Default
          1
 
+.. _addParams-*(array-of-strings)*:
+
+*(array of strings)*
+====================
 
 .. container:: table-row
 
@@ -34,7 +44,7 @@ Adds parameters to an HTML tag.
          *(array of strings)*
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          The name of the property defines the property to be added to the
@@ -56,7 +66,7 @@ Adds parameters to an HTML tag.
 .. _addparams-examples:
 
 Example:
-""""""""
+========
 
 ::
 
@@ -65,10 +75,11 @@ Example:
    page.13.stdWrap.addParams.bgcolor = white
    page.13.stdWrap.addParams._offset = -1
 
-Result example::
+Result example:
+
+.. code-block:: html
 
    <tr><td bgcolor="white">
 
-This example adds the 'bgColor' property to the value of the TEXT
-cObject.
-
+This example adds the :ts:`bgColor` property to the value of the :ref:`cobj-text`
+:ref:`data-type-cobject`.

--- a/Documentation/Functions/Cache/Index.rst
+++ b/Documentation/Functions/Cache/Index.rst
@@ -3,22 +3,23 @@
 
 .. _cache:
 
+=====
 cache
-^^^^^
+=====
 
 Stores the rendered content into the caching framework and reads it
 from there. This allows you to reuse this content without prior
-rendering. The presence of "cache.key" will trigger this feature. It
+rendering. The presence of :ts:`cache.key` will trigger this feature. It
 is evaluated twice:
 
-- Content is read from cache directly after the stdWrapPreProcess hook
-  and before "setContentToCurrent". If there is a cache entry for the
-  given cache key, stdWrap processing will stop and the cached content
+- Content is read from cache directly after the ``stdWrapPreProcess`` hook
+  and before ``setContentToCurrent``. If there is a cache entry for the
+  given cache key, :ts:`stdWrap` processing will stop and the cached content
   will be returned. If no cache content is found for this key, the
   stdWrap processing continues as usual.
 
 - Writing to cache happens at the end of rendering, directly before the
-  stdWrapPostProcess hook is called and before the "debug\*" functions.
+  ``stdWrapPostProcess`` hook is called and before the "debug\*" functions.
   The rendered content will be stored in the cache, if cache.key was
   set. The configuration options cache.tags and cache.lifetime allow to
   control the caching.
@@ -26,13 +27,18 @@ is evaluated twice:
 
 .. ### BEGIN~OF~TABLE ###
 
+.. _cache-key:
+
+key
+===
+
 .. container:: table-row
 
    Property
          key
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          The cache identifier that is used to store the rendered content into
@@ -43,6 +49,10 @@ is evaluated twice:
          versions of the rendered content while being generic enough to stay
          efficient.
 
+.. _cache-lifetime:
+
+lifetime
+========
 
 .. container:: table-row
 
@@ -50,7 +60,7 @@ is evaluated twice:
          lifetime
 
    Data type
-         mixed /:ref:`stdWrap <stdwrap>`
+         mixed / :ref:`stdwrap`
 
    Description
          Lifetime of the content in cache.
@@ -68,11 +78,15 @@ is evaluated twice:
          purged by id or by tag or if the complete cache is flushed.
 
          **"default":** The default cache lifetime as configured in
-         config.cache\_period is used.
+         :ts:`config.cache_period` is used.
 
    Default
          default
 
+.. _cache-tags:
+
+tags
+====
 
 .. container:: table-row
 
@@ -80,12 +94,12 @@ is evaluated twice:
          tags
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` /:ref:`stdwrap`
 
    Description
          Can hold a comma-separated list of tags. These tags will be attached
-         to the cached content into the cache\_hash storage (not into
-         cache\_pages) and can be used to purge the cached content.
+         to the cached content into the ``cache_hash`` storage (not into
+         ``cache_pages``) and can be used to purge the cached content.
 
 
 .. ###### END~OF~TABLE ######
@@ -96,17 +110,17 @@ is evaluated twice:
 .. _cache-examples:
 
 Examples:
-"""""""""
+=========
 
 ::
 
    5 = TEXT
    5 {
-     stdWrap.cache.key = mycurrenttimestamp
-     stdWrap.cache.tags = tag_a,tag_b,tag_c
-     stdWrap.cache.lifetime = 3600
-     stdWrap.data = date : U
-     stdWrap.strftime = %H:%M:%S
+       stdWrap.cache.key = mycurrenttimestamp
+       stdWrap.cache.tags = tag_a,tag_b,tag_c
+       stdWrap.cache.lifetime = 3600
+       stdWrap.data = date : U
+       stdWrap.strftime = %H:%M:%S
    }
 
 In the above example the current time will be cached with the key
@@ -117,15 +131,15 @@ timestamp). ::
 
    5 = TEXT
    5 {
-     stdWrap.cache.key = mycurrenttimestamp_{page:uid}_{TSFE:sys_language_uid}
-     stdWrap.cache.key.insertData = 1
+       stdWrap.cache.key = mycurrenttimestamp_{page:uid}_{TSFE:sys_language_uid}
+       stdWrap.cache.key.insertData = 1
    }
 
 Here a dynamic key is used. It takes the page id and the language uid
 into account making the object page and language specific.
 
 cache as first-class function:
-""""""""""""""""""""""""""""""
+==============================
 
 The :ts:`stdWrap.cache.` property is also available as first-class function to all
 content objects. This skips the rendering even for content objects that evaluate
@@ -135,33 +149,33 @@ Usage:
 
 .. code-block:: typoscript
 
-	page = PAGE
-	page.10 = COA
-	page.10 {
-		cache.key = coaout
-		cache.lifetime = 60
-		#stdWrap.cache.key = coastdWrap
-		#stdWrap.cache.lifetime = 60
-		10 = TEXT
-		10 {
-			cache.key = mycurrenttimestamp
-			cache.lifetime = 60
-			data = date : U
-			strftime = %H:%M:%S
-			noTrimWrap = |10: | |
-		}
-		20 = TEXT
-		20 {
-			data = date : U
-			strftime = %H:%M:%S
-			noTrimWrap = |20: | |
-		}
-	}
+   page = PAGE
+   page.10 = COA
+   page.10 {
+       cache.key = coaout
+       cache.lifetime = 60
+       #stdWrap.cache.key = coastdWrap
+       #stdWrap.cache.lifetime = 60
+       10 = TEXT
+       10 {
+           cache.key = mycurrenttimestamp
+           cache.lifetime = 60
+           data = date : U
+           strftime = %H:%M:%S
+           noTrimWrap = |10: | |
+       }
+       20 = TEXT
+       20 {
+           data = date : U
+           strftime = %H:%M:%S
+           noTrimWrap = |20: | |
+       }
+   }
 
 The commented part is :ts:`stdWrap.cache.` property available since 4.7,
 that does not stop the rendering of :ts:`COA` including all sub-cObjects.
 
-Additionally, stdWrap support is added to key, lifetime and tags.
+Additionally, :ts:`stdWrap` support is added to key, lifetime and tags.
 
 If you've previously used the :ts:`cache.` property in your custom cObject,
 this will now fail, because :ts:`cache.` is unset to avoid double caching.
@@ -171,8 +185,9 @@ rename your property.
 :ts:`stdWrap.cache` continues to exists and can be used as before. However
 the top level :ts:`stdWrap` of certain cObjects (e.g. :ts:`TEXT` cObject)
 will not evaluate :ts:`cache.` as part of :ts:`stdWrap`, but before starting
-the rendering of the cObject. In conjunction the storing will happen
-after the :ts:`stdWrap` processing right before the content is returned.
+the rendering of the :ref:`data-type-cobject`.
+In conjunction the storing will happen after the :ref:`stdwrap`
+processing right before the content is returned.
 
 Top level :ts:`cache.` will not evaluate the hook
 :php:`$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']['stdWrap_cacheStore']`

--- a/Documentation/Functions/Encapslines/Index.rst
+++ b/Documentation/Functions/Encapslines/Index.rst
@@ -3,10 +3,16 @@
 
 .. _encapslines:
 
+===========
 encapsLines
-^^^^^^^^^^^
+===========
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _encapstaglist:
+
+encapsTagList
+=============
 
 .. container:: table-row
 
@@ -23,7 +29,9 @@ encapsLines
 
             encapsTagList = div, p
 
-         This setting will recognize the red line below as encapsulated lines::
+         This setting will recognize the red line below as encapsulated lines:
+
+         .. code-block:: html
 
             First line of text
             Some <div>text</div>
@@ -31,6 +39,10 @@ encapsLines
             <div>Some text</div>
             <B>Some text</B>
 
+.. _remaptag.[*tagname*]:
+
+remapTag.[*tagname*]
+====================
 
 .. container:: table-row
 
@@ -38,24 +50,32 @@ encapsLines
          remapTag.[*tagname*]
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          Enter a new tag name here if you wish the tagname of any encapsulation
          to be unified to a single tag name.
 
-         For instance, setting this value to "remapTag.P=DIV" would convert::
+         For instance, setting this value to :ts:`remapTag.P=DIV` would convert:
+
+         .. code-block:: html
 
             <p>Some text</p>
             <div>Some text</div>
 
-         to ::
+         to :
+
+         .. code-block:: html
 
             <div>Some text</div>
             <div>Some text</div>
 
          ([*tagname*] is in uppercase.)
 
+.. _addattributes.[*tagname*]:
+
+addAttributes.[*tagname*]
+=========================
 
 .. container:: table-row
 
@@ -71,8 +91,8 @@ encapsLines
          **Example:** ::
 
             addAttributes.P {
-              style=padding-bottom: 0px; margin-top: 1px; margin-bottom: 1px;
-              align=center
+                style = padding-bottom: 0px; margin-top: 1px; margin-bottom: 1px;
+                align = center
             }
 
          ([*tagname*] is in uppercase.) ::
@@ -87,6 +107,10 @@ encapsLines
 
          Default is to always override/set the value of the attributes.
 
+.. _removewrapping:
+
+removeWrapping
+==============
 
 .. container:: table-row
 
@@ -94,12 +118,14 @@ encapsLines
          removeWrapping
 
    Data type
-         boolean
+        :ref:`data-type-boolean`
 
    Description
          If set, then all existing wrapping will be removed.
 
-         This::
+         This:
+
+         .. code-block:: html
 
             First line of text
             Some <div>text</div>
@@ -107,7 +133,9 @@ encapsLines
             <div>Some text</div>
             <b>Some text</b>
 
-         becomes this::
+         becomes this:
+
+         .. code-block:: html
 
             First line of text
             Some <div>text</div>
@@ -115,6 +143,10 @@ encapsLines
             Some text
             <b>Some text</b>
 
+.. _wrapnonwrappedlines:
+
+wrapNonWrappedLines
+===================
 
 .. container:: table-row
 
@@ -122,25 +154,33 @@ encapsLines
          wrapNonWrappedLines
 
    Data type
-         wrap
+        :ref:`stdwrap-wrap`
 
    Description
          Wrapping for non-encapsulated lines
 
          **Example:** ::
 
-            .wrapNonWrappedLines = <p>|</p>
+            wrapNonWrappedLines = <p>|</p>
 
-         This::
+         This:
+
+         .. code-block:: html
 
             First line of text
             <p>Some text</p>
 
-         becomes this::
+         becomes this:
+
+         .. code-block:: html
 
             <P>First line of text</P>
             <p>Some text</p>
 
+.. _innerstdwrap\_all:
+
+innerStdWrap\_all
+=================
 
 .. container:: table-row
 
@@ -148,12 +188,16 @@ encapsLines
          innerStdWrap\_all
 
    Data type
-         ->stdWrap
+        :ref:`stdWrap`
 
    Description
          Wraps the content inside all lines, whether they are encapsulated or
          not.
 
+.. _encapslinesstdwrap.[*tagname*]:
+
+encapsLinesStdWrap.[*tagname*]
+==============================
 
 .. container:: table-row
 
@@ -161,7 +205,7 @@ encapsLines
          encapsLinesStdWrap.[*tagname*]
 
    Data type
-         ->stdWrap
+        :ref:`stdWrap`
 
    Description
          Wraps the content inside all encapsulated lines.
@@ -169,19 +213,28 @@ encapsLines
          ([*tagname*] is in uppercase.)
 
 
+.. _defaultalign:
+
+defaultAlign
+============
+
 .. container:: table-row
 
    Property
          defaultAlign
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          If set, this value is set as the default "align" value of the wrapping
-         tags, both from .encapsTagList, .bypassEncapsTagList and
-         .nonWrappedTag
+         tags, both from :ref:`encapsTagList`, :ts:`bypassEncapsTagList` and
+         :ref:`nonWrappedTag`
 
+.. _nonwrappedtag:
+
+nonWrappedTag
+=============
 
 .. container:: table-row
 
@@ -189,14 +242,15 @@ encapsLines
          nonWrappedTag
 
    Data type
-         tagname
+         :ts:`tagname`
 
    Description
          For all non-wrapped lines, you can here set a tag in which they
          should be wrapped. Example would be "p". This is an alternative to
-         .wrapNonWrappedLines and has the advantage that its attributes are
-         set by .addAttributes as well as defaultAlign. Thus you can match
-         the wrapping tags used for non-wrapped and wrapped lines more easily.
+         :ts:`wrapNonWrappedLines` and has the advantage that its attributes are
+         set by :ts:`addAttributes` as well as :ts:`defaultAlign`.
+         Thus you can match the wrapping tags used for non-wrapped and wrapped
+         lines more easily.
 
 
 .. ###### END~OF~TABLE ######
@@ -207,15 +261,15 @@ encapsLines
 .. _encapslines-examples:
 
 Example:
-""""""""
+========
 
 ::
 
    encapsLines {
-     encapsTagList = div,p
-     remapTag.DIV = P
-     wrapNonWrappedLines = <p>|</p>
-     innerStdWrap_all.ifEmpty = &nbsp;
+       encapsTagList = div,p
+       remapTag.DIV = P
+       wrapNonWrappedLines = <p>|</p>
+       innerStdWrap_all.ifEmpty = &nbsp;
    }
 
 This example shows how to handle content rendered by TYPO3 and
@@ -229,7 +283,9 @@ Say, you have made this content with the Rich Text Editor::
    <div style="text-align: right;">This line is right-aligned.</div>
 
 After being processed by encapsLines with the above configuration, the
-content looks like this::
+content looks like this:
+
+.. code-block:: html
 
    <p>This is line # 1 </p>
    <p>&nbsp;</p>
@@ -245,7 +301,7 @@ the content in the database remains as human readable as possible.
 
 
 Example:
-""""""""
+========
 
 ::
 
@@ -258,21 +314,20 @@ Example:
    # Setting up nonTypoTagStdWrap to wrap the text with p-tags
    tt_content.text.20.parseFunc.nonTypoTagStdWrap >
    tt_content.text.20.parseFunc.nonTypoTagStdWrap.encapsLines {
-     encapsTagList = div,p
-     remapTag.DIV = P
-     wrapNonWrappedLines = <p style="margin: 0 0 0;">|</p>
+       encapsTagList = div,p
+       remapTag.DIV = P
+       wrapNonWrappedLines = <p style="margin: 0 0 0;">|</p>
 
-     # Forcing these attributes onto the encapsulation-tags if any
-     addAttributes.P {
-       style=margin: 0 0 0;
-     }
-     innerStdWrap_all.ifEmpty = &nbsp;
+       # Forcing these attributes onto the encapsulation-tags if any
+       addAttributes.P {
+           style=margin: 0 0 0;
+       }
+       innerStdWrap_all.ifEmpty = &nbsp;
    }
    # Finally removing the <br>-tag after the content...
    tt_content.text.20.wrap >
 
 This is an example of how to wrap traditional tt\_content bodytext
-with <p> tags, setting the line-distances to regular space like that
-generated by a <br> tag, but staying compatible with the RTE features
+with :html:`<p>` tags, setting the line-distances to regular space like that
+generated by a :html:`<br>` tag, but staying compatible with the RTE features
 such as assigning classes and alignment to paragraphs.
-

--- a/Documentation/Functions/Filelink/Index.rst
+++ b/Documentation/Functions/Filelink/Index.rst
@@ -4,6 +4,7 @@
 
 .. _filelink:
 
+========
 filelink
 ========
 
@@ -11,76 +12,84 @@ filelink
    filelink
 
 :aspect:`Description:`
-   Creates a list of file links. Input is a filename specified in :ts:`path`.
-   icon, size and file are rendered in the listed order.
+   Creates a list of file links. Input is a filename specified in
+   :ref:`filelink-path`.
+   :ref:`filelink-icon`, :ref:`filelink-size` and :ref:`filelink-file`
+   are rendered in the listed order.
 
 :aspect:`Overview:`
    ::
 
       1.filelink {
-         altText =
-         ATagBeforeWrap =
-         ATagParams =
-         emptyTitleHandling =
-         file =
-         icon =
-         icon_link =
-         icon_image_ext_list =
-         icon_thumbSize =
-         iconCObject =
-         labelStdWrap =
-         longdescURL =
-         path =
-         removePrependedNumbers =
-         size = =
-         stdWrap =
-         target =
-         # titleText ?
-         titleText =
-         typolinkConfiguration =
-         wrap =
+          altText =
+          ATagBeforeWrap =
+          ATagParams =
+          emptyTitleHandling =
+          file =
+          icon =
+          icon_link =
+          icon_image_ext_list =
+          icon_thumbSize =
+          iconCObject =
+          labelStdWrap =
+          longdescURL =
+          path =
+          removePrependedNumbers =
+          size = =
+          stdWrap =
+          target =
+          # titleText ?
+          titleText =
+          typolinkConfiguration =
+          wrap =
       }
 
+.. _filelink-alttext:
+
 altText
--------
+=======
 
 :aspect:`Property:`
    altText
 
 :aspect:`Data type:`
-   string /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description:`
-   For icons (image made with "iconCObject" must have their own
-   properties). If no alttext is specified, it will use an empty alttext
+   For icons (image made with :ref:`filelink-iconCObject` must have their own properties).
+   If no :ref:`filelink-altText` is specified, it will use an empty :ref:`filelink-altText`.
 
 
+
+.. _filelink-atagbeforewrap:
 
 ATagBeforeWrap
---------------
+==============
 
 :aspect:`Property:`
    ATagBeforeWrap
 
 :aspect:`Data type:`
-   boolean
+   :ref:`data-type-boolean`
 
 :aspect:`Description:`
-   If set, the link is first wrapped with "*.wrap*" and then the <A>-tag.
+   If set, the link is first wrapped with :ref:`filelink-wrap` and then the :html:`<A>`-tag.
 
 :aspect:`Default:`
    0
 
 
 
+.. _filelink-atagparams:
+
 ATagParams
-----------
+==========
 
 :aspect:`Property:`
    ATagParams
 
 :aspect:`Data type:`
-   <A>-params /:ref:`stdWrap <stdwrap>`
+   <A>-params / :ref:`stdwrap`
 
 :aspect:`Description:`
    Additional parameters
@@ -90,32 +99,36 @@ ATagParams
 
 
 
+.. _filelink-emptytitlehandling:
+
 emptyTitleHandling
-------------------
+==================
 
 :aspect:`Property:`
    emptyTitleHandling
 
 :aspect:`Data type:`
-string /:ref:`stdWrap <stdwrap>`
+    :ref:`data-type-string` /:ref:`stdwrap`
 
 :aspect:`Description:`
-   Value can be :ts:`keepEmpty` to preserve an empty title attribute or
-   :ts:`useAlt` to use the alt attribute instead.
+   Value can be "keepEmpty" to preserve an empty title attribute or
+   "useAlt" to use the alt attribute instead.
 
 :aspect:`Default:`
    :ts:`useAlt`
 
 
 
+.. _filelink-file:
+
 file
-----
+====
 
 :aspect:`Property:`
    file
 
 :aspect:`Data type:`
-   ->stdWrap
+   :ref:`stdwrap`
 
 :aspect:`Description:`
    stdWrap of the label (by default the label is the filename) after
@@ -123,27 +136,31 @@ file
 
 
 
+.. _filelink-icon:
+
 icon
-----
+====
 
 :aspect:`Property:`
    icon
 
 :aspect:`Data type:`
-   :ref:`boolean <data-type-bool>`/:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Overview:`
    ::
 
       1.filelink {
-         icon = 1
-         icon.path =
-         icon.ext =
-         icon.widthAttribute =
-         icon.heightAttribute =
-         icon.stdWrap {
-            # ...
-         ]
+          icon = 1
+          icon {
+              path =
+              ext =
+              widthAttribute =
+              heightAttribute =
+              stdWrap {
+                  # ...
+              }
+          }
       }
 
 
@@ -151,13 +168,13 @@ icon
    Set, if an icon should be shown.
 
    The filename of the icon used is the one of the filetype of the file
-   given in path_ (see above) plus extension (by default :file:`.gif`).
+   given in :ts:`path` (see above) plus extension (by default :file:`.gif`).
    For example for CSS files the icon file :file:`css.gif` will be used
    by default.
    If for a certain filetype no icon file is found in :ts:`icon.path`, the file
    :file:`default` plus extension (for example :file:`default.gif`) will be used.
 
-   The following sub-properties are available and have stdWrap functionality:
+   The following sub-properties are available and have :ref:`stdwrap` functionality:
 
    -  :ts:`path`:
             Path to the icon set.
@@ -171,14 +188,16 @@ icon
 
 
 
+.. _filelink-icon\_link:
+
 icon\_link
-----------
+==========
 
 :aspect:`Property:`
    icon\_link
 
 :aspect:`Data type:`
-   boolean
+   :ref:`data-type-boolean`
 
 :aspect:`Description:`
    Set if the icon should be linked as well.
@@ -188,14 +207,16 @@ icon\_link
 
 
 
+.. _filelink-icon\_image\_ext\_list:
+
 icon\_image\_ext\_list
-----------------------
+======================
 
 :aspect:`Property:`
    icon\_image\_ext\_list
 
 :aspect:`Data type:`
-   *list of image extensions* /:ref:`stdWrap <stdwrap>`
+   *list of image extensions* / :ref:`stdwrap`
 
 :aspect:`Description:`
    This is a comma-separated list of those file extensions that should
@@ -203,14 +224,16 @@ icon\_image\_ext\_list
 
 
 
+.. _filelink-icon\_thumbsize:
+
 icon\_thumbSize
----------------
+===============
 
 :aspect:`Property:`
    icon\_thumbSize
 
 :aspect:`Data type:`
-   string /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description:`
    Defines the size of the thumbnail in pixels.
@@ -230,14 +253,16 @@ icon\_thumbSize
 
 
 
+.. _filelink-iconcobject:
+
 iconCObject
------------
+===========
 
 :aspect:`Property:`
    iconCObject
 
 :aspect:`Data type:`
-   cObject
+   :ref:`data-type-cobject`
 
 :aspect:`Description:`
    Enter a cObject to use alternatively for the icons, for example IMAGE type.
@@ -246,14 +271,16 @@ iconCObject
 
 
 
+.. _filelink-labelstdwrap:
+
 labelStdWrap
-------------
+============
 
 :aspect:`Property:`
    labelStdWrap
 
 :aspect:`Data type:`
-   ->stdWrap
+   :ref:`stdwrap`
 
 :aspect:`Description:`
    stdWrap options for the label (by default the label is the filename)
@@ -262,14 +289,16 @@ labelStdWrap
 
 
 
+.. _filelink-longdescurl:
+
 longdescURL
------------
+===========
 
 :aspect:`Property:`
    longdescURL
 
 :aspect:`Data type:`
-   string /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description:`
    For icons (image made with "iconCObject" must have their own
@@ -279,28 +308,32 @@ longdescURL
 
 
 
+.. _filelink-path:
+
 path
-----
+====
 
 :aspect:`Property:`
    path
 
 :aspect:`Data type:`
-   path /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-path` / :ref:`stdwrap`
 
 :aspect:`Example:`
    :ts:`path = "uploads/media/`
 
 
 
+.. _filelink-removeprependednumbers:
+
 removePrependedNumbers
-----------------------
+======================
 
 :aspect:`Property:`
    removePrependedNumbers
 
 :aspect:`Data type:`
-   boolean
+   :ref:`data-type-bool`
 
 :aspect:`Description:`
    If set, any 2-digit *appended(!)* numbers in the filename are removed.
@@ -310,60 +343,71 @@ removePrependedNumbers
 
 
 
+.. _filelink-size:
+
 size
-----
+====
 
 :aspect:`Property:`
    size
 
 :aspect:`Data type:`
-   boolean /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description:`
    Set if size should be shown
 
 
 
+.. _filelink-stdwrap:
+
 stdWrap
--------
+=======
 
 :aspect:`Property:`
    stdWrap
 
 :aspect:`Data type:`
-   ->stdWrap
+   :ref:`stdwrap`
 
 
+
+.. _filelink-target:
 
 target
-------
+======
 
 :aspect:`Property:`
    target
 
 :aspect:`Data type:`
-   target /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-target` / :ref:`stdwrap`
 
 :aspect:`Description:`
    Target for the <a>-tag.
 
 
 
+.. _filelink-titletext:
+
 titleText
----------
-?
+=========
+
+tbd.
 
 
 
+
+.. _filelink-typolinkconfiguration:
 
 typolinkConfiguration
----------------------
+=====================
 
 :aspect:`Property:`
    typolinkConfiguration
 
 :aspect:`Data type:`
-   :ref:`->typolink <typolink>`
+   :ref:`typolink`
 
 :aspect:`Description:`
    This property can be used to pass additional typolink settings for
@@ -377,14 +421,16 @@ typolinkConfiguration
 
 
 
+.. _filelink-wrap:
+
 wrap
-----
+====
 
 :aspect:`Property:`
    wrap
 
 :aspect:`Data type:`
-   wrap /:ref:`stdWrap <stdwrap>`
+   :ref:`data-type-wrap` / :ref:`stdwrap`
 
 :aspect:`Description:`
    Wraps the links.
@@ -399,13 +445,12 @@ Filelink Example
 ::
 
    1.filelink {
-      path = uploads/media/
-      icon = 1
-      icon.wrap = <td> | </td>
-      size = 1
-      size.wrap = <td> | </td>
-      file.wrap = <td> | </td>
-      target = _blank
-      stdWrap = <tr> | </tr>
+       path = uploads/media/
+       icon = 1
+       icon.wrap = <td> | </td>
+       size = 1
+       size.wrap = <td> | </td>
+       file.wrap = <td> | </td>
+       target = _blank
+       stdWrap = <tr> | </tr>
    }
-

--- a/Documentation/Functions/Htmlparser/Index.rst
+++ b/Documentation/Functions/Htmlparser/Index.rst
@@ -3,10 +3,16 @@
 
 .. _htmlparser:
 
+==========
 HTMLparser
-^^^^^^^^^^
+==========
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _htmlparser-allowtags:
+
+allowTags
+=========
 
 .. container:: table-row
 
@@ -19,6 +25,10 @@ HTMLparser
    Description
          Default allowed tags
 
+.. _htmlparser-stripemptytags:
+
+stripEmptyTags
+==============
 
 .. container:: table-row
 
@@ -26,11 +36,15 @@ HTMLparser
          stripEmptyTags
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
-         Passes the content to PHPs ``strip_tags()``.
+         Passes the content to PHPs :php:`strip_tags()`.
 
+.. _htmlparser-stripemptytags.keeptags:
+
+stripEmptyTags.keepTags
+=======================
 
 .. container:: table-row
 
@@ -38,11 +52,15 @@ HTMLparser
          stripEmptyTags.keepTags
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
-         Comma separated list of tags to keep when applying ``strip_tags()``.
+         Comma separated list of tags to keep when applying :php:`strip_tags()`.
 
+.. _htmlparser-tags.[tagname]:
+
+tags.[tagname]
+==============
 
 .. container:: table-row
 
@@ -50,15 +68,19 @@ HTMLparser
          tags.[tagname]
 
    Data type
-         boolean/->HTMLparser\_tags
+         :ref:`data-type-boolean` / :ref:`htmlparser-tags`
 
    Description
          Either set this property to 0 or 1 to allow or deny the tag. If you
-         enter ->HTMLparser\_tags properties, those will automatically overrule
+         enter :ref:`htmlparser-tags` properties, those will automatically overrule
          this option, thus it's not needed then.
 
          [tagname] in lowercase.
 
+.. _htmlparser-localnesting:
+
+localNesting
+============
 
 .. container:: table-row
 
@@ -72,6 +94,10 @@ HTMLparser
          List of tags (among the already set tags), which will be forced to
          have the nesting-flag set to true
 
+.. _htmlparser-globalnesting:
+
+globalNesting
+=============
 
 .. container:: table-row
 
@@ -85,6 +111,10 @@ HTMLparser
          List of tags (among the already set tags), which will be forced to
          have the nesting-flag set to "global"
 
+.. _htmlparser-rmtagifnoattrib:
+
+rmTagIfNoAttrib
+===============
 
 .. container:: table-row
 
@@ -96,8 +126,12 @@ HTMLparser
 
    Description
          List of tags (among the already set tags), which will be forced to
-         have the rmTagIfNoAttrib set to true
+         have the :ref:`htmlparser-rmTagIfNoAttrib` set to true
 
+.. _htmlparser-noattrib:
+
+noAttrib
+========
 
 .. container:: table-row
 
@@ -112,6 +146,10 @@ HTMLparser
          have the allowedAttribs value set to zero (which means, all attributes
          will be removed.
 
+.. _htmlparser-removetags:
+
+removeTags
+==========
 
 .. container:: table-row
 
@@ -125,6 +163,10 @@ HTMLparser
          List of tags (among the already set tags), which will be configured so
          they are surely removed.
 
+.. _htmlparser-keepnonmatchedtags:
+
+keepNonMatchedTags
+==================
 
 .. container:: table-row
 
@@ -132,18 +174,22 @@ HTMLparser
          keepNonMatchedTags
 
    Data type
-         boolean / "protect"
+         :ref:`data-type-boolean` / "protect"
 
    Description
          If set (true=1), then all tags are kept regardless of tags present as
-         keys in $tags-array.
+         keys in :php:`$tags`-array.
 
-         If "protect", then the preserved tags have their <> converted to &lt;
-         and &gt;
+         If "protect", then the preserved tags have their :html:`<>`
+         converted to :html:`&lt;` and :html:`&gt;`
 
          Default is to REMOVE all tags, which are not specifically assigned to
          be allowed! So you might probably want to set this value!
 
+.. _htmlparser-htmlspecialchars:
+
+htmlSpecialChars
+================
 
 .. container:: table-row
 
@@ -158,17 +204,18 @@ HTMLparser
 
          **0:** Disabled - nothing is done.
 
-         **1:** The content outside tags is htmlspecialchar()'ed (PHP-
-         function which converts &"<> to &...;).
+         **1:** The content outside tags is :php:`htmlspecialchar()`'ed
+         (PHP-function which converts :html:`&"<>` to :html:`&...;`).
 
-         **2:** Same as "1", but entities like "&amp;" or "&#234" are
+         **2:** Same as "1", but entities like :html:`&amp;` or :html:`&#234` are
          untouched.
 
-         **-1:** Does the opposite of "1". It converts &lt; to <, &gt;
-         to >, &quot; to " etc.
+         **-1:** Does the opposite of "1".
+         It converts :html:`&lt;` to :html:`<`,
+         :html:`&gt;` to :html:`>`,
+         :html:`&quot;` to :html:`"` etc.
 
 
 .. ###### END~OF~TABLE ######
 
 [page:->HTMLparser; tsref:->HTMLparser]
-

--- a/Documentation/Functions/HtmlparserTags/Index.rst
+++ b/Documentation/Functions/HtmlparserTags/Index.rst
@@ -3,11 +3,17 @@
 
 .. _htmlparser-tags:
 
+================
 HTMLparser\_tags
-^^^^^^^^^^^^^^^^
+================
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _htmlparser-tags-overrideattribs:
+
+overrideAttribs
+===============
 
 .. container:: table-row
 
@@ -15,11 +21,15 @@ HTMLparser\_tags
          overrideAttribs
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          If set, this string is preset as the attributes of the tag.
 
+.. _htmlparser-tags-allowedattribs:
+
+allowedAttribs
+==============
 
 .. container:: table-row
 
@@ -41,6 +51,10 @@ HTMLparser\_tags
 
          **(blank/not set):** All attributes are allowed.
 
+.. _htmlparser-tags-fixattrib-attribute-set:
+
+fixAttrib.[attribute].set
+=========================
 
 .. container:: table-row
 
@@ -48,11 +62,15 @@ HTMLparser\_tags
          fixAttrib.[attribute].set
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          Force the attribute value to this value.
 
+.. _htmlparser-tags-fixattrib-attribute-unset:
+
+fixAttrib.[attribute].unset
+===========================
 
 .. container:: table-row
 
@@ -60,11 +78,15 @@ HTMLparser\_tags
          fixAttrib.[attribute].unset
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          If set, the attribute is unset.
 
+.. _htmlparser-tags-fixattrib-attribute-default:
+
+fixAttrib.[attribute].default
+=============================
 
 .. container:: table-row
 
@@ -72,12 +94,16 @@ HTMLparser\_tags
          fixAttrib.[attribute].default
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          If no attribute exists by this name, this value is set as default
          value (if this value is not blank)
 
+.. _htmlparser-tags-fixattrib-attribute-always:
+
+fixAttrib.[attribute].always
+============================
 
 .. container:: table-row
 
@@ -85,12 +111,11 @@ HTMLparser\_tags
          fixAttrib.[attribute].always
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          If set, the attribute is always processed. Normally an attribute is
          processed only if it exists
-
 
 .. container:: table-row
 
@@ -104,12 +129,16 @@ HTMLparser\_tags
          fixAttrib.[attribute].lower
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          If any of these keys are set, the value is passed through the
          respective PHP-functions.
 
+.. _htmlparser-tags-fixattrib-attribute-range:
+
+fixAttrib.[attribute].range
+===========================
 
 .. container:: table-row
 
@@ -122,6 +151,10 @@ HTMLparser\_tags
    Description
          Setting integer range.
 
+.. _htmlparser-tags-fixattrib-attribute-list:
+
+fixAttrib.[attribute].list
+==========================
 
 .. container:: table-row
 
@@ -135,6 +168,10 @@ HTMLparser\_tags
          Attribute value must be in this list. If not, the value is set to the
          first element.
 
+.. _htmlparser-tags-fixattrib-attribute-removeiffalse:
+
+fixAttrib.[attribute].removeIfFalse
+===================================
 
 .. container:: table-row
 
@@ -142,13 +179,17 @@ HTMLparser\_tags
          fixAttrib.[attribute].removeIfFalse
 
    Data type
-         boolean/"blank" string
+         :ref:`data-type-boolean` / "blank" string
 
    Description
          If set, then the attribute is removed if it is "false". If this value
          is set to "blank" then the value must be a blank string (that means a
          "zero" value will not be removed)
 
+.. _htmlparser-tags-fixattrib-attribute-removeifequals:
+
+fixAttrib.[attribute].removeIfEquals
+====================================
 
 .. container:: table-row
 
@@ -156,11 +197,15 @@ HTMLparser\_tags
          fixAttrib.[attribute].removeIfEquals
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          If the attribute value matches the value set here, then it is removed.
 
+.. _htmlparser-tags-fixattrib-attribute-casesensitivecomp:
+
+fixAttrib.[attribute].casesensitiveComp
+=======================================
 
 .. container:: table-row
 
@@ -168,12 +213,17 @@ HTMLparser\_tags
          fixAttrib.[attribute].casesensitiveComp
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
-         If set, the comparison in .removeIfEquals and .list will be case-
-         sensitive. At this point, it's insensitive.
+         If set, the comparison in :ref:`htmlparser-tags-fixattrib-attribute-removeifequals`
+         and :ref:`htmlparser-tags-fixattrib-attribute-list` will be case-sensitive.
+         At this point, it's insensitive.
 
+.. _htmlparser-tags-fixattrib-attribute-prefixlocalanchors:
+
+fixAttrib.[attribute].prefixLocalAnchors
+========================================
 
 .. container:: table-row
 
@@ -181,22 +231,26 @@ HTMLparser\_tags
          fixAttrib.[attribute].prefixLocalAnchors
 
    Data type
-         integer
+         :ref:`data-type-integer`
 
    Description
-         If the first char is a "#" character (anchor of fx. <a> tags) this
+         If the first char is a "#" character (anchor of fx. :html:`<a>` tags) this
          will prefix either a relative or absolute path.
 
          If the value is "1" you will get the absolute path
-         (TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3\_REQUEST\_URL')).
+         (:php:`TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_URL')`).
 
          If the value is "2" you will get the relative path (stripping of
-         TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3\_SITE\_URL')).
+         :php:`TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_SITE_URL')`).
 
          **Example:** ::
 
             ...fixAttrib.href.prefixLocalAnchors = 1
 
+.. _htmlparser-tags-fixattrib-attribute-prefixrelpathwith:
+
+fixAttrib.[attribute].prefixRelPathWith
+=======================================
 
 .. container:: table-row
 
@@ -204,7 +258,7 @@ HTMLparser\_tags
          fixAttrib.[attribute].prefixRelPathWith
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          If the value of the attribute seems to be a relative URL (no scheme
@@ -216,6 +270,10 @@ HTMLparser\_tags
          ...fixAttrib.src.prefixRelPathWith =
          http://192.168.230.3/typo3/32/dummy/
 
+.. _htmlparser-tags-fixattrib-attribute-userfunc:
+
+fixAttrib.[attribute].userFunc
+==============================
 
 .. container:: table-row
 
@@ -223,34 +281,35 @@ HTMLparser\_tags
          fixAttrib.[attribute].userFunc
 
    Data type
-         function reference
+         :ref:`data-type-function-name`
 
    Description
          User function for processing of the attribute. The return value
          of this function will be used as the new tag value.
 
-         **Example:**
+         **Example:**::
 
-         ...fixAttrib.href.userFunc = tx\_realurl->test\_urlProc
-         
+            ...fixAttrib.href.userFunc = \Vendor\ExtName\ClassName->function
+
          Two parameters are passed to the function:
-         
+
          1. The tag value as a string or an array containing the tag value
             and additional configuration (see below).
          2. The reference the to HtmlParser instance that calls the method.
-         
+
          By default the first parameter is the value of the processed tag.
          This changes when you pass additional configuration options to the
-         user function:
-         
-         ...fixAttrib.href.userFunc.myCustomParm = myCustomValue
-         
+         user function::
+
+            ...fixAttrib.href.userFunc.myCustomParm = myCustomValue
+
          In that case the first parameter passed to the user function will
          be an array containing these values:
-         
-         - attributeValue: The original value of the processed attribute
-         - myCustomParm: myCustomValue
 
+.. _htmlparser-tags-protect:
+
+protect
+=======
 
 .. container:: table-row
 
@@ -258,11 +317,15 @@ HTMLparser\_tags
          protect
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
-         If set, the tag <> is converted to &lt; and &gt;
+         If set, the tag :html:`<>` is converted to :html:`&lt;` and :html:`&gt;`
 
+.. _htmlparser-tags-remap:
+
+remap
+=====
 
 .. container:: table-row
 
@@ -270,11 +333,15 @@ HTMLparser\_tags
          remap
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          If set, the tagname is remapped to this tagname
 
+.. _htmlparser-tags-rmtagifnoattrib:
+
+rmTagIfNoAttrib
+===============
 
 .. container:: table-row
 
@@ -282,11 +349,15 @@ HTMLparser\_tags
          rmTagIfNoAttrib
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          If set, then the tag is removed if no attributes happened to be there.
 
+.. _htmlparser-tags-nesting:
+
+nesting
+=======
 
 .. container:: table-row
 
@@ -299,16 +370,15 @@ HTMLparser\_tags
    Description
          If set true, then this tag must have starting and ending tags in the
          correct order. Any tags not in this order will be discarded. Thus
-         '</B><B><I></B></I></B>' will be converted to '<B><I></B></I>'.
+         :html:`</B><B><I></B></I></B>` will be converted to :html:`<B><I></B></I>`.
 
          Is the value "global" then true nesting in relation to other tags
          marked for "global" nesting control is preserved. This means that if
-         <B> and <I> are set for global nesting then this string
-         '</B><B><I></B></I></B>' is converted to '<B></B>'
+         :html:`<B>` and :html:`<I>` are set for global nesting then this string
+         :html:`</B><B><I></B></I></B>` is converted to :html:`<B></B>`
 
 
 .. ###### END~OF~TABLE ######
 
 
 [page:->HTMLparser\_tags; tsref:->HTMLparser\_tags]
-

--- a/Documentation/Functions/If/Index.rst
+++ b/Documentation/Functions/If/Index.rst
@@ -3,8 +3,9 @@
 
 .. _if:
 
+==
 if
-^^
+==
 
 Allows you to check multiple conditions.
 
@@ -12,11 +13,16 @@ This function returns true, if ALL of the present conditions are met
 (they are connected with an "AND", a logical conjunction). If a
 single condition is false, the value returned is false.
 
-The returned value may still be negated by the ".negate"-property.
+The returned value may still be negated by the :ref:`if-negate`-property.
 
 Also check the explanations and the examples further below!
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _if-directreturn:
+
+directReturn
+============
 
 .. container:: table-row
 
@@ -24,13 +30,17 @@ Also check the explanations and the examples further below!
          directReturn
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
          If this property exists, no other conditions will be checked. Instead
          the true/false of this value is returned. Can be used to set
          true/false with a TypoScript constant.
 
+.. _if-isnull:
+
+isNull
+======
 
 .. container:: table-row
 
@@ -38,13 +48,13 @@ Also check the explanations and the examples further below!
          isNull
 
    Data type
-         stdWrap
+         :ref:`stdWrap`
 
    Description
-         If the resulting content of the stdWrap is null (NULL type in PHP)
+         If the resulting content of the :ts:`stdWrap` is null (:php:`NULL` type in PHP)
          ...
 
-         Since null values cannot be assigned in TypoScript, only the stdWrap
+         Since null values cannot be assigned in TypoScript, only the :ts:`stdWrap`
          features are available below this property.
 
          **Example:** ::
@@ -52,13 +62,17 @@ Also check the explanations and the examples further below!
             page.10 = COA_INT
             page.10.10 = TEXT
             page.10.10 {
-              stdWrap.if.isNull.field = description
-              value = No description available.
+                stdWrap.if.isNull.field = description
+                value = No description available.
             }
 
          This example returns "No description available.", if the content of
-         the field "description" is NULL.
+         the field "description" is :php:`NULL`.
 
+.. _if-istrue:
+
+isTrue
+======
 
 .. container:: table-row
 
@@ -66,11 +80,15 @@ Also check the explanations and the examples further below!
          isTrue
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          If the content is "true".... (not empty string and not zero)
 
+.. _if-isfalse:
+
+isFalse
+=======
 
 .. container:: table-row
 
@@ -78,11 +96,15 @@ Also check the explanations and the examples further below!
          isFalse
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          If the content is "false"... (empty or zero)
 
+.. _if-ispositive:
+
+isPositive
+==========
 
 .. container:: table-row
 
@@ -90,11 +112,15 @@ Also check the explanations and the examples further below!
          isPositive
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>` \+ calc
+         :ref:`data-type-integer` / :ref:`stdwrap` \+ calc
 
    Description
          Returns false, if the content is not positive.
 
+.. _if-isgreaterthan:
+
+isGreaterThan
+=============
 
 .. container:: table-row
 
@@ -102,11 +128,15 @@ Also check the explanations and the examples further below!
          isGreaterThan
 
    Data type
-         value /:ref:`stdWrap <stdwrap>`
+         value / :ref:`stdwrap`
 
    Description
-         Returns false, if the content is not greater than ".value".
+         Returns false, if the content is not greater than :ts:`value`.
 
+.. _if-islessthan:
+
+isLessThan
+==========
 
 .. container:: table-row
 
@@ -114,11 +144,15 @@ Also check the explanations and the examples further below!
          isLessThan
 
    Data type
-         value /:ref:`stdWrap <stdwrap>`
+         value / :ref:`stdwrap`
 
    Description
-         Returns false, if the content is not less than ".value".
+         Returns false, if the content is not less than :ts:`value`.
 
+.. _if-equals:
+
+equals
+======
 
 .. container:: table-row
 
@@ -126,15 +160,20 @@ Also check the explanations and the examples further below!
          equals
 
    Data type
-         value /:ref:`stdWrap <stdwrap>`
+         value / :ref:`stdwrap`
 
    Description
-         Returns false, if the content does not equal ".value".
+         Returns false, if the content does not equal :ts:`value`.
 
          **Example:** ::
 
             if.equals = POST
             if.value.data = GETENV:REQUEST_METHOD
+
+.. _if-isinlist:
+
+isInList
+========
 
 .. container:: table-row
 
@@ -142,20 +181,25 @@ Also check the explanations and the examples further below!
          isInList
 
    Data type
-         value /:ref:`stdWrap <stdwrap>`
+         value / :ref:`stdwrap`
 
    Description
          Returns false, if the content is not in the comma-separated list
-         ".value".
+         :ts:`.value`.
 
-         **Note:** The list in ".value" may not have spaces between elements!
+         **Note:** The list in :ts:`value` may not have spaces between elements!
 
          **Example:** ::
 
             if.isInList.field = uid
             if.value = 1,2,34,50,87
 
-         This returns true, if the uid is part of the list in .value.
+         This returns true, if the uid is part of the list in :ts:`value`.
+
+.. _if-value:
+
+value
+=====
 
 .. container:: table-row
 
@@ -163,11 +207,15 @@ Also check the explanations and the examples further below!
          value
 
    Data type
-         value /:ref:`stdWrap <stdwrap>`
+         value / :ref:`stdwrap`
 
    Description
          The value to check. This is the comparison value mentioned above.
 
+.. _if-negate:
+
+negate
+======
 
 .. container:: table-row
 
@@ -175,7 +223,7 @@ Also check the explanations and the examples further below!
          negate
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
          This property is checked after all other properties. If set, it
@@ -199,28 +247,28 @@ Also check the explanations and the examples further below!
 .. _if-explanation:
 
 Explanation
-"""""""""""
+===========
 
 The "if"-function is a very odd way of returning true or false!
 Beware!
 
 "if" is normally used to decide whether to render an object or to return
-a value (see the cObjects and stdWrap).
+a value (see the :ref:`data-type-cobject` and :ref:`stdWrap`).
 
 Here is how it works:
 
 The function returns true or false. Whether it returns true or false
-depends on the properties of this function. Say if you set "isTrue =
-1" then the result is true. If you set "isTrue.field = header", the
-function returns true if the field "header" in $cObj->data is set!
+depends on the properties of this function. Say if you set :ts:`isTrue = 1`
+then the result is true. If you set :ts:`isTrue.field = header`, the
+function returns true if the field "header" in :php:`$cObj->data` is set!
 
 If you want to compare values, you must load a base-value in the
-".value"-property. Example::
+:ts:`value`-property. Example::
 
    .value = 10
    .isGreaterThan = 11
 
-This would return true because the value of ".isGreaterThan" is
+This would return true because the value of :ts:`isGreaterThan` is
 greater than 10, which is the base-value.
 
 More complex is this::
@@ -230,16 +278,16 @@ More complex is this::
    .isTrue.field = header
    .negate = 1
 
-There are two conditions - isGreaterThan and isTrue. If they are both
-true, the total is true (both are connected with an AND). BUT(!) then
-the result of the function in total would be false because the
-".negate"-flag inverts the result!
+There are two conditions - :ts:`isGreaterThan` and :ts:`isTrue`.
+If they are both true, the total is true (both are connected with an AND).
+BUT(!) then the result of the function in total would be false because the
+:ts:`negate`-flag inverts the result!
 
 
 .. _if-examples:
 
 Examples:
-~~~~~~~~~
+=========
 
 This is a GIFBUILDER object that will write "NEW" on a menu-item if
 the field "newUntil" has a date less than the current date! ::
@@ -248,9 +296,9 @@ the field "newUntil" has a date less than the current date! ::
      30.text = NEW!
      30.offset = 10,10
      30.if {
-       value.data = date: U
-       isLessThan.field = newUntil
-       negate = 1
+         value.data = date: U
+         isLessThan.field = newUntil
+         negate = 1
      }
 
 
@@ -263,4 +311,3 @@ page. ::
      additionalParams = &L=0
      additionalParams.if.value = 2
      additionalParams.if.isGreaterThan.data = GP:L
-

--- a/Documentation/Functions/Imagelinkwrap/Index.rst
+++ b/Documentation/Functions/Imagelinkwrap/Index.rst
@@ -4,6 +4,7 @@
 
 .. _imagelinkwrap:
 
+=============
 imageLinkWrap
 =============
 
@@ -13,14 +14,14 @@ imageLinkWrap
 
 
 Properties
-----------
+==========
 
 .. container:: ts-properties
 
   ===================================================== ===================================================================== ======= ==================
   Property                                              Data types                                                            stdWrap Default
   ===================================================== ===================================================================== ======= ==================
-  :ts:`imageLinkWrap =`                                 :ref:`data-type-boolean`                                              yes       0
+  imageLinkWrap_ =                                      :ref:`data-type-boolean`                                              yes       0
   enable_ =                                             :ref:`data-type-boolean`                                              yes       0
   file_ =                                               :ref:`stdwrap`                                                        yes
   width_ =                                              :ref:`data-type-positive-integer`                                     yes
@@ -43,18 +44,8 @@ Properties
   stdWrap_ =                                            :ref:`stdwrap`                                                        yes
   ===================================================== ===================================================================== ======= ==================
 
-
-
-Property details
-----------------
-
-.. contents::
-   :local:
-   :depth: 1
-
-
 enable
-~~~~~~
+======
 
 :ts:`imageLinkWrap.enable =` :ref:`data-type-boolean`
 
@@ -64,7 +55,7 @@ Whether or not to link the image. Must be set to True to make
 
 
 file
-~~~~
+====
 
 :ts:`imageLinkWrap.file =` :ref:`stdwrap`
 
@@ -72,7 +63,7 @@ Apply :ref:`stdwrap` functionality to the file path.
 
 
 width
-~~~~~
+=====
 
 :ts:`imageLinkWrap.width =` :ref:`data-type-positive-integer`
 
@@ -83,7 +74,7 @@ image will be preserved.
 
 
 height
-~~~~~~
+======
 
 :ts:`imageLinkWrap.height =` :ref:`data-type-positive-integer`
 
@@ -95,7 +86,7 @@ image will be preserved.
 
 
 effects
-~~~~~~~
+=======
 
 :ts:`imageLinkWrap.effects =` like :ref:`gifbuilder-effect` of
 :ref:`GIFBUILDER`
@@ -103,7 +94,7 @@ effects
 Apply image effects to the preview image.
 
 Example for effects
-"""""""""""""""""""
+~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: typoscript
 
@@ -119,7 +110,7 @@ Example for effects
 
 
 sample
-~~~~~~
+======
 
 :ts:`imageLinkWrap.sample =` :ref:`data-type-boolean`
 
@@ -133,7 +124,7 @@ GraphicsMagick or ImageMagick.
 
 
 alternativeTempPath
-~~~~~~~~~~~~~~~~~~~
+===================
 
 :ts:`imageLinkWrap.alternativeTempPath =` :ref:`data-type-path`
 
@@ -142,7 +133,7 @@ images.
 
 
 title
-~~~~~
+=====
 
 :ts:`imageLinkWrap.title =` :ref:`data-type-string`
 
@@ -151,7 +142,7 @@ Needs :ts:`JSwindow = 1`.
 
 
 bodyTag
-~~~~~~~
+=======
 
 :ts:`imageLinkWrap.bodyTag =` :ref:`data-type-tag`
 
@@ -176,7 +167,7 @@ Example:
 
 
 wrap
-~~~~
+====
 
 :ts:`imageLinkWrap.wrap =` :ref:`data-type-wrap`
 
@@ -185,7 +176,7 @@ Needs :ts:`JSwindow = 1`.
 
 
 target
-~~~~~~
+======
 
 :ts:`imageLinkWrap.target =` :ref:`data-type-target`
 
@@ -211,7 +202,7 @@ Examples:
 
 
 JSwindow
-~~~~~~~~
+========
 
 :ts:`imageLinkWrap.JSwindow =` :ref:`data-type-boolean`
 
@@ -222,7 +213,7 @@ the dimensions of the image.
 
 
 JSwindow.expand
-~~~~~~~~~~~~~~~
+===============
 
 :ts:`imageLinkWrap.JSwindow.expand =` :ts:`x`,
 :ts:`y`
@@ -235,7 +226,7 @@ preview window.
 
 
 JSwindow.newWindow
-~~~~~~~~~~~~~~~~~~
+==================
 
 :ts:`imageLinkWrap.JSwindow.newWindow =` :ref:`data-type-boolean`
 
@@ -244,15 +235,14 @@ attribute then the image will be opened in a window with the name given
 by `target`. If that windows is kept open and the next image with the
 same :ref:`data-type-target` attribute is to be shown then it will appear
 in the same preview window.
-If :ts:`JSwindow.newWindow` is set to True
-(:ts:` = 1`) then a unique hash value is used as `target`
-value for each image. This garantees that each image is opened in a new
-window.
+If :ts:`JSwindow.newWindow` is set to True,
+then a unique hash value is used as `target` value for each image.
+This guarantees that each image is opened in a new window.
 
 
 
 JSwindow.altUrl
-~~~~~~~~~~~~~~~
+===============
 
 :ts:`imageLinkWrap.JSwindow.altUrl =` :ref:`data-type-string`
 
@@ -262,7 +252,7 @@ Otherwise the default "showpic" script will be used.
 
 
 JSwindow.altUrl\_noDefaultParams
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+================================
 
 :ts:`imageLinkWrap.JSwindow.altUrl_noDefaultParams =`
 :ref:`data-type-boolean`
@@ -275,7 +265,7 @@ in a special way.
 
 
 typolink
-~~~~~~~~
+========
 
 :ts:`imageLinkWrap.typolink =` like :ref:`typolink`
 
@@ -286,7 +276,7 @@ everything else.
 
 
 directImageLink
-~~~~~~~~~~~~~~~
+===============
 
 :ts:`imageLinkWrap.directImageLink =` :ref:`data-type-boolean`
 
@@ -297,7 +287,7 @@ generated that points directly to the image file. This means that no
 
 
 linkParams
-~~~~~~~~~~
+==========
 
 :ts:`imageLinkWrap.linkParams =` any of the options of
 :ref:`typolink`
@@ -326,7 +316,7 @@ resized images in the frontend. More complete examples are
 
 
 stdWrap
-~~~~~~~
+=======
 
 :ts:`imageLinkWrap.stdWrap =` :ref:`stdwrap`
 
@@ -336,7 +326,7 @@ result.
 
 
 What it does
-------------
+============
 
 :ts:`imageLinkWrap = 1`
 
@@ -359,7 +349,7 @@ special values.
 
 
 Implementation
---------------
+==============
 
 - imageLinkWrap__ in API__,
 - method `imageLinkWrap` in
@@ -378,7 +368,7 @@ __ http://typo3.org/api/typo3cms/
 .. _imagelinkwrap-examples:
 
 Examples for imageLinkWrap
---------------------------
+==========================
 
 .. contents::
    :local:
@@ -397,11 +387,11 @@ Basic example: Create a link to the showpic script
 
    10 = IMAGE
    10 {
-         # point to the image
+      # point to the image
       file = fileadmin/demo/lorem_ipsum/images/a4.jpg
-         # make it rather small
+      # make it rather small
       file.width = 80
-         # add a link to tx_cms_showpic.php that shows the original image
+      # add a link to tx_cms_showpic.php that shows the original image
       imageLinkWrap = 1
       imageLinkWrap {
          enable = 1
@@ -427,7 +417,7 @@ Basic example: Link directly to the original image
       imageLinkWrap = 1
       imageLinkWrap {
          enable = 1
-            # link directly to the image
+         # link directly to the image
          directImageLink = 1
          # JSwindow = 1
       }
@@ -586,4 +576,3 @@ __ http://gettopup.com/
    Links of interest:
    `click-enlage (de) <http://jweiland.net/typo3/typoscript/click-enlarge.html>`_,
    `lightbox.ts <https://github.com/georgringer/modernpackage/blob/master/Resources/Private/TypoScript/content/lightbox.ts>`_,
-

--- a/Documentation/Functions/Imgresource/Index.rst
+++ b/Documentation/Functions/Imgresource/Index.rst
@@ -13,13 +13,18 @@ imgResource.
 
 .. ### BEGIN~OF~TABLE ###
 
+.. _imgresource-ext:
+
+ext
+===
+
 .. container:: table-row
 
    Property
          ext
 
    Data type
-         imageExtension /:ref:`stdWrap <stdwrap>`
+         imageExtension / :ref:`stdwrap`
 
    Default
          web
@@ -28,8 +33,14 @@ imgResource.
          Target file extension for the processed image. The value "web" checks if the file extension
          is one of gif, jpg, jpeg, or png and if not it will find the best target extension.
          The target extension must be in the list of file extensions perceived as images.
-         This is defined in :php:`$TYPO3_CONF_VARS['GFX']['imagefile_ext']` in the install tool.
+         This is defined in :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`
+         in the install tool.
 
+
+.. _imgresource-width:
+
+width
+=====
 
 .. container:: table-row
 
@@ -37,7 +48,7 @@ imgResource.
          width
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
          If both the width and the height are set and one of the numbers is
@@ -78,17 +89,26 @@ imgResource.
             .height = 100c-25
 
 
+.. _imgresource-height:
+
+height
+======
+
 .. container:: table-row
 
    Property
          height
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
-         See ".width"
+         See :ref:`imgresource-width`
 
+.. _imgresource-params:
+
+params
+======
 
 .. container:: table-row
 
@@ -96,13 +116,17 @@ imgResource.
          params
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          GraphicsMagick/ImageMagick command-line:
 
-         fx. "-rotate 90", "-negate" or "-quality 90"
+         fx. ``-rotate 90``, ``-negate`` or ``-quality 90``
 
+.. _imgresource-sample:
+
+sample
+======
 
 .. container:: table-row
 
@@ -110,16 +134,19 @@ imgResource.
          sample
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Default
          0
 
    Description
-         If set, `-sample` is used to scale images instead of `-geometry`. Sample
+         If set, ``-sample`` is used to scale images instead of ``-geometry``. Sample
          does not use anti-aliasing and is therefore much faster.
 
+.. _imgresource-noscale:
 
+noScale
+=======
 
 .. container:: table-row
 
@@ -127,7 +154,7 @@ imgResource.
          noScale
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Default
          0
@@ -148,10 +175,16 @@ imgResource.
             file.noScale = 1
 
          This example results in an image tag like the following. Note that
-         `src="fileadmin/test.jpg"` is the *original* file::
+         `src="fileadmin/test.jpg"` is the *original* file:
+
+         .. code-block:: html
 
             <img src="fileadmin/test.jpg" width="240" height="180" />
 
+.. _imgresource-crop:
+
+crop
+====
 
 .. container:: table-row
 
@@ -159,7 +192,7 @@ imgResource.
          crop
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Default
          not-set (when file/image is a file_reference the crop value of
@@ -179,6 +212,10 @@ imgResource.
 
             tt_content.image.20.1.file.crop = 50,50,100,100
 
+.. _imgresource-cropvariant:
+
+cropVariant
+===========
 
 .. container:: table-row
 
@@ -186,7 +223,7 @@ imgResource.
          cropVariant
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Default
          default
@@ -202,6 +239,10 @@ imgResource.
          tt_content.image.20.1.file.crop.data = file:current:crop
          tt_content.image.20.1.file.cropVariant = desktop
 
+.. _imgresource-alternativetemppath:
+
+alternativeTempPath
+===================
 
 .. container:: table-row
 
@@ -209,11 +250,15 @@ imgResource.
          alternativeTempPath
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          Enter an alternative path to use for temporary images.
 
+.. _imgresource-frame:
+
+frame
+=====
 
 .. container:: table-row
 
@@ -221,13 +266,17 @@ imgResource.
          frame
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Chooses the frame in a PDF or GIF file.
 
          "" = first frame (zero)
 
+.. _imgresource-import:
+
+import
+======
 
 .. container:: table-row
 
@@ -235,12 +284,12 @@ imgResource.
          import
 
    Data type
-         path /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-path` / :ref:`stdwrap`
 
    Description
          *value* should be set to the path of the file
 
-         with stdWrap you get the filename from the data-array
+         with :ref:`stdwrap` you get the filename from the data-array
 
    Example
          This returns the first image in the field "image" from the
@@ -250,6 +299,10 @@ imgResource.
             .import.field = image
             .import.listNum = 0
 
+.. _imgresource-treatidasreference:
+
+treatIdAsReference
+==================
 
 .. container:: table-row
 
@@ -257,7 +310,7 @@ imgResource.
          treatIdAsReference
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Default
          0
@@ -267,7 +320,10 @@ imgResource.
          instead of to sys_file. This allows using file references, for
          example with :ts:`import.data = levelmedia: ...`.
 
+.. _imgresource-maxw:
 
+maxW
+====
 
 .. container:: table-row
 
@@ -275,11 +331,15 @@ imgResource.
          maxW
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
          Maximum width
 
+.. _imgresource-maxh:
+
+maxH
+====
 
 .. container:: table-row
 
@@ -287,11 +347,15 @@ imgResource.
          maxH
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
          Maximum height
 
+.. _imgresource-minw:
+
+minW
+====
 
 .. container:: table-row
 
@@ -299,11 +363,15 @@ imgResource.
          minW
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
          Minimum width (overrules maxW/maxH)
 
+.. _imgresource-minh:
+
+minH
+====
 
 .. container:: table-row
 
@@ -311,11 +379,15 @@ imgResource.
          minH
 
    Data type
-         pixels /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-pixels` / :ref:`stdwrap`
 
    Description
          Minimum height (overrules maxW/maxH)
 
+.. _imgresource-stripprofile:
+
+stripProfile
+============
 
 .. container:: table-row
 
@@ -323,7 +395,7 @@ imgResource.
          stripProfile
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Default
          0
@@ -358,7 +430,7 @@ imgResource.
          m.mask
 
    Data type
-         imgResource
+         :ref:`data-type-imgresource`
 
    Description
          The mask with which the image is masked onto "m.bgImg". Both "m.mask"
@@ -373,7 +445,7 @@ imgResource.
          m.bgImg
 
    Data type
-         imgResource
+         :ref:`data-type-imgresource`
 
    Description
          **Note:** Both "m.mask" and "m.bgImg" must be valid images.
@@ -385,7 +457,7 @@ imgResource.
          m.bottomImg
 
    Data type
-         imgResource
+         :ref:`data-type-imgresource`
 
    Description
          An image masked by "m.bottomImg\_mask" onto "m.bgImg" before the
@@ -406,7 +478,7 @@ imgResource.
          m.bottomImg\_mask
 
    Data type
-         imgResource
+         :ref:`data-type-imgresource`
 
    Description
          (optional)
@@ -431,4 +503,3 @@ pixels::
 
    file = fileadmin/toplogo.gif
    file.width = 200
-

--- a/Documentation/Functions/Index.rst
+++ b/Documentation/Functions/Index.rst
@@ -3,8 +3,9 @@
 
 .. _functions:
 
+=========
 Functions
----------
+=========
 
 
 .. toctree::
@@ -33,4 +34,3 @@ Functions
    Htmlparser/Index
    HtmlparserTags/Index
    Cache/Index
-

--- a/Documentation/Functions/Makelinks/Index.rst
+++ b/Documentation/Functions/Makelinks/Index.rst
@@ -3,8 +3,9 @@
 
 .. _makelinks:
 
+=========
 makelinks
-^^^^^^^^^
+=========
 
 makelinks substitutes all appearances of web addresses or mail links
 with a real link-tag. Web addresses and mail links must be contained in
@@ -17,13 +18,18 @@ the text in the following form::
 
 .. ### BEGIN~OF~TABLE ###
 
+.. _makelinks-http-extTarget:
+
+http.extTarget
+==============
+
 .. container:: table-row
 
    Property
          http.extTarget
 
    Data type
-         target
+         :ref:`data-type-target`
 
    Description
          The target of the link.
@@ -31,6 +37,10 @@ the text in the following form::
    Default
          \_top
 
+.. _makelinks-http-wrap:
+
+http.wrap
+=========
 
 .. container:: table-row
 
@@ -38,11 +48,15 @@ the text in the following form::
          http.wrap
 
    Data type
-         wrap /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-wrap` / :ref:`stdwrap`
 
    Description
          Wrap around the link.
 
+.. _makelinks-http-ATagBeforeWrap:
+
+http.ATagBeforeWrap
+===================
 
 .. container:: table-row
 
@@ -50,15 +64,19 @@ the text in the following form::
          http.ATagBeforeWrap
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
-         If set, the link is first wrapped with *http.wrap* and then the
-         <A>-tag.
+         If set, the link is first wrapped with :ts:`http.wrap` and then the
+         :html:`<a>`-tag.
 
    Default
          0
 
+.. _makelinks-http-keep:
+
+http.keep
+=========
 
 .. container:: table-row
 
@@ -81,6 +99,10 @@ the text in the following form::
             http.keep = "scheme,path":        http://www.example.com/test/doc.php
             http.keep = "scheme,path,query":  http://www.example.com/test/doc.php?id=3
 
+.. _makelinks-http-ATagParams:
+
+http.ATagParams
+===============
 
 .. container:: table-row
 
@@ -88,7 +110,7 @@ the text in the following form::
          http.ATagParams
 
    Data type
-         <A>-params /:ref:`stdWrap <stdwrap>`
+         <A>-params / :ref:`stdwrap`
 
    Description
          Additional parameters
@@ -97,6 +119,10 @@ the text in the following form::
 
             http.ATagParams = class="board"
 
+.. _makelinks-mailto.wrap:
+
+mailto.wrap
+===========
 
 .. container:: table-row
 
@@ -104,11 +130,15 @@ the text in the following form::
          mailto.wrap
 
    Data type
-         wrap /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-wrap` / :ref:`stdwrap`
 
    Description
          Wrap around the link.
 
+.. _makelinks-mailto.ATagBeforeWrap:
+
+mailto.ATagBeforeWrap
+=====================
 
 .. container:: table-row
 
@@ -116,15 +146,19 @@ the text in the following form::
          mailto.ATagBeforeWrap
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
-         If set, the link is first wrapped with mailto *.wrap* and then the
-         <A>-tag.
+         If set, the link is first wrapped with mailto :ts:`wrap` and then the
+         :html:`<a>`-tag.
 
    Default
          0
 
+.. _makelinks-mailto.ATagParams:
+
+mailto.ATagParams
+=================
 
 .. container:: table-row
 
@@ -132,7 +166,7 @@ the text in the following form::
          mailto.ATagParams
 
    Data type
-         <A>-params /:ref:`stdWrap <stdwrap>`
+         <A>-params / :ref:`stdwrap`
 
    Description
          Additional parameters
@@ -146,4 +180,3 @@ the text in the following form::
 
 
 [tsref:->makelinks]
-

--- a/Documentation/Functions/Numberformat/Index.rst
+++ b/Documentation/Functions/Numberformat/Index.rst
@@ -3,22 +3,28 @@
 
 .. _numberformat:
 
+============
 numberFormat
-^^^^^^^^^^^^
+============
 
 With this property you can format a float value and display it as you
-want, for example as a price. It is a wrapper for the number\_format()
+want, for example as a price. It is a wrapper for the :php:`number_format()`
 function of PHP.
 
 You can define how many decimals you want and which separators you
 want for decimals and thousands.
 
 Since the properties are finally used by the PHP function
-number\_format(), you need to make sure that they are valid parameters
+:php:`number_format()`, you need to make sure that they are valid parameters
 for that function. Consult the PHP manual, if unsure.
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _numberformat-decimals:
+
+decimals
+========
 
 .. container:: table-row
 
@@ -26,7 +32,7 @@ for that function. Consult the PHP manual, if unsure.
          decimals
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Number of decimals the formatted number will have. Defaults to 0, so
@@ -36,6 +42,10 @@ for that function. Consult the PHP manual, if unsure.
    Default
          0
 
+.. _numberformat-dec\_point:
+
+dec\_point
+==========
 
 .. container:: table-row
 
@@ -43,7 +53,7 @@ for that function. Consult the PHP manual, if unsure.
          dec\_point
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
    Description
          Character that divides the decimals from the rest of the number.
@@ -52,6 +62,10 @@ for that function. Consult the PHP manual, if unsure.
    Default
          .
 
+.. _numberformat-thousands\_sep:
+
+thousands\_sep
+==============
 
 .. container:: table-row
 
@@ -59,7 +73,7 @@ for that function. Consult the PHP manual, if unsure.
          thousands\_sep
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Character that divides the thousands of the number. Defaults to ",";
@@ -99,18 +113,17 @@ Examples:
 
    lib.carViews = CONTENT
    lib.carViews {
-     table = tx_mycarext_car
-     select.pidInList = 42
-     renderObj = TEXT
-     renderObj {
-       stdWrap.field = views
-       # By default use 3 decimals or
-       # use the number given by the Get/Post variable precisionLevel, if set.
-       stdWrap.numberFormat.decimals = 3
-       stdWrap.numberFormat.decimals.override.data = GP:precisionLevel
-       stdWrap.numberFormat.dec_point = ,
-       stdWrap.numberFormat.thousands_sep = .
-     }
+       table = tx_mycarext_car
+       select.pidInList = 42
+       renderObj = TEXT
+       renderObj {
+           stdWrap.field = views
+           # By default use 3 decimals or
+           # use the number given by the Get/Post variable precisionLevel, if set.
+           stdWrap.numberFormat.decimals = 3
+           stdWrap.numberFormat.decimals.override.data = GP:precisionLevel
+           stdWrap.numberFormat.dec_point = ,
+           stdWrap.numberFormat.thousands_sep = .
+       }
    }
    # Could result in something like "9.586,007".
-

--- a/Documentation/Functions/Numrows/Index.rst
+++ b/Documentation/Functions/Numrows/Index.rst
@@ -3,8 +3,9 @@
 
 .. _numrows:
 
+=======
 numRows
-^^^^^^^
+=======
 
 This object allows you to specify a SELECT query, which will be
 executed in the database. The object then returns the number of
@@ -12,6 +13,11 @@ rows, which were returned by the query.
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _numrows-table:
+
+table
+=====
 
 .. container:: table-row
 
@@ -24,6 +30,10 @@ rows, which were returned by the query.
    Description
          Name of the database table to query.
 
+.. _numrows-select:
+
+select
+======
 
 .. container:: table-row
 
@@ -31,17 +41,16 @@ rows, which were returned by the query.
          select
 
    Data type
-         :ref:`->select <select>`
+         :ref:`select`
 
    Description
          Select query for the operation.
 
-         The sub-property "selectFields" is overridden internally with
-         "count(\*)".
+         The sub-property :ts:`selectFields` is overridden internally with
+         :php:`count(*)`.
 
 
 .. ###### END~OF~TABLE ######
 
 
 [tsref:->numRows]
-

--- a/Documentation/Functions/Parsefunc/Index.rst
+++ b/Documentation/Functions/Parsefunc/Index.rst
@@ -3,14 +3,20 @@
 
 .. _parsefunc:
 
+=========
 parseFunc
-^^^^^^^^^
+=========
 
 This object is used to parse some content for stuff like special typo
-tags, the "makeLinks"-things and so on...
+tags, the :ref:`parsefunc-makeLinks`-things and so on...
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _parsefunc-externalBlocks:
+
+externalBlocks
+==============
 
 .. container:: table-row
 
@@ -28,30 +34,30 @@ tags, the "makeLinks"-things and so on...
 
          **.[tagname]** {
 
-            **callRecursive:** Boolean. If set, the content of the block is
+            **callRecursive:** :ref:`data-type-boolean`. If set, the content of the block is
             directed into parseFunc again. Otherwise the content is just passed
-            through with no other processing than stdWrap (see below).
+            through with no other processing than :ref:`stdwrap` (see below).
 
-            **callRecursive.dontWrapSelf:** Boolean. If set, the tags of the
+            **callRecursive.dontWrapSelf:** :ref:`data-type-boolean`. If set, the tags of the
             block is *not* wrapped around the content returned from parseFunc.
 
             **callRecursive.alternativeWrap:** Alternative wrapping instead of
             the original tags.
 
-            **callRecursive.tagStdWrap:** ->stdWrap processing of the block-tags.
+            **callRecursive.tagStdWrap:** :ref:`stdwrap` processing of the block-tags.
 
-            **stdWrap:** ->stdWrap processing of the whole block (regardless of
+            **stdWrap:** :ref:`stdwrap` processing of the whole block (regardless of
             whether callRecursive was set.)
 
-            **stripNLprev:** Boolean. Strips off last line break of the previous
+            **stripNLprev:** :ref:`data-type-boolean`. Strips off last line break of the previous
             outside block.
 
-            **stripNLnext:** Boolean. Strips off first line break of the next
+            **stripNLnext:** :ref:`data-type-boolean`. Strips off first line break of the next
             outside block.
 
-            **stripNL:** Boolean. Does both of the above.
+            **stripNL:** :ref:`data-type-boolean`. Does both of the above.
 
-            **HTMLtableCells:** Boolean. If set, then the content is expected
+            **HTMLtableCells:** :ref:`data-type-boolean`. If set, then the content is expected
             to be a table and every table-cell is traversed.
 
             Below, "default" means all cells and "1", "2", "3", ... overrides
@@ -59,17 +65,17 @@ tags, the "makeLinks"-things and so on...
 
             **HTMLtableCells.[default/1/2/3/...]** {
 
-               **callRecursive:** Boolean. The content is parsed through current
+               **callRecursive:** :ref:`data-type-boolean`. The content is parsed through current
                parseFunc.
 
-               **stdWrap:** ->stdWrap processing of the content in the cell.
+               **stdWrap:** :ref:`stdwrap` processing of the content in the cell.
 
-               **tagStdWrap:** -> The <TD> tag is processed by ->stdWrap.
+               **tagStdWrap:** -> The :html:`<TD>` tag is processed by :ref:`stdwrap`.
 
             }
 
-         **HTMLtableCells.addChr10BetweenParagraphs:** Boolean. If set, then
-         all appearances of "</P><P>" will have a chr(10) inserted between them.
+         **HTMLtableCells.addChr10BetweenParagraphs:** :ref:`data-type-boolean`. If set, then
+         all appearances of :html:`</P><P>` will have a :php:`chr(10)` inserted between them.
 
          }
 
@@ -85,24 +91,28 @@ tags, the "makeLinks"-things and so on...
          overridden. ::
 
             tt_content.text.20.parseFunc.externalBlocks {
-              blockquote.callRecursive = 1
-              blockquote.callRecursive.tagStdWrap.HTMLparser = 1
-              blockquote.callRecursive.tagStdWrap.HTMLparser {
-                tags.blockquote.fixAttrib.style.list = margin-bottom:0;margin-top:0;
-                tags.blockquote.fixAttrib.style.always = 1
-              }
-              blockquote.stripNLprev = 1
-              blockquote.stripNLnext = 1
+                blockquote.callRecursive = 1
+                blockquote.callRecursive.tagStdWrap.HTMLparser = 1
+                blockquote.callRecursive.tagStdWrap.HTMLparser {
+                    tags.blockquote.fixAttrib.style.list = margin-bottom:0;margin-top:0;
+                    tags.blockquote.fixAttrib.style.always = 1
+                }
+                blockquote.stripNLprev = 1
+                blockquote.stripNLnext = 1
 
-              table.stripNL = 1
-              table.stdWrap.HTMLparser = 1
-              table.stdWrap.HTMLparser {
-                tags.table.overrideAttribs = border="0" style="margin-top: 10px;"
-                tags.tr.allowedAttribs = 0
-                tags.td.overrideAttribs = class="table-cell" style="font-size: 10px;"
-              }
+                table.stripNL = 1
+                table.stdWrap.HTMLparser = 1
+                table.stdWrap.HTMLparser {
+                    tags.table.overrideAttribs = border="0" style="margin-top: 10px;"
+                    tags.tr.allowedAttribs = 0
+                    tags.td.overrideAttribs = class="table-cell" style="font-size: 10px;"
+                }
             }
 
+.. _parsefunc-constants:
+
+constants
+=========
 
 .. container:: table-row
 
@@ -110,7 +120,7 @@ tags, the "makeLinks"-things and so on...
          constants
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          You can define constants in the :ref:`top-level object "constants"
@@ -127,10 +137,14 @@ tags, the "makeLinks"-things and so on...
          *(The definition of the constant above is top-level TypoScript. It
          belongs on one level with the objects "config" and "page".)*
 
-         If you now use parseFunc with .constants = 1, all occurrences of the
+         If you now use parseFunc with :ts:`constants = 1`, all occurrences of the
          string ###EMAIL### in the text will be substituted with the actual
          address.
 
+.. _parsefunc-short:
+
+short
+=====
 
 .. container:: table-row
 
@@ -149,10 +163,14 @@ tags, the "makeLinks"-things and so on...
          with a link to typo3.org. ::
 
             short {
-              T3 = TYPO3 CMS
-              T3web = <a href="http://typo3.org">typo3.org</a>
+                T3 = TYPO3 CMS
+                T3web = <a href="http://typo3.org">typo3.org</a>
             }
 
+.. _parsefunc-plainTextStdWrap:
+
+plainTextStdWrap
+================
 
 .. container:: table-row
 
@@ -160,11 +178,15 @@ tags, the "makeLinks"-things and so on...
          plainTextStdWrap
 
    Data type
-         ->stdWrap
+         :ref:`stdwrap`
 
    Description
-         This is stdWrap properties for all non-tag content.
+         This is :ref:`stdwrap` properties for all non-tag content.
 
+.. _parsefunc-userFunc:
+
+userFunc
+========
 
 .. container:: table-row
 
@@ -172,14 +194,18 @@ tags, the "makeLinks"-things and so on...
          userFunc
 
    Data type
-         function name
+         :ref:`data-type-function-name`
 
    Description
          This passes the non-tag content to a function of your own choice.
-         Similar to e.g. .postUserFunc in stdWrap.
+         Similar to e.g. :ref:`stdwrap-postuserfunc` in :ref:`stdWrap`.
 
-         Remember the function name must possibly be prepended "user\_"
+         Remember the function name must possibly be prepended :php:`user_`.
 
+.. _parsefunc-nonTypoTagStdWrap:
+
+nonTypoTagStdWrap
+=================
 
 .. container:: table-row
 
@@ -187,16 +213,20 @@ tags, the "makeLinks"-things and so on...
          nonTypoTagStdWrap
 
    Data type
-         ->stdWrap
+         :ref:`stdWrap`
 
    Description
-         Like .plainTextStdWrap. Difference:
+         Like :ref:`parsefunc-plainTextStdWrap`. Difference:
 
-         .plainTextStdWrap works an ALL non-tag pieces in the text.
-         .nonTypoTagStdWrap is post processing of all text (including tags)
-         between special TypoTags (unless .breakoutTypoTagContent is not set
-         for the TypoTag).
+         :ref:`parsefunc-plainTextStdWrap` works an ALL non-tag pieces in the text.
+         :ref:`parsefunc-nonTypoTagStdWrap` is post processing of all text
+         (including tags) between special TypoTags
+         (unless :ts:`breakoutTypoTagContent` is not set for the TypoTag).
 
+.. _parsefunc-nonTypoTagUserFunc:
+
+nonTypoTagUserFunc
+==================
 
 .. container:: table-row
 
@@ -204,14 +234,20 @@ tags, the "makeLinks"-things and so on...
          nonTypoTagUserFunc
 
    Data type
-         function name
+         :ref:`data-type-function-name`
 
    Description
-         Like .userFunc. Differences is (like nonTypoTagStdWrap) that this is
-         post processing of all content pieces around TypoTags while .userFunc
-         processes all non-tag content. (Notice: .breakoutTypoTagContent must
-         be set for the TypoTag if it's excluded from nonTypoTagContent).
+         Like :ref:`parsefunc-userFunc`.
+         Differences is (like :ref:`parsefunc-nonTypoTagStdWrap`)
+         that this is post processing of all content pieces around TypoTags while
+         :ref:`parsefunc-userFunc` processes all non-tag content.
+         (Notice: :ts:`breakoutTypoTagContent` must be set for the TypoTag
+         if it's excluded from :ts:`nonTypoTagContent`).
 
+.. _parsefunc-sword:
+
+sword
+=====
 
 .. container:: table-row
 
@@ -219,17 +255,21 @@ tags, the "makeLinks"-things and so on...
          sword
 
    Data type
-         wrap
+         :ref:`data-type-wrap`
 
    Description
-         Marks up any words from the GET-method send array sword\_list[] in the
+         Marks up any words from the GET-method send array :php:`sword_list[]` in the
          text. The word MUST be at least two characters long!
 
-         **Note:** works only with $GLOBALS['TSFE']->no\_cache = 1.
+         **Note:** works only with :php:`$GLOBALS['TSFE']->no_cache = 1`.
 
    Default
-         <font color="red">\|</font>
+         :ts:`<font color="red">|</font>`
 
+.. _parsefunc-makelinks:
+
+makelinks
+=========
 
 .. container:: table-row
 
@@ -237,12 +277,16 @@ tags, the "makeLinks"-things and so on...
          makelinks
 
    Data type
-         boolean / ->makelinks
+         :ref:`data-type-boolean` / ->makelinks
 
    Description
          Convert web addresses prefixed with "http://" and mail addresses
          prefixed with "mailto:" to links.
 
+.. _parsefunc-tags:
+
+tags
+====
 
 .. container:: table-row
 
@@ -256,6 +300,10 @@ tags, the "makeLinks"-things and so on...
          Here you can define **custom tags** that will parse the content to
          something.
 
+.. _parsefunc-allowTags:
+
+allowTags
+=========
 
 .. container:: table-row
 
@@ -268,9 +316,13 @@ tags, the "makeLinks"-things and so on...
    Description
          List of tags, which are allowed to exist in code!
 
-         Highest priority: If a tag is found in allowTags, denyTags is
-         ignored!
+         Highest priority: If a tag is found in :ref:`parsefunc-allowTags`,
+         :ref:`parsefunc-denyTags` is ignored!
 
+.. _parsefunc-denyTags:
+
+denyTags
+========
 
 .. container:: table-row
 
@@ -283,17 +335,21 @@ tags, the "makeLinks"-things and so on...
    Description
          List of tags, which may **not** exist in code! (use "\*" for all.)
 
-         Lowest priority: If a tag is **not** found in allowTags, denyTags is
-         checked. If denyTags is not "\*" and the tag is not found in the list,
-         the tag may exist!
+         Lowest priority: If a tag is **not** found in :ref:`parsefunc-allowTags`,
+         :ref:`parsefunc-denyTags` is checked.
+         If denyTags is not "\*" and the tag is not found in the list, the tag may exist!
 
          **Example:**
 
-         This allows <B>, <I>, <A> and <IMG> -tags to exist ::
+         This allows :html:`<b>`, :html:`<i>`, :html:`<a>` and :html:`<img>` -tags to exist ::
 
             .allowTags = b,i,a,img
             .denyTags = *
 
+.. _parsefunc-if:
+
+if
+==
 
 .. container:: table-row
 
@@ -317,37 +373,36 @@ tags, the "makeLinks"-things and so on...
 .. _parsefunc-examples:
 
 Example:
-""""""""
+========
 
 This example takes the content of the field "bodytext" and parses it
-through the makelinks-functions and substitutes all <LINK> and
-<TYPOLIST>-tags with something else. ::
+through the :ref:`parsefunc-makelinks`-functions and substitutes all
+:html:`<LINK>` and :html:`<TYPOLIST>`-tags with something else. ::
 
    tt_content.text.default {
-     20 = TEXT
-     20.stdWrap.field = bodytext
-     20.stdWrap.wrap = | <br>
-     20.stdWrap.brTag = <br>
-     20.stdWrap.parseFunc {
-       makelinks = 1
-       makelinks.http.keep = path
-       makelinks.http.extTarget = _blank
-       makelinks.mailto.keep = path
-       tags {
-         link = TEXT
-         link {
-           stdWrap.current = 1
-           stdWrap.typolink.extTarget = _blank
-           stdWrap.typolink.target = {$cLinkTagTarget}
-           stdWrap.typolink.wrap = <p style="color: red; font-weight: bold;">|</p>
-           stdWrap.typolink.parameter.data = parameters : allParams
-         }
+       20 = TEXT
+       20.stdWrap.field = bodytext
+       20.stdWrap.wrap = | <br>
+       20.stdWrap.brTag = <br>
+       20.stdWrap.parseFunc {
+           makelinks = 1
+           makelinks.http.keep = path
+           makelinks.http.extTarget = _blank
+           makelinks.mailto.keep = path
+           tags {
+               link = TEXT
+               link {
+                   stdWrap.current = 1
+                   stdWrap.typolink.extTarget = _blank
+                   stdWrap.typolink.target = {$cLinkTagTarget}
+                   stdWrap.typolink.wrap = <p style="color: red; font-weight: bold;">|</p>
+                   stdWrap.typolink.parameter.data = parameters : allParams
+               }
 
-         typolist < tt_content.bullets.default.20
-         typolist.trim = 1
-         typolist.field >
-         typolist.current = 1
+               typolist < tt_content.bullets.default.20
+               typolist.trim = 1
+               typolist.field >
+               typolist.current = 1
+           }
        }
-     }
    }
-

--- a/Documentation/Functions/Replacement/Index.rst
+++ b/Documentation/Functions/Replacement/Index.rst
@@ -3,8 +3,9 @@
 
 .. _replacement:
 
+===========
 replacement
-^^^^^^^^^^^
+===========
 
 This object performs an ordered search and replace operation on the
 current content with the possibility of using PCRE regular expressions.
@@ -13,17 +14,26 @@ allows multiple replacements at once.
 
 .. ### BEGIN~OF~TABLE ###
 
+.. _replacement-search:
+
+search
+======
+
 .. container:: table-row
 
    Property
          search
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Defines the string that shall be replaced.
 
+.. _replacement-replace:
+
+replace
+=======
 
 .. container:: table-row
 
@@ -31,11 +41,15 @@ allows multiple replacements at once.
          replace
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Defines the string to be used for the replacement.
 
+.. _replacement-useregexp:
+
+useRegExp
+=========
 
 .. container:: table-row
 
@@ -43,7 +57,7 @@ allows multiple replacements at once.
          useRegExp
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Description
          Defines that the search and replace strings are considered as PCRE
@@ -52,14 +66,18 @@ allows multiple replacements at once.
          **Example:** ::
 
             10 {
-              search = #(a )CAT#i
-              replace = \1cat
-              useRegExp = 1
+                search = #(a )CAT#i
+                replace = \1cat
+                useRegExp = 1
             }
 
    Default
          0
 
+.. _replacement-useoptionsplitreplace:
+
+useOptionSplitReplace
+=====================
 
 .. container:: table-row
 
@@ -67,7 +85,7 @@ allows multiple replacements at once.
          useOptionSplitReplace
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Description
          This property allows to use :ref:`objects-optionsplit` for the replace
@@ -87,28 +105,28 @@ allows multiple replacements at once.
 .. _replacement-examples:
 
 Examples:
-"""""""""
+=========
 
 ::
 
    10 = TEXT
    10 {
-     value = There_are_a_cat,_a_dog_and_a_tiger_in_da_hood!_Yeah!
-     stdWrap.replacement {
-       10 {
-         search = _
-         replace.char = 32
+       value = There_are_a_cat,_a_dog_and_a_tiger_in_da_hood!_Yeah!
+       stdWrap.replacement {
+           10 {
+               search = _
+               replace.char = 32
+           }
+           20 {
+               search = in da hood
+               replace = around the block
+           }
+           30 {
+               search = #a (Cat|Dog|Tiger)#i
+               replace = an animal
+               useRegExp = 1
+           }
        }
-       20 {
-         search = in da hood
-         replace = around the block
-       }
-       30 {
-         search = #a (Cat|Dog|Tiger)#i
-         replace = an animal
-         useRegExp = 1
-       }
-     }
    }
 
 This returns: "There are an animal, an animal and an animal around the
@@ -122,9 +140,9 @@ The following examples demonstrate the use of :ref:`objects-optionsplit`:
    20 = TEXT
    20.value = There_are_a_cat,_a_dog_and_a_tiger_in_da_hood!_Yeah!
    20.stdWrap.replacement.10 {
-     search = _
-     replace = 1 || 2 || 3
-     useOptionSplitReplace = 1
+       search = _
+       replace = 1 || 2 || 3
+       useOptionSplitReplace = 1
    }
 
 This returns: "There1are2a3cat,3a3dog3and3a3tiger3in3da3hood!3Yeah!"
@@ -134,11 +152,10 @@ This returns: "There1are2a3cat,3a3dog3and3a3tiger3in3da3hood!3Yeah!"
    30 = TEXT
    30.value = There are a cat, a dog and a tiger in da hood! Yeah!
    30.stdWrap.replacement.10 {
-     search = #(a) (Cat|Dog|Tiger)#i
-     replace = ${1} tiny ${2} || ${1} midsized ${2} || ${1} big ${2}
-     useRegExp = 1
-     useOptionSplitReplace = 1
+       search = #(a) (Cat|Dog|Tiger)#i
+       replace = ${1} tiny ${2} || ${1} midsized ${2} || ${1} big ${2}
+       useRegExp = 1
+       useOptionSplitReplace = 1
    }
 
 This returns: "There are a tiny cat, a midsized dog and a big tiger in da hood! Yeah!"
-

--- a/Documentation/Functions/Round/Index.rst
+++ b/Documentation/Functions/Round/Index.rst
@@ -3,8 +3,9 @@
 
 .. _round:
 
+=====
 round
-^^^^^
+=====
 
 With this property you can round the value up, down or to a certain
 number of decimals. For each roundType the according PHP function will
@@ -16,13 +17,18 @@ selected round method.
 
 .. ### BEGIN~OF~TABLE ###
 
+.. _round-roundtype:
+
+roundType
+=========
+
 .. container:: table-row
 
    Property
          roundType
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Round method which should be used.
@@ -38,6 +44,10 @@ selected round method.
    Default
          round
 
+.. _round-decimals:
+
+decimals
+========
 
 .. container:: table-row
 
@@ -45,7 +55,7 @@ selected round method.
          decimals
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Number of decimals the rounded value will have. Only used with the
@@ -55,13 +65,18 @@ selected round method.
    Default
          0
 
+.. _round-round:
+
+round
+=====
+
 .. container:: table-row
 
    Property
          round
 
    Data type
-         boolean
+         :ref:`data-type-boolean`
 
    Description
          Set round = 1 to enable rounding.
@@ -85,10 +100,10 @@ Examples:
 
    lib.number = TEXT
    lib.number {
-     value = 3.14159
-     stdWrap.round = 1
-     stdWrap.round.roundType = round
-     stdWrap.round.decimals = 2
+       value = 3.14159
+       stdWrap.round = 1
+       stdWrap.round.roundType = round
+       stdWrap.round.decimals = 2
    }
 
 This returns 3.14.

--- a/Documentation/Functions/Select/Index.rst
+++ b/Documentation/Functions/Select/Index.rst
@@ -3,6 +3,7 @@
 
 .. _select:
 
+======
 select
 ======
 
@@ -22,12 +23,12 @@ in the :php:`$GLOBALS['TCA']`.
 
 
 Comprehensive example
----------------------
+=====================
 
 See PHP source code for
-:ref:`TYPO3 \\ CMS \\ Frontend \\ ContentObject \\ ContentObjectRenderer <t3api:typo3\\cms\\frontend\\ContentObject\\ContentObjectRenderer>`,
-:ref:`ContentObjectRenderer::getQuery() <t3api:typo3\\cms\\frontend\\ContentObject\\ContentObjectRenderer::getQuery>`,
-:ref:`ContentObjectRenderer::getWhere() <t3api:typo3\\cms\\frontend\\ContentObject\\ContentObjectRenderer::getWhere>`.
+:php:`\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer`,
+:php:`ContentObjectRenderer::getQuery()`,
+:php:`ContentObjectRenderer::getWhere()`.
 
 
 .. Preamble: :
@@ -74,15 +75,15 @@ Condensed form::
 .. _select-uidInList:
 
 uidInList
----------
+=========
 
 .. container:: table-row
 
    Property
-         :ts:`uidInList`
+         uidInList
 
    Data type
-         *list of record\_ids* /:ref:`stdWrap`
+         *list of record\_ids* / :ref:`stdWrap`
 
    Description
          Comma-separated list of record uids from the according database table.
@@ -92,9 +93,11 @@ uidInList
          **Note:** :ts:`this` is a *special keyword* and replaced with the id of the
          *current record*.
 
-   Examples
-         | :ts:`select.uidInList = 1,2,3`
-         | :ts:`select.uidInList = this`
+   Example
+         ::
+
+            select.uidInList = 1,2,3
+            select.uidInList = this
 
 
 
@@ -102,15 +105,15 @@ uidInList
 .. _select-pidInList:
 
 pidInList
----------
+=========
 
 .. container:: table-row
 
    Property
-         :ts:`pidInList`
+         pidInList
 
    Data type
-         *list of page\_ids* /:ref:`stdWrap`
+         *list of page\_ids* / :ref:`stdWrap`
 
    Description
          Comma-separated list of pids of the record. This will be page_ids. For
@@ -156,15 +159,15 @@ pidInList
 .. _select-recursive:
 
 recursive
----------
+=========
 
 .. container:: table-row
 
    Property
-         :ts:`recursive`
+         recursive
 
    Data type
-         integer /:ref:`stdWrap`
+         :ref:`data-type-integer` / :ref:`stdWrap`
 
    Description
          Number of recursivity levels for the pidInList.
@@ -176,20 +179,21 @@ recursive
 .. _select-orderBy:
 
 orderBy
--------
+=======
 
 .. container:: table-row
 
    Property
-         :ts:`orderBy`
+         orderBy
 
    Data type
-         *SQL-orderBy* /:ref:`stdWrap`
+         *SQL-orderBy* / :ref:`stdWrap`
 
    Description
          ORDER BY clause without the words "ORDER BY".
 
-         **Example:** ::
+   Example
+         ::
 
             orderBy = sorting, title
 
@@ -197,20 +201,21 @@ orderBy
 .. _select-groupBy:
 
 groupBy
--------
+=======
 
 .. container:: table-row
 
    Property
-         :ts:`groupBy`
+         groupBy
 
    Data type
-         *SQL-groupBy* /:ref:`stdWrap`
+         *SQL-groupBy* / :ref:`stdWrap`
 
    Description
          GROUP BY clause without the words "GROUP BY".
 
-         **Example:** ::
+   Example
+         ::
 
             groupBy = CType
 
@@ -219,60 +224,61 @@ groupBy
 .. _select-max:
 
 max
----
+===
 
 .. container:: table-row
 
    Property
-         :ts:`max`
+         max
 
    Data type
-         integer +calc +"total" /:ref:`stdWrap`
+         :ref:`data-type-integer` +calc +"total" / :ref:`stdWrap`
 
    Description
          Max records
 
-         **Special keyword:** "total" is substituted with count(\*).
+         **Special keyword:** "total" is substituted with :php:`count(*)`.
 
 
 
 .. _select-begin:
 
 begin
------
+=====
 
 
 .. container:: table-row
 
    Property
-         :ts:`begin`
+         begin
 
    Data type
-         integer +calc +"total" /:ref:`stdWrap`
+         :ref:`data-type-integer` +calc +"total" / :ref:`stdWrap`
 
    Description
          Begin with record number *value*.
 
-         **Special keyword:** "total" is substituted with count(\*).
+         **Special keyword:** "total" is substituted with :php:`count(*)`.
 
 
 .. _select-where:
 
 where
------
+=====
 
 .. container:: table-row
 
    Property
-         :ts:`where`
+         where
 
    Data type
-         *SQL-where* /:ref:`stdWrap`
+         *SQL-where* / :ref:`stdWrap`
 
    Description
          WHERE clause without the word "WHERE".
 
-         **Example:** ::
+   Example
+         ::
 
             where = (title LIKE '%SOMETHING%' AND NOT doktype)
 
@@ -280,39 +286,39 @@ where
 .. _select-languageField:
 
 languageField
--------------
+=============
 
 .. container:: table-row
 
    Property
-         :ts:`languageField`
+         languageField
 
    Data type
-         string /:ref:`stdWrap`
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          By default all records that have language-relevant information in the
          TCA "ctrl"-section are translated on translated pages.
 
-         This can be disabled by setting languageField = 0.
+         This can be disabled by setting :ts:`languageField = 0`.
 
 
 .. _select-includeRecordsWithoutDefaultTranslation:
 
 includeRecordsWithoutDefaultTranslation
----------------------------------------
+=======================================
 
 .. container:: table-row
 
    Property
-         :ts:`includeRecordsWithoutDefaultTranslation`
+         includeRecordsWithoutDefaultTranslation
 
    Data type
-         boolean /:ref:`stdWrap`
+         :ref:`data-type-bool` / :ref:`stdWrap`
 
    Description
-         If content language overlay is activated and the option "languageField" is not disabled,
-         includeRecordsWithoutDefaultTranslation allows to additionally fetch records,
+         If content language overlay is activated and the option :ts:`languageField` is not disabled,
+         :ts:`includeRecordsWithoutDefaultTranslation` allows to additionally fetch records,
          which do **not** have a parent in the default language.
 
    Default
@@ -323,18 +329,18 @@ includeRecordsWithoutDefaultTranslation
 .. _select-selectFields:
 
 selectFields
-------------
+============
 
 .. container:: table-row
 
    Property
-         :ts:`selectFields`
+         selectFields
 
    Data type
-         string /:ref:`stdWrap`
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
-         List of fields to select, or "count(\*)".
+         List of fields to select, or :php:`count(*)`.
 
          If the records need to be localized, please include the
          relevant localization-fields (uid, pid, languageField and
@@ -351,15 +357,15 @@ selectFields
 .. _select-rightjoin:
 
 join, leftjoin, rightjoin
--------------------------
+=========================
 
 .. container:: table-row
 
    Property
-         :ts:`join`, :ts:`leftjoin`, :ts:`rightjoin`
+         join, leftjoin, rightjoin
 
    Data type
-         string /:ref:`stdWrap`
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Enter the table name for JOIN, LEFT OUTER JOIN and RIGHT OUTER JOIN
@@ -370,12 +376,12 @@ join, leftjoin, rightjoin
 .. _select-markers:
 
 markers
--------
+=======
 
 .. container:: table-row
 
    Property
-         :ts:`markers`
+         markers
 
    Data type
          *(array of markers)*
@@ -393,7 +399,7 @@ markers
 
          Sets the value directly.
 
-         **<markername>.commaSeparatedList:** (boolean)
+         **<markername>.commaSeparatedList:** (:ref:`data-type-boolean`)
 
          If set, the value is interpreted as a comma-separated list of values.
          Each value in the list is individually escaped and quoted.
@@ -402,21 +408,23 @@ markers
 
          All stdWrap properties can be used for each markername.
 
-         **Example:** ::
+   Example
+
+         ::
 
             page.60 = CONTENT
             page.60 {
-              table = tt_content
-              select {
-                pidInList = 73
-                where = header != ###whatever###
-                orderBy = ###sortfield###
-                markers {
-                  whatever.data = GP:first
-                  sortfield.value = sor
-                  sortfield.wrap = |ting
+                table = tt_content
+                select {
+                    pidInList = 73
+                    where = header != ###whatever###
+                    orderBy = ###sortfield###
+                    markers {
+                        whatever.data = GP:first
+                        sortfield.value = sor
+                        sortfield.wrap = |ting
+                    }
                 }
-              }
             }
 
          This example selects all records from table tt_content, which are on page 73 and

--- a/Documentation/Functions/Split/Index.rst
+++ b/Documentation/Functions/Split/Index.rst
@@ -3,17 +3,23 @@
 
 .. _split:
 
+=====
 split
-^^^^^
+=====
 
 This object is used to split the input by a character and then parse
 the result onto some functions.
 
 For each iteration the split index starting with 0 (zero) is stored in
-the register key SPLIT\_COUNT.
+the register key :ts:`SPLIT_COUNT`.
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _split-token:
+
+token
+=====
 
 .. container:: table-row
 
@@ -21,11 +27,15 @@ the register key SPLIT\_COUNT.
          token
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          String or character (token) used to split the value.
 
+.. _split-max:
+
+max
+===
 
 .. container:: table-row
 
@@ -33,11 +43,15 @@ the register key SPLIT\_COUNT.
          max
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Maximum number of splits.
 
+.. _split-min:
+
+min
+===
 
 .. container:: table-row
 
@@ -45,11 +59,15 @@ the register key SPLIT\_COUNT.
          min
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Minimum number of splits.
 
+.. _split-returnkey:
+
+returnKey
+=========
 
 .. container:: table-row
 
@@ -57,13 +75,17 @@ the register key SPLIT\_COUNT.
          returnKey
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          Instead of parsing the split result, just return the element of the
          index with this number immediately and stop processing of the split
          function.
 
+.. _split-returncount:
+
+returnCount
+===========
 
 .. container:: table-row
 
@@ -71,7 +93,7 @@ the register key SPLIT\_COUNT.
          returnCount
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Description
          Counts all elements resulting from the split, returns their number
@@ -87,6 +109,10 @@ the register key SPLIT\_COUNT.
                 split.returnCount = 1
             }
 
+.. _split-cobjnum:
+
+cObjNum
+=======
 
 .. container:: table-row
 
@@ -94,12 +120,16 @@ the register key SPLIT\_COUNT.
          cObjNum
 
    Data type
-         *cObjNum* +optionSplit /:ref:`stdWrap <stdwrap>`
+         *cObjNum* +optionSplit / :ref:`stdwrap`
 
    Description
          This is a pointer the array of this object ("1,2,3,4"), that should
          treat the items, resulting from the split.
 
+.. _split-1,2,3,4:
+
+1,2,3,4
+=======
 
 .. container:: table-row
 
@@ -107,13 +137,13 @@ the register key SPLIT\_COUNT.
          1,2,3,4
 
    Data type
-         ->CARRAY /:ref:`stdWrap <stdwrap>`
+         ->CARRAY / :ref:`stdwrap`
 
    Description
          The object that should treat the value.
 
          **Note:** The "current"-value is set to the value of current item,
-         when the objects are called. See "stdWrap" / current.
+         when the objects are called. See :ref:`stdwrap` / current.
 
          **Example for stdWrap:** ::
 
@@ -123,11 +153,15 @@ the register key SPLIT\_COUNT.
          **Example for CARRAY:** ::
 
             1 {
-              10 = TEXT
-              10.stdWrap.current = 1
-              10.stdWrap.wrap = <b> | </b>
+                10 = TEXT
+                10.stdWrap.current = 1
+                10.stdWrap.wrap = <b> | </b>
             }
 
+.. _split-wrap:
+
+wrap
+====
 
 .. container:: table-row
 
@@ -135,7 +169,7 @@ the register key SPLIT\_COUNT.
          wrap
 
    Data type
-         wrap +optionSplit /:ref:`stdWrap <stdwrap>`
+         wrap +optionSplit / :ref:`stdwrap`
 
    Description
          Defines a wrap for each item.
@@ -149,23 +183,27 @@ the register key SPLIT\_COUNT.
 .. _split-examples:
 
 Example:
-""""""""
+========
 
 This is an example of TypoScript code that imports the content of
-field "bodytext" from the $cObj->data-array (ln 2). The content is
+field "bodytext" from the :php:`$cObj->data-array` (ln 2). The content is
 split by the line break character (ln 4). The items should all be
-treated with a stdWrap (ln 5) which imports the value of the item (ln
+treated with a :ts:`stdWrap` (ln 5) which imports the value of the item (ln
 6). This value is wrapped in a table row where the first column is a
 bullet-gif (ln 7). Finally the whole thing is wrapped in the proper
-table-tags (ln 9). ::
+table-tags (ln 9). :
 
-   1         20 = TEXT
-   2         20.stdWrap.field = bodytext
-   3         20.stdWrap.split {
-   4           token.char = 10
-   5           cObjNum = 1
-   6           1.current = 1
-   7           1.wrap = <tr><td><img src="dot.gif"></td><td> | </td></tr>
-   8         }
-   9         20.stdWrap.wrap = <table style="width: 368px;"> | </table><br>
+.. code-block:: typoscript
+   :linenos:
 
+   20 = TEXT
+   20.stdWrap {
+       field = bodytext
+       split {
+           token.char = 10
+           cObjNum = 1
+           1.current = 1
+           1.wrap = <tr><td><img src="dot.gif"></td><td> | </td></tr>
+       }
+       stdWrap.wrap = <table style="width: 368px;"> | </table><br>
+   }

--- a/Documentation/Functions/Stdwrap/Index.rst
+++ b/Documentation/Functions/Stdwrap/Index.rst
@@ -4,8 +4,9 @@
 
 .. _stdwrap:
 
+=======
 stdWrap
-^^^^^^^
+=======
 
 This function is often added as a property to values in TypoScript.
 
@@ -22,44 +23,44 @@ returned.
 
 stdWrap properties are executed in the order they appear in the table
 below. If you want to study this further please refer to
-typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php,
-where you will find the function stdWrap() and the array $stdWrapOrder,
+:file:`typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php`,
+where you will find the function :php:`stdWrap()` and the array :php:`$stdWrapOrder`,
 which represents the exact order of execution.
 
-Note that the stdWrap property "orderedStdWrap" allows you to execute
-multiple stdWrap functions in a freely selectable order.
+Note that the :ts:`stdWrap` property "orderedStdWrap" allows you to execute
+multiple :ts:`stdWrap` functions in a freely selectable order.
 
 
 .. _stdwrap-content-supplying:
 
 Content-supplying properties of stdWrap
-"""""""""""""""""""""""""""""""""""""""
+=======================================
 
 The properties in this table are parsed in the listed order. The
-properties "data", "field", "current", "cObject" (in that order!) are
-special as they are used to import content from variables or arrays.
-The above example could be rewritten to this::
+properties :ts:`data`, :ts:`field`, :ts:`current`, :ts:`cObject`
+(in that order!) are special as they are used to import content
+from variables or arrays. The above example could be rewritten to this::
 
    10 = TEXT
    10.value = some text
    10.stdWrap.case = upper
    10.stdWrap.field = header
 
-Now the line "10.value = some text" is obsolete, because the whole
-value is "imported" from the field called "header" from the $cObj
-->data-array.
+Now the line :ts:`10.value = some text` is obsolete, because the whole
+value is "imported" from the field called "header" from the
+:php:`$cObj->data-array`.
 
 
 .. _stdwrap-get-data:
 
 Getting data
-~~~~~~~~~~~~
+============
 
 
 .. _stdwrap-setcontenttocurrent:
 
 setContentToCurrent
-'''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -67,7 +68,7 @@ setContentToCurrent
          setContentToCurrent
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Sets the current value to the incoming content of the function.
@@ -76,7 +77,7 @@ setContentToCurrent
 .. _stdwrap-addpagecachetags:
 
 addPageCacheTags
-''''''''''''''''
+~~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -84,7 +85,7 @@ addPageCacheTags
          addPageCacheTags
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Comma-separated list of cache tags, which should be added to the page
@@ -112,7 +113,7 @@ addPageCacheTags
 .. _stdwrap-setcurrent:
 
 setCurrent
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -120,7 +121,7 @@ setCurrent
          setCurrent
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Sets the "current"-value. This is normally set from some outside
@@ -130,7 +131,7 @@ setCurrent
 .. _stdwrap-lang:
 
 lang
-''''
+~~~~
 
 .. container:: table-row
 
@@ -138,7 +139,7 @@ lang
          lang
 
    Data type
-         Array of language keys /stdWrap
+         Array of language keys / :ref:`stdWrap`
 
    Description
          This is used to define optional language specific values.
@@ -160,7 +161,7 @@ lang
 .. _stdwrap-data:
 
 data
-''''
+~~~~
 
 .. container:: table-row
 
@@ -168,13 +169,13 @@ data
          data
 
    Data type
-         :ref:`data-type-gettext` /stdWrap
+         :ref:`data-type-gettext` / :ref:`stdWrap`
 
 
 .. _stdwrap-field:
 
 field
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -182,11 +183,11 @@ field
          field
 
    Data type
-         Field name /stdWrap
+         Field name / :ref:`stdWrap`
 
    Description
          Sets the content to the value of the according field
-         (which comes from $cObj->data[*field*]).
+         (which comes from :php:`$cObj->data[*field*]`).
 
          **Example:** ::
 
@@ -205,14 +206,14 @@ field
          unless it is a blank string. If a blank string, the value of
          the title field is returned.
 
-         **Note:** $cObj->data changes depending on the context.
+         **Note:** :php:`$cObj->data` changes depending on the context.
          See the description for the data type ":ref:`data-type-gettext`"/field!
 
 
 .. _stdwrap-current:
 
 current
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -220,7 +221,7 @@ current
          current
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Sets the content to the "current"-value (see :ref:`->split <split>`)
@@ -229,7 +230,7 @@ current
 .. _stdwrap-cobject:
 
 cObject
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -246,7 +247,7 @@ cObject
 .. _stdwrap-numrows:
 
 numRows
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -254,7 +255,7 @@ numRows
          numRows
 
    Data type
-         :ref:`->numRows <numrows>` /stdWrap
+         :ref:`->numRows <numrows>` / :ref:`stdWrap`
 
    Description
          Returns the number of rows resulting from the supplied SELECT query.
@@ -262,7 +263,7 @@ numRows
 .. _stdwrap-preuserfunc:
 
 preUserFunc
-'''''''''''
+~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -270,7 +271,7 @@ preUserFunc
          preUserFunc
 
    Data type
-         Function name
+         :ref:`data-type-function-name`
 
    Description
          Calls the provided PHP function. If you specify the name with a '->'
@@ -281,19 +282,19 @@ preUserFunc
          value to be processed. As second parameter any sub-properties of
          preUserFunc are provided to the function.
 
-         See *.postUserFunc*!
+         See :ref:`stdwrap-postUserFunc`.
 
 
 .. _stdwrap-override-conditions:
 
 Override and conditions
-~~~~~~~~~~~~~~~~~~~~~~~
+=======================
 
 
 .. _stdwrap-override:
 
 override
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -301,7 +302,7 @@ override
          override
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          if "override" returns something else than "" or zero (trimmed), the
@@ -311,7 +312,7 @@ override
 .. _stdwrap-preifemptylistnum:
 
 preIfEmptyListNum
-'''''''''''''''''
+~~~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -319,16 +320,16 @@ preIfEmptyListNum
          preIfEmptyListNum
 
    Data type
-         (as "listNum" below)
+         (as ":ref:`stdwrap-listNum`" below)
 
    Description
-         (as "listNum" below)
+         (as ":ref:`stdwrap-listNum`" below)
 
 
 .. _stdwrap-ifnull:
 
 ifNull
-''''''
+~~~~~~
 
 .. container:: table-row
 
@@ -336,10 +337,10 @@ ifNull
          ifNull
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
-         If the content is null (NULL type in PHP), the content is overridden
+         If the content is null (:php:`NULL` type in PHP), the content is overridden
          with the value defined here.
 
          **Example:** ::
@@ -354,13 +355,13 @@ ifNull
             }
 
          This example shows the content of the field description or, if that
-         field contains the value NULL, the text "No description defined.".
+         field contains the value :php:`NULL`, the text "No description defined.".
 
 
 .. _stdwrap-ifempty:
 
 ifEmpty
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -368,17 +369,17 @@ ifEmpty
          ifEmpty
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          If the trimmed content is empty at this point, the content is loaded
-         with "ifEmpty". Zeros are treated as empty values!
+         with :ts:`ifEmpty`. Zeros are treated as empty values!
 
 
 .. _stdwrap-ifblank:
 
 ifBlank
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -386,16 +387,16 @@ ifBlank
          ifBlank
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
-         Same as "ifEmpty" but the check is done using strlen().
+         Same as :ts:`ifEmpty` but the check is done using :php:`strlen()`.
 
 
 .. _stdwrap-listnum:
 
 listNum
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -403,7 +404,7 @@ listNum
          listNum
 
    Data type
-         integer :ref:`+calc <objects-calc>` +"last" +"rand" /stdWrap
+         :ref:`data-type-integer` :ref:`+calc <objects-calc>` +"last" +"rand" / :ref:`stdWrap`
 
    Description
          Explodes the content with "," (comma) and the content is set to the
@@ -449,7 +450,7 @@ listNum
 .. _stdwrap-trim:
 
 trim
-''''
+~~~~
 
 .. container:: table-row
 
@@ -457,17 +458,17 @@ trim
          trim
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         If set, the PHP-function trim() will be used to remove whitespaces
+         If set, the PHP-function :php:`trim()` will be used to remove whitespaces
          around the value.
 
 
 .. _stdwrap-strpad:
 
 strPad
-''''''
+~~~~~~
 
 .. container:: table-row
 
@@ -485,7 +486,7 @@ strPad
 .. _stdwrap-stdwrap:
 
 stdWrap
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -493,16 +494,16 @@ stdWrap
          stdWrap
 
    Data type
-         ->stdWrap
+         :ref:`stdWrap`
 
    Description
-         Recursive call to the stdWrap function.
+         Recursive call to the :ts:`stdWrap` function.
 
 
 .. _stdwrap-required:
 
 required
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -510,7 +511,7 @@ required
          required
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          This flag requires the content to be set to some value after any
@@ -524,7 +525,7 @@ required
 .. _stdwrap-if:
 
 if
-''''''''''
+~~
 
 .. container:: table-row
 
@@ -541,7 +542,7 @@ if
 .. _stdwrap-fieldrequired:
 
 fieldRequired
-'''''''''''''
+~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -549,7 +550,7 @@ fieldRequired
          fieldRequired
 
    Data type
-         Field name /stdWrap
+         Field name / :ref:`stdWrap`
 
    Description
          The value in this field **must** be set.
@@ -558,13 +559,13 @@ fieldRequired
 .. _stdwrap-parsedata:
 
 Parsing data
-~~~~~~~~~~~~
+============
 
 
 .. _stdwrap-csconv:
 
 csConv
-''''''
+~~~~~~
 
 .. container:: table-row
 
@@ -572,7 +573,7 @@ csConv
          csConv
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Convert the charset of the string from the charset given as value to
@@ -582,7 +583,7 @@ csConv
 .. _stdwrap-parsefunc:
 
 parseFunc
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -590,7 +591,7 @@ parseFunc
          parseFunc
 
    Data type
-         object path reference / :ref:`->parseFunc <parsefunc>` /stdWrap
+         object path reference / :ref:`->parseFunc <parsefunc>` / :ref:`stdWrap`
 
    Description
          Processing instructions for the content.
@@ -611,7 +612,7 @@ parseFunc
 .. _stdwrap-htmlparser:
 
 HTMLparser
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -619,7 +620,7 @@ HTMLparser
          HTMLparser
 
    Data type
-         boolean / :ref:`->HTMLparser <htmlparser>` /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`->HTMLparser <htmlparser>` / :ref:`stdWrap`
 
    Description
          This object allows you to parse the HTML-content and perform all kinds of
@@ -633,7 +634,7 @@ HTMLparser
 .. _stdwrap-split:
 
 split
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -641,13 +642,13 @@ split
          split
 
    Data type
-         :ref:`->split <split>` /stdWrap
+         :ref:`->split <split>` / :ref:`stdWrap`
 
 
 .. _stdwrap-replacement:
 
 replacement
-'''''''''''
+~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -655,7 +656,7 @@ replacement
          replacement
 
    Data type
-         :ref:`->replacement <replacement>` /stdWrap
+         :ref:`->replacement <replacement>` / :ref:`stdWrap`
 
    Description
          Performs an ordered search/replace on the current content with the
@@ -667,7 +668,7 @@ replacement
 .. _stdwrap-prioricalc:
 
 prioriCalc
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -675,7 +676,7 @@ prioriCalc
          prioriCalc
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Calculation of the value using operators -+\*/%^ plus respects
@@ -685,7 +686,7 @@ prioriCalc
 
          Returns a doublevalue.
 
-         If .prioriCalc is set to "intval" an integer is returned.
+         If :ts:`prioriCalc` is set to "intval" an integer is returned.
 
          There is no error checking and division by zero or other invalid
          values may generate strange results. Also you should use a proper syntax
@@ -706,7 +707,7 @@ prioriCalc
 .. _stdwrap-char:
 
 char
-''''
+~~~~
 
 .. container:: table-row
 
@@ -714,10 +715,10 @@ char
          char
 
    Data type
-         integer /stdWrap
+         :ref:`data-type-integer` / :ref:`stdWrap`
 
    Description
-         Content is set to chr(*value*). This returns a one-character
+         Content is set to :php:`chr(*value*)`. This returns a one-character
          string containing the character specified by ascii code. Reliable
          results will be obtained only for character codes in the integer
          range 0 - 127. See
@@ -731,7 +732,7 @@ char
 .. _stdwrap-intval:
 
 intval
-''''''
+~~~~~~
 
 .. container:: table-row
 
@@ -739,10 +740,10 @@ intval
          intval
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         PHP function intval(); returns an integer:
+         PHP function :php:`intval()` returns an integer:
 
          .. code-block:: php
 
@@ -752,7 +753,7 @@ intval
 .. _stdwrap-hash:
 
 hash
-''''
+~~~~
 
 .. container:: table-row
 
@@ -760,7 +761,7 @@ hash
          hash
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Returns a hashed value of the current content. Set to one of the
@@ -781,7 +782,7 @@ hash
 .. _stdwrap-round:
 
 round
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -789,7 +790,7 @@ round
          round
 
    Data type
-         :ref:`->round <round>` /stdWrap
+         :ref:`->round <round>` / :ref:`stdWrap`
 
    Description
          Round the value with the selected method to the given number of
@@ -799,7 +800,7 @@ round
 .. _stdwrap-numberformat:
 
 numberFormat
-''''''''''''
+~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -817,7 +818,7 @@ numberFormat
 .. _stdwrap-date:
 
 date
-''''
+~~~~
 
 .. container:: table-row
 
@@ -825,7 +826,7 @@ date
          date
 
    Data type
-         :ref:`data-type-date-conf` /stdWrap
+         :ref:`data-type-date-conf` / :ref:`stdWrap`
 
    Description
          The content should be data-type "UNIX-time". Returns the content
@@ -854,7 +855,7 @@ date
 .. _stdwrap-strftime:
 
 strftime
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -862,7 +863,7 @@ strftime
          strftime
 
    Data type
-         :ref:`data-type-strftime-conf` /stdWrap
+         :ref:`data-type-strftime-conf` / :ref:`stdWrap`
 
    Description
          Exactly like "date" above. See the PHP manual (`strftime <http://www.php.net/strftime>`_) for the
@@ -876,7 +877,7 @@ strftime
          **.charset:** Can be set to the charset of the output string if you
          need to convert it to UTF-8. Default is to take the
          intelligently guessed charset from
-         TYPO3\CMS\Core\Charset\CharsetConverter.
+         :php:`TYPO3\CMS\Core\Charset\CharsetConverter`.
 
          **.GMT:** If set, the PHP function `gmstrftime() <http://www.php.net/gmstrftime>`_ will be used instead
          of `strftime() <http://www.php.net/strftime>`_.
@@ -885,7 +886,7 @@ strftime
 .. _stdwrap-strtotime:
 
 strtotime
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -893,7 +894,7 @@ strtotime
          strtotime
 
    Data type
-         string
+         :ref:`data-type-string`
 
    Description
          Allows conversion of formatted dates to timestamp, e.g. to perform date calculations.
@@ -921,7 +922,7 @@ strtotime
 .. _stdwrap-age:
 
 age
-'''
+~~~
 
 .. container:: table-row
 
@@ -929,7 +930,7 @@ age
          age
 
    Data type
-         boolean or string /stdWrap
+         :ref:`boolean <data-type-bool>` or :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          If enabled with a "1" (number, integer) the content is seen as a date
@@ -962,7 +963,7 @@ age
 .. _stdwrap-case:
 
 case
-''''
+~~~~
 
 .. container:: table-row
 
@@ -970,7 +971,7 @@ case
          case
 
    Data type
-         :ref:`data-type-case` /stdWrap
+         :ref:`data-type-case` / :ref:`stdWrap`
 
    Description
          Converts case
@@ -981,7 +982,7 @@ case
 .. _stdwrap-bytes:
 
 bytes
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -989,7 +990,7 @@ bytes
          bytes
 
    Data type
-         boolean/stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Default
          iec, 1024
@@ -1125,7 +1126,7 @@ bytes
 .. _stdwrap-substring:
 
 substring
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1133,18 +1134,18 @@ substring
          substring
 
    Data type
-         [p1], [p2] /stdWrap
+         [p1], [p2] / :ref:`stdWrap`
 
    Description
          Returns the substring with [p1] and [p2] sent as the 2nd and 3rd
-         parameter to the PHP `mb_substr <http://www.php.net/mb_substr>`_ function.
+         parameter to the PHP `mb_substr <http://www.php.net/mb_substr>`_ function.
 
          Uses "UTF-8" for the operation.
 
 .. _stdwrap-crophtml:
 
 cropHTML
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -1152,22 +1153,22 @@ cropHTML
          cropHTML
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
-         Crops the content to a certain length. In contrast to stdWrap.crop it
+         Crops the content to a certain length. In contrast to :ts:`stdWrap.crop` it
          respects HTML tags. It does not crop inside tags and closes open tags.
-         Entities (like ">") are counted as one char. See stdWrap.crop below
+         Entities (like ">") are counted as one char. See :ts:`stdWrap.crop` below
          for a syntax description and examples.
 
-         Note that stdWrap.crop should not be used if stdWrap.cropHTML is
+         Note that :ts:`stdWrap.crop` should not be used if :ts:`stdWrap.cropHTML` is
          already used.
 
 
 .. _stdwrap-striphtml:
 
 stripHtml
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1175,7 +1176,7 @@ stripHtml
          stripHtml
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Strips all HTML tags.
@@ -1184,7 +1185,7 @@ stripHtml
 .. _stdwrap-crop:
 
 crop
-''''
+~~~~
 
 .. container:: table-row
 
@@ -1192,7 +1193,7 @@ crop
          crop
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Crops the content to a certain length.
@@ -1218,13 +1219,13 @@ crop
 
          **Examples:**
 
-         20 \| ... => max 20 characters. If more, the value will be truncated
+         :ts:`20 | ...` => max 20 characters. If more, the value will be truncated
          to the first 20 characters and prepended with "..."
 
-         -20 \| ... => max 20 characters. If more, the value will be truncated
+         :ts:`-20 | ...` => max 20 characters. If more, the value will be truncated
          to the last 20 characters and appended with "..."
 
-         20 \| ... \| 1 => max 20 characters. If more, the value will be
+         :ts:`20 | ... | 1` => max 20 characters. If more, the value will be
          truncated to the first 20 characters and prepended with "...". If
          the division is in the middle of a word, the remains of that word is
          removed.
@@ -1235,7 +1236,7 @@ crop
 .. _stdwrap-rawurlencode:
 
 rawUrlEncode
-''''''''''''
+~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1243,7 +1244,7 @@ rawUrlEncode
          rawUrlEncode
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Passes the content through the PHP function `rawurlencode() <http://www.php.net/rawurlencode>`_.
@@ -1252,7 +1253,7 @@ rawUrlEncode
 .. _stdwrap-htmlspecialchars:
 
 htmlSpecialChars
-''''''''''''''''
+~~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1260,19 +1261,19 @@ htmlSpecialChars
          htmlSpecialChars
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Passes the content through the PHP function `htmlspecialchars() <http://www.php.net/htmlspecialchars>`_.
 
-         Additional property ".preserveEntities" will preserve entities so only
+         Additional property :ts:`preserveEntities` will preserve entities so only
          non-entity characters are affected.
 
 
 .. _stdwrap-encodeforjavascriptvalue:
 
 encodeForJavaScriptValue
-''''''''''''''''''''''''
+~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1280,7 +1281,7 @@ encodeForJavaScriptValue
          encodeForJavaScriptValue
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Encodes content to be used safely inside strings in JavaScript.
@@ -1290,7 +1291,7 @@ encodeForJavaScriptValue
          TypoScript.
 
          Passes the content through the core function
-         :ref:`t3api:TYPO3\\CMS\\Core\\Utility\\GeneralUtility::quoteJSvalue`.
+         :php:`\TYPO3\CMS\Core\Utility\GeneralUtility::quoteJSvalue`.
 
          **Example:** ::
 
@@ -1305,7 +1306,7 @@ encodeForJavaScriptValue
 .. _stdwrap-doublebrtag:
 
 doubleBrTag
-'''''''''''
+~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1313,7 +1314,7 @@ doubleBrTag
          doubleBrTag
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          All double-line-breaks are substituted with this value.
@@ -1322,7 +1323,7 @@ doubleBrTag
 .. _stdwrap-br:
 
 br
-''
+~~
 
 .. container:: table-row
 
@@ -1330,17 +1331,17 @@ br
          br
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
          Pass the value through the PHP function `nl2br() <http://www.php.net/nl2br>`_. This
-         converts each line break to a <br /> or a <br> tag depending on doctype.
+         converts each line break to a :html:`<br />` or a :html:`<br>` tag depending on doctype.
 
 
 .. _stdwrap-brtag:
 
 brTag
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -1348,7 +1349,7 @@ brTag
          brTag
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          All ASCII codes of "10" (line feed, LF) are substituted with the
@@ -1358,7 +1359,7 @@ brTag
 .. _stdwrap-encapslines:
 
 encapsLines
-'''''''''''
+~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1366,17 +1367,17 @@ encapsLines
          encapsLines
 
    Data type
-         :ref:`->encapsLines <encapslines>` /stdWrap
+         :ref:`->encapsLines <encapslines>` / :ref:`stdWrap`
 
    Description
-         Lets you split the content by chr(10) and process each line
+         Lets you split the content by :php:`chr(10)` and process each line
          independently. Used to format content made with the RTE.
 
 
 .. _stdwrap-keywords:
 
 keywords
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -1384,17 +1385,17 @@ keywords
          keywords
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         Splits the content by characters "," ";" and chr(10) (return), trims
+         Splits the content by characters "," ";" and php:`chr(10)` (return), trims
          each value and returns a comma-separated list of the values.
 
 
 .. _stdwrap-innerwrap:
 
 innerWrap
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1402,7 +1403,7 @@ innerWrap
          innerWrap
 
    Data type
-         :ref:`wrap <data-type-wrap>` /stdWrap
+         :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
    Description
          Wraps the content.
@@ -1411,7 +1412,7 @@ innerWrap
 .. _stdwrap-innerwrap2:
 
 innerWrap2
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1419,16 +1420,16 @@ innerWrap2
          innerWrap2
 
    Data type
-         :ref:`wrap <data-type-wrap>` /stdWrap
+         :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
    Description
-         Same as .innerWrap (but watch the order in which they are executed).
+         Same as :ts:`innerWrap` (but watch the order in which they are executed).
 
 
 .. _stdwrap-addparams:
 
 addParams
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1436,7 +1437,7 @@ addParams
          addParams
 
    Data type
-         :ref:`->addParams <addparams>` /stdWrap
+         :ref:`->addParams <addparams>` / :ref:`stdWrap`
 
    Description
          Lets you add tag parameters to the content *if* the content is a tag!
@@ -1445,7 +1446,7 @@ addParams
 .. _stdwrap-filelink:
 
 filelink
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -1453,7 +1454,7 @@ filelink
          filelink
 
    Data type
-         :ref:`->filelink <filelink>` /stdWrap
+         :ref:`->filelink <filelink>` / :ref:`stdWrap`
 
    Description
          Used to make lists of links to files.
@@ -1462,7 +1463,7 @@ filelink
 .. _stdwrap-precobject:
 
 preCObject
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1473,13 +1474,13 @@ preCObject
          :ref:`data-type-cobject`
 
    Description
-         cObject prepended the content.
+         :ref:`stdwrap-cObject` prepended the content.
 
 
 .. _stdwrap-postcobject:
 
 postCObject
-'''''''''''
+~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1490,13 +1491,13 @@ postCObject
          :ref:`data-type-cobject`
 
    Description
-         cObject appended the content.
+         :ref:`stdwrap-cObject` appended the content.
 
 
 .. _stdwrap-wrapalign:
 
 wrapAlign
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1504,17 +1505,17 @@ wrapAlign
          wrapAlign
 
    Data type
-         :ref:`align <data-type-align>` /stdWrap
+         :ref:`align <data-type-align>` / :ref:`stdWrap`
 
    Description
-         Wraps content with <div style=text-align:[*value*];"> \| </div>
+         Wraps content with :ts:`<div style=text-align:[*value*];"> | </div>`
          *if* align is set.
 
 
 .. _stdwrap-typolink:
 
 typolink
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -1522,7 +1523,7 @@ typolink
          typolink
 
    Data type
-         :ref:`->typolink <typolink>` /stdWrap
+         :ref:`->typolink <typolink>` / :ref:`stdWrap`
 
    Description
          Wraps the content with a link-tag.
@@ -1530,7 +1531,7 @@ typolink
 .. _stdwrap-wrap:
 
 wrap
-''''
+~~~~
 
 .. container:: table-row
 
@@ -1538,17 +1539,17 @@ wrap
          wrap
 
    Data type
-         :ref:`wrap <data-type-wrap>` /+.splitChar /stdWrap
+         :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
    Description
-         .splitChar defines an alternative splitting character (default is "\|"
+         :ts:`splitChar` defines an alternative splitting character (default is "\|"
          - the vertical line)
 
 
 .. _stdwrap-notrimwrap:
 
 noTrimWrap
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1556,7 +1557,7 @@ noTrimWrap
          noTrimWrap
 
    Data type
-         "special" wrap /+.splitChar /stdWrap
+         "special" wrap /+.splitChar / :ref:`stdWrap`
 
    Description
          This wraps the content *without* trimming the values. That means that
@@ -1574,12 +1575,12 @@ noTrimWrap
 
          **Additional property:**
 
-         .splitChar
+         :ts:`splitChar`
 
-         Can be set to define an alternative special character. stdWrap is
+         Can be set to define an alternative special character. :ts:`stdWrap` is
          available. Default is "\|" - the vertical line. This sub-property is
          useful in cases when the default special character would be recognized
-         by :ref:`objects-optionsplit` (which takes precedence over noTrimWrap).
+         by :ref:`objects-optionsplit` (which takes precedence over :ts:`noTrimWrap`).
 
          **Example:** ::
 
@@ -1587,14 +1588,14 @@ noTrimWrap
             noTrimWrap.splitChar = ^
 
          :ref:`objects-optionsplit` will use the "\|\|" to have two subparts in
-         the first part. In each subpart noTrimWrap will then use the "^" as
+         the first part. In each subpart :ts:`noTrimWrap` will then use the "^" as
          special character.
 
 
 .. _stdwrap-wrap2:
 
 wrap2
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -1602,16 +1603,16 @@ wrap2
          wrap2
 
    Data type
-         :ref:`wrap <data-type-wrap>` /+.splitChar /stdWrap
+         :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
    Description
-         *same as .wrap (but watch the order in which they are executed)*
+         same as :ref:`stdwrap-wrap` (but watch the order in which they are executed)
 
 
 .. _stdwrap-datawrap:
 
 dataWrap
-''''''''
+~~~~~~~~
 
 .. container:: table-row
 
@@ -1619,7 +1620,7 @@ dataWrap
          dataWrap
 
    Data type
-         mixed /stdWrap
+         mixed / :ref:`stdWrap`
 
    Description
          The content is parsed for pairs of curly braces. The content of the
@@ -1630,14 +1631,14 @@ dataWrap
 
             <div id="{tsfe : id}"> | </div>
 
-         This will produce a <div> tag around the content with an id attribute
+         This will produce a :html:`<div>` tag around the content with an id attribute
          that contains the number of the current page.
 
 
 .. _stdwrap-prepend:
 
 prepend
-'''''''
+~~~~~~~
 
 .. container:: table-row
 
@@ -1648,13 +1649,13 @@ prepend
          :ref:`data-type-cobject`
 
    Description
-         cObject prepended to content (before)
+         :ref:`stdwrap-cobject` prepended to content (before)
 
 
 .. _stdwrap-append:
 
 append
-''''''
+~~~~~~
 
 .. container:: table-row
 
@@ -1665,13 +1666,13 @@ append
          :ref:`data-type-cobject`
 
    Description
-         cObject appended to content (after)
+         :ref:`stdwrap-cobject` appended to content (after)
 
 
 .. _stdwrap-wrap3:
 
 wrap3
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -1679,16 +1680,16 @@ wrap3
          wrap3
 
    Data type
-         :ref:`wrap <data-type-wrap>` /+.splitChar /stdWrap
+         :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
    Description
-         *same as .wrap (but watch the order in which they are executed)*
+         same as :ts:`wrap` (but watch the order in which they are executed)
 
 
 .. _stdwrap-orderedstdwrap:
 
 orderedStdWrap
-''''''''''''''
+~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1696,13 +1697,13 @@ orderedStdWrap
          orderedStdWrap
 
    Data type
-         Array of numeric keys with /stdWrap each
+         Array of numeric keys with / :ref:`stdWrap` each
 
    Description
-         Execute multiple stdWrap statements in a freely selectable order. The order
+         Execute multiple :ts:`stdWrap` statements in a freely selectable order. The order
          is determined by the numeric order of the keys. This allows to use multiple
          stdWrap statements without having to remember the rather complex sorting
-         order in which the stdWrap functions are executed.
+         order in which the :ts:`stdWrap` functions are executed.
 
          **Example:** ::
 
@@ -1719,9 +1720,9 @@ orderedStdWrap
             }
 
          In this example orderedStdWrap is executed on the value "a".
-         10.innerWrap is executed first, followed by 10.wrap. Then the next key
-         is processed which is 20. Afterwards 30.wrap is executed on what
-         already was created.
+         :ts:`10.innerWrap` is executed first, followed by :ts:`10.wrap`.
+         Then the next key is processed which is 20. Afterwards :ts:`30.wrap`
+         is executed on what already was created.
 
          This results in "This is a working solution."
 
@@ -1729,7 +1730,7 @@ orderedStdWrap
 .. _stdwrap-outerwrap:
 
 outerWrap
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1737,7 +1738,7 @@ outerWrap
          outerWrap
 
    Data type
-         :ref:`wrap <data-type-wrap>` /stdWrap
+         :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
    Description
          *Wraps the complete content*
@@ -1746,7 +1747,7 @@ outerWrap
 .. _stdwrap-insertdata:
 
 insertData
-''''''''''
+~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1754,10 +1755,10 @@ insertData
          insertData
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         If set, then the content string is parsed like .dataWrap above.
+         If set, then the content string is parsed like :ts:`dataWrap` above.
 
          **Example:**
 
@@ -1776,7 +1777,7 @@ insertData
 .. _stdwrap-postuserfunc:
 
 postUserFunc
-''''''''''''
+~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1784,7 +1785,7 @@ postUserFunc
          postUserFunc
 
    Data type
-         function name
+         :ref:`data-type-function-name`
 
    Description
          Calls the provided PHP function. If you specify the name with a '->'
@@ -1793,9 +1794,9 @@ postUserFunc
          Two parameters are sent to the PHP function: As first parameter a
          content variable, which contains the current content. This is the
          value to be processed. As second parameter any sub-properties of
-         postUserFunc are provided to the function.
+         :ts:`postUserFunc` are provided to the function.
 
-         The description of the cObject :ref:`USER <cobj-user>` contains some
+         The description of the :ts:`cObject` :ref:`USER <cobj-user>` contains some
          more in-depth information.
 
          **Example:**
@@ -1820,7 +1821,8 @@ postUserFunc
               stdWrap.postUserFunc.typolink = 11
             }
 
-         Your methods will get the parameters ``$content`` and ``$conf`` (in that order) and need to return a string.
+         Your methods will get the parameters :php:`$content` and :php:`$conf`
+         (in that order) and need to return a string.
 
          .. code-block:: php
 
@@ -1829,7 +1831,8 @@ postUserFunc
              * Example of a method in a PHP class to be called from TypoScript
              *
              */
-            class YourClass {
+            class YourClass
+            {
               /**
                * Reference to the parent (calling) cObject set from TypoScript
                */
@@ -1842,7 +1845,8 @@ postUserFunc
                * @param	array		TypoScript properties passed to this method.
                * @return	string	The input string reversed. If the TypoScript property "uppercase" was set, it will also be in uppercase. May also be linked.
                */
-              public function reverseString($content, $conf) {
+              public function reverseString($content, $conf)
+              {
                 $content = strrev($content);
                 if (isset($conf['uppercase']) && $conf['uppercase'] === '1') {
                   // Use the method caseshift() from ContentObjectRenderer.php.
@@ -1856,25 +1860,24 @@ postUserFunc
               }
             }
 
-         For page.10 the content, which is present when postUserFunc is
+         For :ts:`page.10` the content, which is present when :ts:`postUserFunc` is
          executed, will be given to the PHP function
-         ``reverseString()``. The result will be "!DLROW OLLEH".
+         :php:`reverseString()`. The result will be "!DLROW OLLEH".
 
-         The content of page.20 will be processed by the function
-         ``reverseString()`` from the class ``YourClass``. This also returns
+         The content of :ts:`page.20` will be processed by the function
+         :php:`reverseString()` from the class :php:`YourClass`. This also returns
          the text "!DLROW OLLEH", but wrapped into a link to the page
-         with the ID 11. The result will be "<a
-         href="index.php?id=11">!DLROW OLLEH</a>".
+         with the ID 11. The result will be :html:`<a href="index.php?id=11">!DLROW OLLEH</a>`.
 
-         Note how in the second example $cObj, the reference to the
-         calling cObject, is utilised to use functions from
-         ContentObjectRenderer.php!
+         Note how in the second example :php:`$cObj`, the reference to the
+         calling :ts:`cObject`, is utilised to use functions from
+         :file:`ContentObjectRenderer.php`!
 
 
 .. _stdwrap-postuserfuncint:
 
 postUserFuncInt
-'''''''''''''''
+~~~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1882,7 +1885,7 @@ postUserFuncInt
          postUserFuncInt
 
    Data type
-         function name
+         :ref:`data-type-function-name`
 
    Description
          Calls the provided PHP function. If you specify the name with a '->'
@@ -1894,7 +1897,8 @@ postUserFuncInt
          postUserFuncInt are provided to the function.
 
          The result will be rendered non-cached, outside the main
-         page-rendering. Please see the description of the cObject :ref:`USER_INT <cobj-user-int>`.
+         page-rendering. Please see the description of the :ts:`cObject`
+         :ref:`USER_INT <cobj-user-int>`.
 
          Supplied by Jens Ellerbrock
 
@@ -1902,7 +1906,7 @@ postUserFuncInt
 .. _stdwrap-preficomment:
 
 prefixComment
-'''''''''''''
+~~~~~~~~~~~~~
 
 .. container:: table-row
 
@@ -1910,14 +1914,14 @@ prefixComment
          prefixComment
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          Prefixes content with an HTML comment with the second part of input
          string (divided by "\|") where first part is an integer telling how
          many trailing tabs to put before the comment on a new line.
 
-         The content is parsed through insertData.
+         The content is parsed through :ref:`stdwrap-insertData`.
 
          **Example:** ::
 
@@ -1929,7 +1933,7 @@ prefixComment
 .. _stdwrap-editicons:
 
 editIcons
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1937,11 +1941,11 @@ editIcons
          editIcons
 
    Data type
-         string /stdWrap
+         :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
          If not empty, then insert an icon linking to
-         typo3/sysext/backend/Classes/Controller/EditDocumentController.php
+         :file:`typo3/sysext/backend/Classes/Controller/EditDocumentController.php`
          with some parameters to build and backend user edit form for certain
          fields.
 
@@ -1987,7 +1991,7 @@ editIcons
 .. _stdwrap-editpanel:
 
 editPanel
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -1995,16 +1999,16 @@ editPanel
          editPanel
 
    Data type
-         boolean / editPanel
+         :ref:`boolean <data-type-bool>` / :ref:`cobj-editpanel`
 
    Description
-         See cObject :ref:`cobj-editpanel`.
+         See :ts:`cObject` :ref:`cobj-editpanel`.
 
 
 .. _stdwrap-cache:
 
 cache
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -2012,7 +2016,7 @@ cache
          cache
 
    Data type
-         :ref:`cache <cache>`
+         :ref:`cache`
 
    Description
          Caches rendered content in the caching framework.
@@ -2021,7 +2025,7 @@ cache
 .. _stdwrap-debug:
 
 debug
-'''''
+~~~~~
 
 .. container:: table-row
 
@@ -2029,12 +2033,12 @@ debug
          debug
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         Prints content with HTMLSpecialChars() and <pre></pre>: Useful for
-         debugging which value stdWrap actually ends up with, if you are
-         constructing a website with TypoScript.
+         Prints content with :php:`HTMLSpecialChars()` and :html:`<pre></pre>`:
+         Useful for debugging which value :ts:`stdWrap` actually ends up with,
+         if you are constructing a website with TypoScript.
 
          Should be used under construction only.
 
@@ -2042,7 +2046,7 @@ debug
 .. _stdwrap-debugfunc:
 
 debugFunc
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -2050,10 +2054,10 @@ debugFunc
          debugFunc
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         Prints the content directly to browser with the debug() function.
+         Prints the content directly to browser with the :php:`debug()` function.
 
          Should be used under construction only.
 
@@ -2063,7 +2067,7 @@ debugFunc
 .. _stdwrap-debugdata:
 
 debugData
-'''''''''
+~~~~~~~~~
 
 .. container:: table-row
 
@@ -2071,14 +2075,13 @@ debugData
          debugData
 
    Data type
-         boolean /stdWrap
+         :ref:`boolean <data-type-bool>` / :ref:`stdWrap`
 
    Description
-         Prints the current data-array, $cObj->data, directly to browser. This
-         is where ".field" gets data from.
+         Prints the current data-array, :php:`$cObj->data`, directly to browser. This
+         is where :ts:`field` gets data from.
 
          Should be used under construction only.
 
 
 [tsref:->stdWrap]
-

--- a/Documentation/Functions/Strpad/Index.rst
+++ b/Documentation/Functions/Strpad/Index.rst
@@ -3,15 +3,21 @@
 
 .. _strpad:
 
+======
 strPad
-^^^^^^
+======
 
 This property returns the input value padded to a certain length. The
 padding is added on the left side, the right side or on both sides.
-strPad uses the PHP function str_pad() for the operation.
+strPad uses the PHP function :php:`str_pad()` for the operation.
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _strpad-length:
+
+length
+======
 
 .. container:: table-row
 
@@ -19,7 +25,7 @@ strPad uses the PHP function str_pad() for the operation.
          length
 
    Data type
-         integer /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-integer` / :ref:`stdwrap`
 
    Description
          The length of the output string. If the value is negative, less
@@ -29,6 +35,10 @@ strPad uses the PHP function str_pad() for the operation.
    Default
          0
 
+.. _strpad-padwith:
+
+padWith
+=======
 
 .. container:: table-row
 
@@ -36,18 +46,22 @@ strPad uses the PHP function str_pad() for the operation.
          padWith
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
-         The character(s) to pad with. The value of padWith may be
+         The character(s) to pad with. The value of :ref:`strpad-padWith` may be
          truncated, if the required number of padding characters cannot
-         be evenly divided by the length of the value of padWith. Note
-         that leading and trailing spaces of padWith are stripped! If
+         be evenly divided by the length of the value of :ts:`padWith`. Note
+         that leading and trailing spaces of :ts:`padWith` are stripped! If
          you want to pad with spaces, omit this option.
 
    Default
          (space character)
 
+.. _strpad-type:
+
+type
+====
 
 .. container:: table-row
 
@@ -55,7 +69,7 @@ strPad uses the PHP function str_pad() for the operation.
          type
 
    Data type
-         *(list of keywords)* /:ref:`stdWrap <stdwrap>`
+         *(list of keywords)* / :ref:`stdwrap`
 
    Description
          The side(s) of the input value, on which the padding should be
@@ -74,7 +88,7 @@ strPad uses the PHP function str_pad() for the operation.
 .. _strpad-examples:
 
 Examples:
-"""""""""
+=========
 
 ::
 
@@ -82,10 +96,9 @@ Examples:
    # The input value is 34 signs long.
    10.value = TYPO3 - inspiring people to share.
    10.value.strPad {
-     length = 37
-     padWith = =
-     type = both
+        length = 37
+        padWith = =
+        type = both
    }
 
 This results in "=TYPO3 - inspiring people to share.==".
-

--- a/Documentation/Functions/Tags/Index.rst
+++ b/Documentation/Functions/Tags/Index.rst
@@ -3,16 +3,22 @@
 
 .. _tags:
 
+====
 tags
-^^^^
+====
 
 Used to create custom tags and define how they should be parsed. This
-is used in conjunction with *parseFunc*.
+is used in conjunction with :ref:`parseFunc`.
 
 The best known is the "link" tag, which is used to create links.
 
 
 .. ### BEGIN~OF~TABLE ###
+
+.. _tags-array-of-strings:
+
+*(array of strings)*
+====================
 
 .. container:: table-row
 
@@ -20,7 +26,7 @@ The best known is the "link" tag, which is used to create links.
          *(array of strings)*
 
    Data type
-         cObject
+         :ref:`data-type-cobject`
 
    Description
          Every entry in the array of strings corresponds to a tag, that will
@@ -28,36 +34,38 @@ The best known is the "link" tag, which is used to create links.
 
          Every entry must be set to a content object.
 
-         "current" is set to the content of the tag, eg <TAG>content</TAG>:
-         here "current" is set to "content". It can be used with
-         stdWrap.current = 1.
+         :ts:`current` is set to the content of the tag, eg :html:`<TAG>content</TAG>`:
+         here :ts:`current` is set to :ts:`content`. It can be used with
+         :ts:`stdWrap.current = 1`.
 
          **Parameters:**
 
-         Parameters of the tag are set in $cObj->parameters (key is lowercased)::
+         Parameters of the tag are set in :php:`$cObj->parameters` (key is lowercased):
+
+         .. code-block:: html
 
             <TAG COLOR="red">content</TAG>
 
-         This sets $cObj->parameters[color] = red.
+         This sets :php:`$cObj->parameters['color'] = 'red'`.
 
-         $cObj->parameters[allParams] is automatically set to the whole
-         parameter-string of the tag. Here it is ' color="red"'
+         :php:`$cObj->parameters['allParams']` is automatically set to the whole
+         parameter-string of the tag. Here it is :html:`color="red"`
 
          **Special properties for each content object:**
 
-         **[cObject].stripNL:** Boolean option, which tells *parseFunc* that
+         **[cObject].stripNL:** :ref:`data-type-boolean` option, which tells :ts:`parseFunc` that
          newlines before and after the content of the tag should be stripped.
 
-         **[cObject].breakoutTypoTagContent:** Boolean option, which tells
-         parseFunc that this block of content is breaking up the nonTypoTag
+         **[cObject].breakoutTypoTagContent:** :ref:`data-type-boolean` option, which tells
+         :ref:`parseFunc` that this block of content is breaking up the nonTypoTag
          content and that the content after this must be re-wrapped.
 
          **Examples:** ::
 
             tags.bold = TEXT
             tags.bold {
-              stdWrap.current = 1
-              stdWrap.wrap = <p style="font-weight: bold;"> | </p>
+                stdWrap.current = 1
+                stdWrap.wrap = <p style="font-weight: bold;"> | </p>
             }
             tags.bold.stdWrap.stripNL = 1
 
@@ -73,50 +81,49 @@ The best known is the "link" tag, which is used to create links.
 .. _tags-examples:
 
 Example:
-""""""""
+========
 
-This example creates 4 custom tags. The <LINK>-, <TYPOLIST>-,
-<GRAFIX>- and <PIC>-tags:
+This example creates 4 custom tags. The :html:`<LINK>`-, :html:`<TYPOLIST>`-,
+:html:`<GRAFIX>`- and :html:`<PIC>`-tags:
 
-<LINK> is made into a typolink and provides an easy way of creating
+:html:`<LINK>` is made into a typolink and provides an easy way of creating
 links in text.
 
-<TYPOLIST> is used to create bullet-lists.
+:html:`<TYPOLIST>` is used to create bullet-lists.
 
-<GRAFIX> will create an image file with 90x10 pixels where the text is
+:html:`<GRAFIX>` will create an image file with 90x10 pixels where the text is
 the content of the tag.
 
-<PIC> lets us place an image in the text. The content of the tag
-should be the image-reference in "fileadmin/images/". ::
+:html:`<PIC>` lets us place an image in the text. The content of the tag
+should be the image-reference in :file:`fileadmin/images/`. ::
 
        tags {
-         link = TEXT
-         link {
-           stdWrap.current = 1
-           stdWrap.typolink.extTarget = _blank
-           stdWrap.typolink.target = {$cLinkTagTarget}
-           stdWrap.typolink.wrap = <p style="color: red;">|</p>
-           stdWrap.typolink.parameter.data = parameters : allParams
-         }
-
-         typolist < tt_content.bullets.default.20
-         typolist.trim = 1
-         typolist.field >
-         typolist.current = 1
-
-         grafix = IMAGE
-         grafix {
-           file = GIFBUILDER
-           file {
-             XY = 90,10
-             100 = TEXT
-             100.text.current = 1
-             100.offset = 5,10
+           link = TEXT
+           link {
+               stdWrap.current = 1
+               stdWrap.typolink.extTarget = _blank
+               stdWrap.typolink.target = {$cLinkTagTarget}
+               stdWrap.typolink.wrap = <p style="color: red;">|</p>
+               stdWrap.typolink.parameter.data = parameters : allParams
            }
-         }
-         # Transforms <pic>file.png</pic> to <img src="fileadmin/images/file.png" >
-         pic = IMAGE
-         pic.file.import = fileadmin/images/
-         pic.file.import.current = 1
-       }
 
+           typolist < tt_content.bullets.default.20
+           typolist.trim = 1
+           typolist.field >
+           typolist.current = 1
+
+           grafix = IMAGE
+           grafix {
+               file = GIFBUILDER
+               file {
+                   XY = 90,10
+                   100 = TEXT
+                   100.text.current = 1
+                   100.offset = 5,10
+               }
+           }
+           # Transforms <pic>file.png</pic> to <img src="fileadmin/images/file.png" >
+           pic = IMAGE
+           pic.file.import = fileadmin/images/
+           pic.file.import.current = 1
+       }

--- a/Documentation/Functions/Typolink/Index.rst
+++ b/Documentation/Functions/Typolink/Index.rst
@@ -27,7 +27,7 @@ extTarget
          extTarget
 
    Data type
-         target /:ref:`stdWrap <stdwrap>`
+         target / :ref:`stdwrap`
 
    Description
          Target used for external links
@@ -47,7 +47,7 @@ fileTarget
          fileTarget
 
    Data type
-         target /:ref:`stdWrap <stdwrap>`
+         target / :ref:`stdwrap`
 
    Description
          Target used for file links
@@ -64,7 +64,7 @@ target
          target
 
    Data type
-         target /:ref:`stdWrap <stdwrap>`
+         target / :ref:`stdwrap`
 
    Description
          Target used for internal links
@@ -81,7 +81,7 @@ no\_cache
          no\_cache
 
    Data type
-         boolean /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-bool` / :ref:`stdwrap`
 
    Description
          Adds "&no\_cache=1" to the link
@@ -98,18 +98,19 @@ useCacheHash
          useCacheHash
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
          If set, the additionalParams list is exploded and calculated into a
          hash string appended to the URL, like "&cHash=ae83fd7s87". When the
          caching mechanism sees this value, it calculates the same value on the
-         server based on incoming values in HTTP\_GET\_VARS, excluding
+         server based on incoming values in :php:`HTTP_GET_VARS`, excluding
          id, type, no\_cache, ftu, cHash, MP values. If the incoming cHash value
          matches the calculated value, the page may be cached based on this.
 
-         The $TYPO3\_CONF\_VARS['SYS']['encryptionKey'] is included in the hash
-         in order to make it unique for the server and non-predictable.
+         The :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']`
+         is included in the hash in order to make it unique for the
+         server and non-predictable.
 
 
 .. _typolink-additionalParams:
@@ -123,7 +124,7 @@ additionalParams
          additionalParams
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          This is parameters that are added to the end of the URL. This must be
@@ -156,7 +157,7 @@ addQueryString
          addQueryString
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
          Add the QUERY\_STRING to the start of the link. Notice that this does
@@ -199,7 +200,7 @@ wrap
          wrap
 
    Data type
-         wrap /:ref:`stdWrap <stdwrap>`
+         wrap / :ref:`stdwrap`
 
    Description
          Wraps the links.
@@ -216,10 +217,10 @@ ATagBeforeWrap
          ATagBeforeWrap
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
-         If set, the link is first wrapped with :ts:`.wrap` and then the
+         If set, the link is first wrapped with :ts:`wrap` and then the
          <A>-tag.
 
    Default
@@ -236,7 +237,7 @@ parameter
          parameter
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          This is the main data that is used for creating the link. It can be
@@ -349,7 +350,7 @@ forceAbsoluteUrl
          forceAbsoluteUrl
 
    Data type
-         boolean
+         :ref:`boolean <data-type-bool>`
 
    Description
          Forces links to internal pages to be absolute, thus having a proper
@@ -382,7 +383,7 @@ title
          title
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Sets the title parameter of the A-tag.
@@ -399,7 +400,7 @@ JSwindow\_params
          JSwindow\_params
 
    Data type
-         string
+         :ref:`data-type-string
 
    Description
          Preset values for opening the window. This example lists almost all
@@ -419,11 +420,11 @@ returnLast
          returnLast
 
    Data type
-         string
+         :ref:`data-type-string
 
    Description
          If set to "url", then it will return the URL of the link
-         ($this->lastTypoLinkUrl).
+         (:php:`$this->lastTypoLinkUrl`).
 
          If set to "target", it will return the target of the link.
 
@@ -442,7 +443,7 @@ section
          section
 
    Data type
-         string /:ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          If this value is present, it's prepended with a "#" and placed after
@@ -463,7 +464,7 @@ ATagParams
          ATagParams
 
    Data type
-         <A>-params /:ref:`stdWrap <stdwrap>`
+         <A>-params / :ref:`stdwrap`
 
    Description
          Additional parameters
@@ -484,7 +485,7 @@ linkAccessRestrictedPages
          linkAccessRestrictedPages
 
    Data type
-         boolean
+         :ref:`data-type-bool`
 
    Description
          If set, typolinks pointing to access restricted pages will still link
@@ -502,7 +503,7 @@ userFunc
          userFunc
 
    Data type
-         function name
+         :ref:`data-type-function-name`
 
    Description
          This passes the link-data compiled by the typolink function to a user-
@@ -559,7 +560,7 @@ Resource handler key (`page`)
    - file
    - folder
 
-   More keys can be added via :php:`$TYPO3_CONF_VARS['SYS']['linkHandler']` in
+   More keys can be added via :php:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['linkHandler']` in
    an associative array where the key is the handler key and the value is a
    class implementing the LinkHandlerInterface.
 
@@ -667,12 +668,12 @@ Registering the handler for keyword "pressrelease" is done like this:
 
 .. code-block:: php
 
-   $TYPO3_CONF_VARS['SC_OPTIONS']['tslib/class.tslib_content.php']
+   $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_content.php']
      ['typolinkLinkHandler']['pressrelease'] =
      'EXT:pressrelease/class.linkHandler.php:&tx_linkHandler';
 
-The class file "pressrelease/class.linkHandler.php" contains the class
-"tx\_linkHandler" which could look like this:
+The class file :file:`pressrelease/class.linkHandler.php` contains the class
+:php:`tx_linkHandler` which could look like this:
 
 .. code-block:: php
 
@@ -696,11 +697,12 @@ called with `&tx_pressrelease[showUid]=123`. In addition you can see
 the "userCacheHash" attribute for the typolink function used in order
 to produce a cached display.
 
-The link that results from this operation will look like this::
+The link that results from this operation will look like this:
+
+.. code-block:: html
 
    <a href="index.php?id=34&amp;
      tx_pressrelease[showUid]=123%3A456&amp;cHash=c0551fead6" >
 
-The link would be encoded with RealURL and respect config.linkVars as
-long as ->typolink is used to generate the final URL.
-
+The link would be encoded with RealURL and respect :ts:`config.linkVars`
+as long as ->typolink is used to generate the final URL.

--- a/Documentation/ObjectsAndProperties/Calc/Index.rst
+++ b/Documentation/ObjectsAndProperties/Calc/Index.rst
@@ -24,5 +24,3 @@ calc example:
 
    45 + 34 * 2 = 158
    (which is the same as this in ordinary arithmetic: (45+34)*2=158)
-
-

--- a/Documentation/ObjectsAndProperties/Introduction/Index.rst
+++ b/Documentation/ObjectsAndProperties/Introduction/Index.rst
@@ -10,10 +10,9 @@ Introduction
 .. _objects-referencing:
 
 Reference to objects
---------------------
+====================
 
 Whenever you see *->[object name]* in the tables it means that the
 property is an object "*object name*" with properties from object
 *object name*. You don't need to define the object type. You will
 often find the according documentation on its own page.
-

--- a/Documentation/ObjectsAndProperties/OptionSplit/Index.rst
+++ b/Documentation/ObjectsAndProperties/OptionSplit/Index.rst
@@ -16,16 +16,16 @@ optionSplit
 Introduction
 ============
 
-`optionSplit` is the codename of a very tricky - but very useful! - function
+:ts:`optionSplit` is the codename of a very tricky - but very useful! - function
 and functionality. It is primarily used with the menu objects where it is
-enable for MANY properties. This make `optionSplit` really powerful.
+enable for MANY properties. This make :ts:`optionSplit` really powerful.
 
 So let's take an example from menu building.
 As a result all A-tags generated from this definition will have the `class` attribute
 set like this: :html:`<a class="z" ... >`::
 
    topmenu.1.NO {
-     ATagParams = class="z"
+       ATagParams = class="z"
    }
 
 How many A-tags will there be? Usually we cannot answer that question in advance
@@ -33,14 +33,14 @@ as we cannot know how long the list of menu items is. From zero to many everythi
 is possible. Let's describe this as: We have an **output sequence of 0 to N items**.
 
 In real life one more thing is important: We often want to have a different properties
-for the first and the last or odd and even elements. `optionSplit` tries to offer
+for the first and the last or odd and even elements. :ts:`optionSplit` tries to offer
 an easy solution for this task as well. We can specify more than just one shaping
 of a value for a property. Let's describe this as: We have an **input sequence M items**.
 
-Now we can precisely define what `optionSplit` is.
+Now we can precisely define what :ts:`optionSplit` is.
 
 Definition:
-   `optionSplit` is a **syntax** to define an input sequence of a fixed amount **M**
+   :ts:`optionSplit` is a **syntax** to define an input sequence of a fixed amount **M**
    of values. It has a fixed, builtin **ruleset**. Its **functionality** is to
    apply ONE of the input values to each output item according to the position of
    the output item and the ruleset.
@@ -49,7 +49,7 @@ In other words:
 
    1. We have an **input sequence of M items**. M is known.
    2. We have an **output sequence of 0 to N items**. N is unknown and may be zero, one, or "large".
-   3. We have a **ruleset** delivered with `optionSplit` that specifies how the input sequence
+   3. We have a **ruleset** delivered with :ts:`optionSplit` that specifies how the input sequence
       should be applied to the output sequence.
 
 In the following we'll try to shed light on this.
@@ -58,9 +58,8 @@ In the following we'll try to shed light on this.
 PHP-Code
 ========
 
-Lookout for usages of the function :php:`splitConfArray` which is part of the :php:`Core TypoScript TemplateService`
-class: :ref:`TYPO3 \\ CMS \\ Core \\ TypoScript \\ TemplateService :: splitConfArray()
-<t3api:TYPO3\\CMS\\Core\\TypoScript\\TemplateService::splitConfArray>`.
+Lookout for usages of the function
+:php:`\TYPO3\CMS\Core\TypoScript\TemplateService::splitConfArray()`.
 
 
 
@@ -73,9 +72,9 @@ Terminology
 It's useful to aggree about some terms first: delimiter string, mainpart, subpart.
 
 Mainparts
----------
+~~~~~~~~~
 
-`optionSplit` uses the string `|*|` to split the total string into **mainparts**.
+:ts:`optionSplit` uses the string `|*|` to split the total string into **mainparts**.
 Up to **three** mainparts will be used. If there are more they
 will be ignored.
 On the input side we may have for example::
@@ -102,7 +101,7 @@ the cases:
 
 
 Subparts
---------
+~~~~~~~~
 
 Each mainpart may be split further into **subparts**. The delimiter for splitting a mainpart into
 subparts is `||`.
@@ -126,7 +125,7 @@ Let's look at a full example that visualizes what we have said so far.
 
 
 Three by three items
---------------------
+~~~~~~~~~~~~~~~~~~~~
 
 We have all three mainparts A, R and Z. And each mainpart is split into three
 subparts::
@@ -188,7 +187,7 @@ More Examples
 =============
 
 Three by two items
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Rules 1 to 7 define this behavior::
 
@@ -220,7 +219,7 @@ Rules 1 to 7 define this behavior::
 
 
 Three by one items
-------------------
+~~~~~~~~~~~~~~~~~~
 
 And again::
 
@@ -253,7 +252,7 @@ And again::
 
 
 Two by three items
-------------------
+~~~~~~~~~~~~~~~~~~
 
 Now the mainpart delimiter `|*|` occurrs only once. So we are
 dealing with the first two mainparts A and R.
@@ -288,7 +287,7 @@ According to rules 1 to 7 we get::
 
 
 Two by two items
-----------------
+~~~~~~~~~~~~~~~~
 
 According to rules 1 to 7 we get::
 
@@ -320,7 +319,7 @@ According to rules 1 to 7 we get::
 
 
 Two by one items
-----------------
+~~~~~~~~~~~~~~~~
 
 According to rules 1 to 7 we get::
 
@@ -353,7 +352,7 @@ According to rules 1 to 7 we get::
 
 
 One by one items
-----------------
+~~~~~~~~~~~~~~~~
 
 With no delimiters at all we still have - implictely - one mainpart
 A with one subpart a::
@@ -387,7 +386,7 @@ A with one subpart a::
 
 
 One by two items
-----------------
+~~~~~~~~~~~~~~~~
 
 One mainpart A with two subparts a and b::
 
@@ -419,7 +418,7 @@ One mainpart A with two subparts a and b::
 
 
 One by three items
-------------------
+~~~~~~~~~~~~~~~~~~
 
 More::
 
@@ -450,7 +449,7 @@ More::
       20     a b c c c c c c c c c c c c c c c c c c
 
 One by four items
------------------
+~~~~~~~~~~~~~~~~~
 
 More::
 
@@ -487,7 +486,7 @@ More examples: Tricky stuff
 
 
 Three items A, no item R, three items Z
----------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 In this situation with still have **three** mainparts. We can tell this from the fact that we have
 TWO occurrences of the mainpart delimiter. And the second mainpart R is really empty.
@@ -527,7 +526,7 @@ As result we get::
 
 
 One item A, no item R, one items Z
------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 With rules 1 to 8 we get::
 
@@ -560,7 +559,7 @@ With rules 1 to 8 we get::
 
 
 One item A, one (unexpected!?) item R, one item Z
--------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. attention::
 
@@ -597,7 +596,7 @@ What happens if there IS a space? Normal behavior of a three by one case! ::
 
 
 More
-----
+~~~~
 
 ::
 
@@ -1436,4 +1435,3 @@ output::
       18     a r    r    r    r    z
       19     a r    r    r    r    r z
       20     a r    r    r    r    r  z
-

--- a/Documentation/ObjectsAndProperties/StdWrap/Index.rst
+++ b/Documentation/ObjectsAndProperties/StdWrap/Index.rst
@@ -9,16 +9,16 @@ Objects and stdWrap
 
 "... /stdWrap"
 
-When a data type is set to "*type* /stdWrap" it means that the value
-is parsed through the stdWrap function with the properties of the
+When a data type is set to "*type* / :ts:`stdWrap`" it means that the value
+is parsed through the :ts:`stdWrap` function with the properties of the
 value as parameters.
 
 
 stdWrap example:
 ================
 
-If the property "pixels" has the data type "integer /stdWrap", the
-value should be set to an integer and can be parsed through stdWrap.
+If the property "pixels" has the data type "integer / :ts:`stdWrap`", the
+value should be set to an integer and can be parsed through :ts:`stdWrap`.
 
 In a real application we could do like this::
 
@@ -26,6 +26,6 @@ In a real application we could do like this::
    .pixels.intval = 1
 
 This example imports the value from the field "imagewidth" of the
-current $cObj->data-array. But we don't trust the result to be an
-integer so we parse it through the intval()-function.
+current :php:`$cObj->data-array`. But we don't trust the result to be an
+integer so we parse it through the :php:`intval()`-function.
 

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -401,13 +401,13 @@ compressCss
    Description
          If set, CSS files referenced in page.includeCSS and the like will be
          minified and compressed. Does not work on files, which are referenced
-         in page.headerData.
+         in ``page.headerData``.
 
          Minification will remove all excess space. The more significant
          compression step (using gzip compression) requires
-         $TYPO3\_CONF\_VARS['FE']['compressionLevel'] to be enabled in the
+         `$GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']` to be enabled in the
          Install Tool. For this to work you also need to activate the gzip-
-         related compressionLevel options in .htaccess, as otherwise the
+         related compressionLevel options in ``.htaccess``, as otherwise the
          compressed files will not be readable by the user agent.
 
          **Example**::
@@ -416,13 +416,15 @@ compressCss
 
          **Note:** TYPO3 comes with a built-in compression handler, but you can
          also register your own one using
-         $GLOBALS['TYPO3\_CONF\_VARS']['FE']['cssCompressHandler'].
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler']``.
 
-         **Example**::
+         **Example**:
+
+         .. code-block:: php
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler'] =
-               TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/class.tx_myext_cssCompressHandler.php:tx_myext_cssCompressHandler->compressCss';
+               \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
+               'Classes/CssCompressHandler.php:Vendor\MyExt\CssCompressHandler->compressCss';
 
 
 
@@ -445,7 +447,7 @@ compressJs
 
    Description
          Enabling this option together with
-         $TYPO3\_CONF\_VARS['FE']['compressionLevel'] in the Install Tool
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']`` in the Install Tool
          delivers Frontend JavaScript files referenced in page.includeJS and
          the like using GZIP compression. Does not work on files, which are
          referenced in page.headerData.
@@ -455,7 +457,7 @@ compressJs
 
          Please note that this requires .htaccess to be adjusted, as otherwise
          the files will not be readable by the user agent. Please see the
-         description of $TYPO3\_CONF\_VARS['FE']['compressionLevel'] in the
+         description of ``$GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']`` in the
          Install Tool.
 
          **Example**::
@@ -464,13 +466,15 @@ compressJs
 
          **Note:** TYPO3 comes with a built-in compression handler, but you can
          also register your own one using
-         $GLOBALS['TYPO3\_CONF\_VARS']['FE']['jsCompressHandler'].
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['jsCompressHandler']``.
 
-         **Example**::
+         **Example**:
+
+         .. code-block:: php
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['jsCompressHandler'] =
-               TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/class.tx_myext_jsCompressHandler.php:tx_myext_jsCompressHandler->compressJs';
+               \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
+               'Classes/JsCompressHandler.php:Vendor\MyExt\JsCompressHandler->compressJs';
 
 
 
@@ -492,7 +496,7 @@ concatenateCss
          0
 
    Description
-         Setting config.concatenateCss merges Stylesheet files referenced in
+         Setting :ts:`config.concatenateCss` merges Stylesheet files referenced in
          the Frontend in page.includeCSS and the like together. Files are merged
          only, if their media attribute has the same value, e.g. if it is "all"
          for several files. Does not work on files, which are referenced in
@@ -504,13 +508,15 @@ concatenateCss
 
          **Note:** TYPO3 comes with a built-in concatenation handler, but you
          can also register your own one using
-         $GLOBALS['TYPO3\_CONF\_VARS']['FE']['cssConcatenateHandler'].
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['cssConcatenateHandler']``.
 
-         **Example**::
+         **Example**:
 
-            $GLOBALS['TYPO3_CONF_VARS']['FE']['cssConcatenateHandler'] =
-               TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/class.tx_myext_cssConcatenateHandler.php:tx_myext_cssConcatenateHandler->concatenateCss';
+         .. code-block:: php
+
+            $GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler'] =
+               \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
+               'Classes/CssCompressHandler.php:Vendor\MyExt\CssCompressHandler->compressCss';
 
 
 
@@ -532,9 +538,9 @@ concatenateJs
          0
 
    Description
-         Setting config.concatenateJs merges JavaScript files referenced in
-         the Frontend in page.includeJS and the like together. Does not work
-         on files, which are referenced in page.headerData.
+         Setting :ts:`config.concatenateJs` merges JavaScript files referenced in
+         the Frontend in :ts:`page.includeJS` and the like together. Does not work
+         on files, which are referenced in :ts:`page.headerData`.
 
          **Example**::
 
@@ -542,13 +548,15 @@ concatenateJs
 
          **Note:** TYPO3 comes with a built-in concatenation handler, but you
          can also register your own one using
-         $GLOBALS['TYPO3\_CONF\_VARS']['FE']['jsConcatenateHandler'].
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['jsConcatenateHandler']``.
 
-         **Example**::
+         **Example**:
+
+         .. code-block:: php
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['jsConcatenateHandler'] =
-               TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/class.tx_myext_jsConcatenateHandler.php:tx_myext_jsConcatenateHandler->concatenateJs';
+               \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
+               'Classes/JsConcatenateHandler.php:Vendor\MyExt\JsConcatenateHandler->concatenateJs';
 
 
 
@@ -570,7 +578,7 @@ concatenateJsAndCss
          0
 
    Description
-         Setting config.concatenateJsAndCss bundles JS and CSS files in the FE.
+         Setting :ts:`config.concatenateJsAndCss` bundles JS and CSS files in the FE.
 
          **Example**::
 
@@ -578,16 +586,19 @@ concatenateJsAndCss
 
          **Note:** TYPO3 comes with a built-in concatenation handler, but you
          can also register your own one using
-         $GLOBALS['TYPO3\_CONF\_VARS']['FE']['concatenateHandler'].
+         ``$GLOBALS['TYPO3_CONF_VARS']['FE']['concatenateHandler']``.
 
-         **Example**::
+         **Example**:
+
+         .. code-block:: php
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['concatenateHandler'] =
-               TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/class.tx_myext_concatenateHandler.php:tx_myext_concatenateHandler->concatenateFiles';
+               \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
+               'Classes/ConcatenateHandler.php:Vendor\MyExt\ConcatenateHandler->concatenateFiles';
+
 
          **Note:** This property was deprecated and is planned to be removed!
-         Use config.concatenateJs and config.concatenateCss instead.
+         Use :ts:`config.concatenateJs` and :ts:`config.concatenateCss` instead.
 
 
 
@@ -904,14 +915,14 @@ disableLanguageHeader
          where "XX" is the ISO code of the according lanuage.
 
          For the default language (sys_language_uid=0), this header is based
-         on the value of config.sys_language_isocode_default. If this is unset,
+         on the value of :ts:`config.sys_language_isocode_default`. If this is unset,
          config.language is used. If that is unset as well, it finally falls
          back to "en".
 
          For other languages, it uses the value from language_isocode from
-         sys_language. That value may be overwritten by config.sys_language_isocode.
+         sys_language. That value may be overwritten by :ts:`config.sys_language_isocode`.
 
-         If config.disableLanguageHeader is set, this header will not be sent.
+         If :ts:`config.disableLanguageHeader` is set, this header will not be sent.
 
 .. _setup-config-doctype:
 
@@ -949,7 +960,7 @@ doctype
 
             Keywords also change the way TYPO3 generates some of the
             XHTML tags to ensure valid XML. If you set doctype to a string, then
-            you must also set config.xhtmlDoctype (see below).
+            you must also set :ts:`config.xhtmlDoctype` (see below).
 
          See :ref:`config.htmlTag_setParams <setup-config-htmltag-setparams>` and
          :ref:`config.htmlTag_langKey <setup-config-htmltag-langkey>` for more


### PR DESCRIPTION
* Fix non existing cross references, mainly for data types.
* Fix missing roles for typoscript, html, etc.
* Fix missing syntax information for code highlighting, mainly php.
* Partly remove references to TYPO3 API, instead use PHP Role.
* Add `GLOBALS` to TYPO3_CONF_VARS to make it easy for copy and paste
  and to make sure everyone is able to get that it's a global PHP array.
* Partly fix some PSR-2 in code examples, e.g. remove tabs, indent curly
  braces.
* Partly remove inline line numbering for code examples, instead use
  :linenos: option from sphinx.
* Partly add missing anchors to enable cross linking.