### PR TITLE
Improve rendering of code example for 'PageTitleProviders'

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2024,7 +2024,6 @@ pageTitleProviders
          the lowest in priority.
 
    Examples
-
          By default, TYPO3 ships with two providers::
 
             config.pageTitleProviders {

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2071,7 +2071,6 @@ pageTitleSeparator
          the end of the separator.
 
    Examples
-
          This produces a title tag with the content "website . page title"::
 
             config.pageTitleSeparator = .


### PR DESCRIPTION
The examples are not rendered inside the container 't3-row'
because of an unnecessary blank line.

Releases: master