### PR TITLE
Remove out of date information about the scope of the `backend` symfony expression

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -218,7 +218,7 @@ backend
    Object
 
 :aspect:`Description`
-   Object with backend information (available in BE only).
+   Object with backend information.
 
 .. _condition-backend-user:
 


### PR DESCRIPTION
Due to https://review.typo3.org/c/Packages/TYPO3.CMS/+/63752 the statement `available in BE only` is not true anymore