### PR TITLE
Improve rendering of code example for 'pageTitleSeparator'

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2072,7 +2072,6 @@ pageTitleSeparator
          the end of the separator.
 
    Examples
-
          This produces a title tag with the content "website . page title"::
 
             config.pageTitleSeparator = .


### PR DESCRIPTION
The examples are not rendered inside the container 't3-row'
because of an unnecessary blank line.

Releases: master, 9.5