### PR TITLE
Fix order and association of headlines to examples

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1966,22 +1966,20 @@ pageTitleSeparator
          the end of the separator.
 
    Examples
-         ::
+
+         This produces a title tag with the content "website . page title"::
 
             config.pageTitleSeparator = .
 
-         This produces a title tag with the content "website. page title"::
+         This produces a title tag with the content "website - page title"::
 
             config.pageTitleSeparator = -
             config.pageTitleSeparator.noTrimWrap = | | |
 
-         This produces a title tag with the content "website - page title"::
+         This produces a title tag with the content "website*page title"::
 
             config.pageTitleSeparator = *
             config.pageTitleSeparator.noTrimWrap = |||
-
-         This produces a title tag with the content "website*page title".
-
 
 
 .. _setup-config-removedefaultcss:


### PR DESCRIPTION
Fix order and association of headlines to examples in "pageTitleSeparator" section.