### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -1422,11 +1422,12 @@ error if tried accessed (depending on site configuration).
          value
 
    Data type
-         comma list of sys\_language uids /:ref:`stdWrap <stdwrap>`
+         comma list of sys\_language uids /:ref:`stdWrap <stdwrap>` or `auto`
 
    Description
          The number of elements in this list determines the number of menu
-         items.
+         items. Setting to `auto` will include all available languages from
+         the current site.
 
 
 .. container:: table-row


### PR DESCRIPTION
Extend HMENU to support auto filling of special.value for special=language

https://github.com/TYPO3/TYPO3.CMS/blob/master/typo3/sysext/core/Documentation/Changelog/master/Feature-84775-ExtendHMENUForLanguageMenus.rst