### PR TITLE
[TASK] Remove the mention of not longer used strlen function

### DIFF
--- a/Documentation/Functions/Stdwrap/Index.rst
+++ b/Documentation/Functions/Stdwrap/Index.rst
@@ -390,7 +390,8 @@ ifBlank
          :ref:`data-type-string` / :ref:`stdWrap`
 
    Description
-         Same as :ts:`ifEmpty` but the check is done using :php:`strlen()`.
+         Same as :ts:`ifEmpty` but the check is done against ''. Zeros are not
+         treated as blank values!
 
 
 .. _stdwrap-listnum:


### PR DESCRIPTION
With the Task #54091 strlen compares to zero are replaced by a check against '' (empty string).