### PR TITLE
Fix references to paragraphs on same page

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -790,7 +790,7 @@ jsFooterInline.[array]
          :ref:`cObject <data-type-cobject>`
 
    Description
-         Same :ts:`jsInline`, except that the JavaScript gets inserted at the
+         Same as :ts:`jsInline`, except that the JavaScript gets inserted at the
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -341,7 +341,7 @@ footerData.[array]
          :ref:`cObject <data-type-cobject>`
 
    Description
-         Same as :ref:`setup-page-headerData` above,
+         Same as :ref:`setup-page-headerData`,
          except that this block gets included at the bottom of the page
          (just before the closing :html:`</body>` tag).
 
@@ -699,8 +699,8 @@ includeJSLibs.[array]
    Description
          Adds JS library files to head of page.
 
-         Same as :ref:`includeJSLibs <setup-page-includejslibs-array>`, except that this block gets
-         included at the bottom of the page (just before the closing :html:`</body>`
+         Same as :ref:`includeJSFooterLibs <setup-page-includejsfooterlibs-array>`, except that this block gets
+         included inside :html:`<head>`.
          tag).
 
 
@@ -790,7 +790,7 @@ jsFooterInline.[array]
          :ref:`cObject <data-type-cobject>`
 
    Description
-         Same :ts:`jsInline` above, except that the JavaScript gets inserted at the
+         Same :ts:`jsInline`, except that the JavaScript gets inserted at the
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.


### PR DESCRIPTION
The "same as includeJSLibs" pointed to itself. "Above" was not always pointing to something above but rather below.