### PR TITLE
[BUGFIX] Remove stdWrap support description and example for config.additionalHeaders

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -176,14 +176,12 @@ additionalHeaders
 
          For each numeric index, there are the following sub-properties:
 
-         **header:** The header string (has :ref:`stdwrap` properties)
+         **header:** The header string
 
          **replace:** Optional. If set, previous headers with the same name
          are replaced with the current one. Default is "1".
-         (has :ref:`stdWrap <stdwrap>` properties)
 
          **httpResponseCode:** Optional. HTTP status code as an integer.
-         (has :ref:`stdwrap` properties)
 
          By default TYPO3 sends a "Content-Type" header with the defined
          encoding, unless this is disabled using :ref:`setup-config-disableCharsetHeader`.
@@ -197,8 +195,7 @@ additionalHeaders
             config.additionalHeaders {
                 10 {
                     # The header string
-                    header = foo:
-                    header.dataWrap = |{page:uid}
+                    header = foo
 
                     # Do not replace previous headers with the same name.
                     replace = 0


### PR DESCRIPTION
The feature to use stdWrap for config.additionalHeaders has been removed due to an incompatibility with page caching.

https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.5/Breaking-86492-RemovedStdWrapSupportForConfigadditionalHeaders.html