### PR TITLE
Remove message_page_is_being_generated

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -75,7 +75,6 @@ Properties
    `language\_alt`_                                      :ref:`data-type-string`
    `linkVars`_                                           :ref:`data-type-list`
    `locale\_all`_                                        :ref:`data-type-string`
-   `message\_page\_is\_being\_generated`_                :ref:`data-type-string`
    `message\_preview`_                                   :ref:`data-type-string`
    `message\_preview\_workspace`_                        :ref:`data-type-string`
    `metaCharset`_                                        :ref:`data-type-string`                            utf-8
@@ -1640,31 +1639,6 @@ locale\_all
 
             locale_all = danish
             locale_all = da_DK
-
-
-.. _setup-config-message-page-is-being-generated:
-
-message\_page\_is\_being\_generated
-===================================
-
-.. container:: table-row
-
-   Property
-         message\_page\_is\_being\_generated
-
-   Data type
-         :ref:`data-type-string`
-
-   Description
-         Alternative HTML message that appears if a page is being generated.
-
-         Normally when a page is being generated a temporary copy is stored in
-         the cache-table with an expire-time of 30 seconds.
-
-         It is possible to use some keywords that are replaced with the
-         corresponding values. Possible keywords are: ###TITLE###,
-         ###REQUEST\_URI###
-
 
 
 .. _setup-config-message-preview:


### PR DESCRIPTION
This key was removed with https://forge.typo3.org/issues/87980.