### PR TITLE
[BUGFIX] Header level

### DIFF
--- a/Documentation/DataTypes/Properties/GetText.rst.txt
+++ b/Documentation/DataTypes/Properties/GetText.rst.txt
@@ -563,7 +563,7 @@ session
 .. _data-type-site:
 
 site
-----
+""""
 
 :aspect:`Data type:`
    site
@@ -603,7 +603,7 @@ site
 .. _data-type-siteLanguage:
 
 siteLanguage
-------------
+""""""""""""
 
 :aspect:`Data type:`
    siteLanguage


### PR DESCRIPTION
site and siteLanguage is sub property of get text and should therefore
be on same level as all other sub properties.

Releases: 9.5, master