### PR TITLE
Optimize example for DataProcessing\SplitProcessor

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -525,7 +525,7 @@ dataProcessing
                         delimiter = ,
                         fieldName = bodytext
                         removeEmptyEntries = 1
-                        filterIntegers = 1
+                        filterIntegers = 0
                         filterUnique = 1
                         as = keywords
                     }


### PR DESCRIPTION
Make example work. Filtering intergers in processor, but outputting keywords in template contradicts itself.