### PR TITLE
Change misleading description for inlineSettings

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -758,7 +758,7 @@ inlineSettings
          (array of strings)
 
    Description
-         ExtJS specific, adds settings to the page.
+         Adds settings to the page as inline javascript, which is accessible within the variable :js:`TYPO3.settings`.
 
    Example
          ::


### PR DESCRIPTION
extJS is no longer part of TYPO3. Change the misleading description text for inlineSettings.