### PR TITLE
Escape * as it is needed for function like

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -739,7 +739,7 @@ like
 :aspect:`Example`
    Search a string with ``*`` within another string::
 
-      [like("fooBarBaz", "*Bar*")]
+      [like("fooBarBaz", "\*Bar\*")]
 
    Search string with single characters in between, using ``?``::
 


### PR DESCRIPTION
I don't know, if I have escaped it correct for Sphinx. Please update, if needed.