### PR TITLE
Fix typoscript condition

### DIFF
--- a/Documentation/Conditions/Reference/Index.rst
+++ b/Documentation/Conditions/Reference/Index.rst
@@ -207,7 +207,7 @@ Operator:       Function:
 
 <=              The hour must be less than or equal to the value.
 
-=>              The hour must be greater than or equal to the value.
+>=              The hour must be greater than or equal to the value.
 
 !=              The hour must be not equal to the value. Comparison with a
                 list of values is possible as well. The condition then


### PR DESCRIPTION
As commented in AbstractConditionMatcher.php (and seen on line 676 in the same rst) the operator has to be `>=` instead of `=>`