### PR TITLE
Add hint for 32bit operating systems

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -310,7 +310,7 @@ cssInline.[array]
    Description
          Allows to add inline CSS to the page :html:`<head>` section.
          The :ts:`cssInline` property contains any number of numeric keys, each representing one cObject.
-         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
+         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
 
    Example
          ::
@@ -347,7 +347,7 @@ footerData.[array]
          (just before the closing :html:`</body>` tag).
 
          The :ts:`footerData` property contains any number of numeric keys, each representing one cObject.
-         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
+         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
 
    Example
          ::
@@ -388,7 +388,7 @@ headerData.[array]
          By default, gets inserted after all the style definitions.
 
          The :ts:`headerData` property contains any number of numeric keys, each representing one cObject.
-         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
+         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
 
    Example
          ::
@@ -797,7 +797,7 @@ jsFooterInline.[array]
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.
-         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
+         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
 
    Example
          ::
@@ -830,7 +830,7 @@ jsInline.[array]
          to an external file.
 
          The :ts:`jsInline` property contains any number of numeric keys, each representing one cObject.
-         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
+         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
 
    Example
          ::

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -310,7 +310,7 @@ cssInline.[array]
    Description
          Allows to add inline CSS to the page :html:`<head>` section.
          The :ts:`cssInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
    Example
          ::
@@ -347,7 +347,7 @@ footerData.[array]
          (just before the closing :html:`</body>` tag).
 
          The :ts:`footerData` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
    Example
          ::
@@ -388,7 +388,7 @@ headerData.[array]
          By default, gets inserted after all the style definitions.
 
          The :ts:`headerData` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
    Example
          ::
@@ -797,7 +797,7 @@ jsFooterInline.[array]
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
    Example
          ::
@@ -830,7 +830,7 @@ jsInline.[array]
          to an external file.
 
          The :ts:`jsInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
    Example
          ::

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -310,6 +310,7 @@ cssInline.[array]
    Description
          Allows to add inline CSS to the page :html:`<head>` section.
          The :ts:`cssInline` property contains any number of numeric keys, each representing one cObject.
+         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
 
    Example
          ::
@@ -346,6 +347,7 @@ footerData.[array]
          (just before the closing :html:`</body>` tag).
 
          The :ts:`footerData` property contains any number of numeric keys, each representing one cObject.
+         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
 
    Example
          ::
@@ -386,6 +388,7 @@ headerData.[array]
          By default, gets inserted after all the style definitions.
 
          The :ts:`headerData` property contains any number of numeric keys, each representing one cObject.
+         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
 
    Example
          ::
@@ -794,6 +797,7 @@ jsFooterInline.[array]
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.
+         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
 
    Example
          ::
@@ -826,6 +830,7 @@ jsInline.[array]
          to an external file.
 
          The :ts:`jsInline` property contains any number of numeric keys, each representing one cObject.
+         The numeric key should not exceed 2147483647 to prevent problems on 32bit operating systems.
 
    Example
          ::

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -310,7 +310,7 @@ cssInline.[array]
    Description
          Allows to add inline CSS to the page :html:`<head>` section.
          The :ts:`cssInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
 
    Example
          ::
@@ -347,7 +347,7 @@ footerData.[array]
          (just before the closing :html:`</body>` tag).
 
          The :ts:`footerData` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
 
    Example
          ::
@@ -388,7 +388,7 @@ headerData.[array]
          By default, gets inserted after all the style definitions.
 
          The :ts:`headerData` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
 
    Example
          ::
@@ -797,7 +797,7 @@ jsFooterInline.[array]
          bottom of the page (just before the closing :html:`</body>` tag).
 
          The :ts:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
 
    Example
          ::
@@ -830,7 +830,7 @@ jsInline.[array]
          to an external file.
 
          The :ts:`jsInline` property contains any number of numeric keys, each representing one cObject.
-         Internally handled as PHP integer, maximum number is therefore restricted to `PHP_INT_MAX`
+         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`
 
    Example
          ::


### PR DESCRIPTION
In `typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php` `cObjGet()` filters and sorts the array keys with `filterAndSortByNumericKeys()` and the help of `MathUtility::canBeInterpretedAsInteger()`.

This is done by a type cast to `int` and a comparison with the original key. This type cast fails with numbers greater than `2147483647` on 32bit operation systems. Yes, there are still web hosting companies out there with 32bit operation systems!