### PR TITLE
Update list of excludeDoktypes

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -290,8 +290,7 @@ into account.
 
    Description
          Enter the list of page document types (doktype) to exclude from menus.
-         By default pages that are "not in menu" (5) are excluded and those
-         marked for backend user access only (6).
+         By default pages that are "backend user access only" (6) are excluded.
 
 
 


### PR DESCRIPTION
The list of `excludeDoktypes` still included the long-time removed value "5"  -see also https://forge.typo3.org/issues/90472

Please review and backport at will. Thank you.