### PR TITLE
Corrcted Example, colPos is not in .select

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -586,9 +586,9 @@ dataProcessing
             # + stdWrap
             table = tt_address
 
-            # All properties from .select can be used directly
+            # All properties from .select :ref:`select` can be used directly
             # + stdWrap
-            colPos = 1
+            orderBy = sorting
             pidInList = 13,14
 
             # The target variable to be handed to the ContentObject again, can


### PR DESCRIPTION
There is no such thing as colPos in .select, see https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/Functions/Select.html for Reference