### PR TITLE
cObjGetSingle can have a third parameter

### DIFF
--- a/Documentation/AppendixA/Index.rst
+++ b/Documentation/AppendixA/Index.rst
@@ -84,10 +84,10 @@ Example:
 
 .. _appendix-include-cobjgetsingle:
 
-$this->cObjGetSingle(value, properties)
-"""""""""""""""""""""""""""""""""""""""
+$this->cObjGetSingle(value, properties[, TSkey = '__'])
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-Gets a content object from the $conf array.
+Gets a content object from the $conf array. $TSkey is an optional string label used for the internal debugging tracking.
 
 
 Example:
@@ -95,7 +95,7 @@ Example:
 
 .. code-block:: php
 
-   $content = $this->cObjGetSingle($conf['image'], $conf['image.']);
+   $content = $this->cObjGetSingle($conf['image'], $conf['image.'], 'My Image 2');
 
 This would return any IMAGE cObject at the property "image" of the
 $conf array for the include script!


### PR DESCRIPTION
    /**
     * Renders a content object
     *
     * @param string $name The content object name, eg. "TEXT" or "USER" or "IMAGE
     * @param array $conf The array with TypoScript properties for the content object
     * @param string $TSkey A string label used for the internal debugging tracking.
     * @return string cObject output
     * @throws \UnexpectedValueException
     */
    public function cObjGetSingle($name, $conf, $TSkey = '__')
    {