### PR TITLE
[TASK] Introduce typolink.language

### DIFF
--- a/Documentation/Conditions/Reference.rst
+++ b/Documentation/Conditions/Reference.rst
@@ -357,10 +357,10 @@ globalVar
 
       [globalVar = GP:style = ]
 
-   This will match, if the GET/POST variable "L" equals 8 or the GET/POST
+   This will match, if the GET/POST variable "foo" equals 8 or the GET/POST
    variable "M" equals 2 or both::
 
-      [globalVar = GP:L = 8, GP:M = 2]
+      [globalVar = GP:foo = 8, GP:M = 2]
 
    Similar to GP, but with array parts of tx_demo from GET and POST merged before matching::
 

--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -335,7 +335,7 @@ into account.
    Description
          If set, then for each page in the menu it will be checked if an
          Alternative Page Language record for the language defined in
-         "config.sys\_language\_uid" (typically defined via &L) exists for the
+         "config.sys\_language\_uid" exists for the
          page. If that is not the case and the pages "Localization settings"
          have the "Hide page if no translation for current language exists"
          flag set, then the menu item will link to a non accessible page that
@@ -1390,13 +1390,11 @@ special = language
 
 Creates a language selector menu. Typically this is made as a menu
 with flags for each language a page is translated to and when the user
-clicks any element the same page id is hit but with a change to the
-"&L" parameter in the URL.
+clicks any element the translated page is hit.
 
 The "language" type will create menu items based on the current page
 record but with the language record for each language overlaid if
-available. The items all link to the current page id and only "&L" is
-changed.
+available.
 
 Note on item states:
 

--- a/Documentation/Functions/If/Index.rst
+++ b/Documentation/Functions/If/Index.rst
@@ -301,13 +301,3 @@ the field "newUntil" has a date less than the current date! ::
          negate = 1
      }
 
-
-In the next example the querystring parameter is used as a condition: A
-typolink or the link of a menu item links back to the default language
-(&L=0), if the currently active language ID is greater than 2. This is
-useful for example if only languages 0 to 2 are available in the target
-page. ::
-
-     additionalParams = &L=0
-     additionalParams.if.value = 2
-     additionalParams.if.isGreaterThan.data = GP:L

--- a/Documentation/Functions/Typolink/Index.rst
+++ b/Documentation/Functions/Typolink/Index.rst
@@ -55,6 +55,37 @@ fileTarget
 
 .. _typolink-target:
 
+.. _typolink-language:
+
+language
+========
+
+.. container:: table-row
+
+    Property
+        language
+
+    Data type
+        integer
+
+    Description
+        Language uid for link target
+
+        Omitting the parameter :typoscript:`language` will use the current language.
+
+
+    Example
+        .. code-block:: typoscript
+
+            page.10 = TEXT
+            page.10.value = Link to the page with the ID in the current language
+            page.10.typolink.parameter = 23
+            page.20 = TEXT
+            page.20.value = Link to the page with the ID in the language 3
+            page.20.typolink.parameter = 23
+            page.20.typolink.language = 3
+
+
 target
 ======
 
@@ -247,7 +278,8 @@ parameter
          Below are a few examples followed by full explanations.
 
    Examples
-         1. Most simple. Will create a link to page 51::
+         1. Most simple. Will create a link to page 51 (if this is not default language,
+             the correct target language will be resolved from the parameter)::
 
                parameter = t3://page?uid=51
 
@@ -270,6 +302,7 @@ parameter
          5. A mailto link with a title attribute (but no target and no class)::
 
                parameter = mailto:info@typo3.org - - "Send a mail to main TYPO3 contact"
+
 
          As you can see from the examples, each significant part of the
          parameter string is separated by a space. Values that can themselves

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -726,7 +726,6 @@ defaultGetVars
 
             config.defaultGetVars {
                 test.var1.var2.p3 = 15
-                L = 3
             }
 
 
@@ -1530,20 +1529,15 @@ linkVars
    Examples
          ::
 
-            config.linkVars = L, print
+            config.linkVars = print
 
-         This will add `&L=[L-value]&print=[print-value]` to all links in
+         This will add `&print=[print-value]` to all links in
          TYPO3. ::
 
-            config.linkVars = L(1-3), print
-
-         Same as above, but `&L=[L-value]` will only be added if the current
-         value is 1, 2 or 3::
-
-            config.linkVars = L(1-3),tracking|green(0-5)
+            config.linkVars = tracking|green(0-5)
 
          With the above configuration the following example GET parameters will
-         be kept: `&L=1&tracking[green]=3`. But a get parameter like
+         be kept: `&tracking[green]=3`. But a get parameter like
          `tracking[blue]` will not be kept.
 
 
@@ -2349,14 +2343,9 @@ sys\_language\_isocode\_default
             config.sys_language_uid = 0
             config.sys_language_isocode_default = da
 
-            [globalVar = GP:L = 1]
-                # ISO code is filled by the respective DB value from sys_language (uid 1)
-                config.sys_language_uid = 1
-
-                # You can override this of course
-                config.sys_language_isocode = fr
+            [siteLanguage = locale = de_CH.UTF-8]
+                config.sys_language_isocode = ch
             [GLOBAL]
-
 
 
 .. _setup-config-sys-language-mode:
@@ -2510,18 +2499,8 @@ sys\_language\_uid
          on the value of the :ts:`sys_language_uid` and other settings like
          :ts:`sys_language_mode`.
 
-         It is usually set to the value of the `&L` request parameter,
-         using a TypoScript condition like in this example::
-
-            config.sys_language_uid = 0
-
-            [globalVar = GP:L = 1]
-                config.sys_language_uid = 1
-            [GLOBAL]
-            [globalVar = GP:L = 2]
-                config.sys_language_uid = 2
-            [GLOBAL]
-
+         It is usually resolved internally by a middleware during bootstrap, taking site configuration setting
+         into account. No manual interference necessary.
 
 
 .. _setup-config-titletagfunction:


### PR DESCRIPTION
See typo3/sysext/core/Documentation/Changelog/9.4/Feature-86057-ImprovedTypolinkURLLinkGeneration.rst

Remove mentions of the famous "L" parameter, as it is now superflous.