### PR TITLE
Add SiteProcessor

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -447,7 +447,7 @@ dataProcessing
      string based on the site language configuration that will be decoded again
      and assigned to :ts:`FLUIDTEMPLATE` as variable.
 
-   - The :php:`SiteProcessor` fetches data from the site entity.
+   - The :php:`SiteProcessor` fetches data from the :ref:`site<t3coreapi:sitehandling>` entity.
 
    **With the help of the :php:`SplitProcessor` the following scenario is
    possible:** ::

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -415,7 +415,7 @@ dataProcessing
          }
       }
 
-   There are five DataProcessors available to allow flexible processing e.g.
+   There are eight DataProcessors available to allow flexible processing e.g.
    for comma-separated values. To use e.g. with the :ts:`FLUIDTEMPLATE` content
    object.
 
@@ -446,6 +446,8 @@ dataProcessing
    - The :php:`LanguageMenuProcessor` utilizes :ts:`HMENU` to generate a JSON encoded menu
      string based on the site language configuration that will be decoded again
      and assigned to :ts:`FLUIDTEMPLATE` as variable.
+
+   - The :php:`SiteProcessor` fetches data from the site entity.
 
    **With the help of the :php:`SplitProcessor` the following scenario is
    possible:** ::
@@ -865,6 +867,25 @@ dataProcessing
          </ul>
       </f:if>
 
+   **Using the :php:`SiteProcessor` the following scenario is possible:**
+
+   Options:
+
+   :`as`: The variable to be used within the result
+
+   .. code-block:: typoscript
+
+      10 = TYPO3\CMS\Frontend\DataProcessing\SiteProcessor
+      10 {
+         as = site
+      }
+
+   In the Fluid template the properties of the site entity can be accessed:
+
+   .. code-block:: html
+
+      <p>{site.rootPageId}</p>
+      <p>{site.someCustomConfiguration}</p>
 
 
 .. _cobj-fluidtemplate-properties-stdwrap:


### PR DESCRIPTION
With [feature 87748](https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/9.5.x/Feature-87748-AddSiteProcessor.html) the SiteProcessor as DataProcessor was introduced. The patch adds it to the documentation.