### PR TITLE
Change title to "TypoScript Template Reference"

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -3,9 +3,9 @@
 
 .. _start:
 
-====================
-TypoScript Reference
-====================
+=============================
+TypoScript Template Reference
+=============================
 
 :Previous Key:
       doc_core_tsref
@@ -17,7 +17,7 @@ TypoScript Reference
       en
 
 :Description:
-      The TypoScript Reference (TSref) is a true reference describing the core Content Objects and functions available for Template building using the TypoScript template engine.
+      The TypoScript Template Reference (TSref) is a true reference describing the core Content Objects and functions available for Template building using the TypoScript template engine.
 
 :Keywords:
       forAdmins, forIntermediates

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -93,6 +93,6 @@ Always remember: In this manual the case of objects **is** important.
 Version numbers
 """""""""""""""
 
-For new features TypoScript Reference includes a note in which TYPO3 version the
+For new features the "TypoScript Template Reference" includes a note in which TYPO3 version the
 feature was added. If such a note is missing, the feature is part of TYPO3 since
 version 7.6 at least.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -23,13 +23,13 @@
 ; you can use in 'conf.py'
 
 
-project     = TypoScript Reference
+project     = TypoScript Template Reference
 version     = master (10-dev)
 release     = master (10-dev)
 t3author    = Documentation Team
 copyright   = since 2000 by the TYPO3 Documentation Team
 
-description = The TypoScript Reference (TSref) is a true reference
+description = The "TypoScript Template Reference" (TSref) is a true reference
    describing the core Content Objects and functions available for
    Template building using the TypoScript template engine.
 


### PR DESCRIPTION
The term "Typoscript" is currently used for the TypoScript syntax
and for TypoScript templating.

We now use "TypoScript Template" when referring to TypoScript templates
to avoid confusion

Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/77
Related: https://github.com/TYPO3-Documentation/T3DocTeam/issues/120
