### PR TITLE
set config.ftu to normal level

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1114,7 +1114,7 @@ formMailCharset
 .. _setup-config-ftu:
 
 ftu
-"""
+===
 
 .. container:: table-row
 


### PR DESCRIPTION
due to different underlining config.ftu was shown as a subheading from config.form mailCharset