### PR TITLE
[BUGFIX] Remove FILE from snippet

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -104,8 +104,7 @@ template
 
    Use this property to define a content object, which should be used as
    template file. It is an alternative to ".file"; if ".template" is set, it
-   takes precedence. While any content object can be used here, the cObject
-   :ref:`FILE <cobj-file>` might be the usual choice.
+   takes precedence.
 
 
 .. _cobj-fluidtemplate-properties-file:
@@ -926,8 +925,10 @@ You could use it with a TypoScript code like this:
    page = PAGE
    page.10 = FLUIDTEMPLATE
    page.10 {
-      template = FILE
-      template.file = EXT:site_default/Resources/Private/Templates/MyTemplate.html
+      templateName = MyTemplate
+      templateRootPaths {
+            10 = EXT:site_default/Resources/Private/Templates
+         }
       partialRootPath = EXT:site_default/Resources/Private/Partials/
       variables {
          mylabel = TEXT

--- a/Documentation/ContentObjects/Template/Index.rst
+++ b/Documentation/ContentObjects/Template/Index.rst
@@ -1,5 +1,7 @@
 .. include:: ../../Includes.txt
 
+.. todo:: Remove this for TYPO3 11: typo3/sysext/core/Documentation/Changelog/master/Breaking-91562-CObjectTEMPLATERemoved.rst
+
 
 .. _cobj-template:
 
@@ -7,9 +9,12 @@
 TEMPLATE
 ========
 
-.. tip::
+.. warning::
 
   It is recommended to use :ref:`cobj-fluidtemplate` instead of TEMPLATE.
+
+  TEMPLATE will be removed in TYPO3 11.
+
   FLUIDTEMPLATE combines Fluid templates with TypoScript. This works very
   similar to TEMPLATE.
 
@@ -17,6 +22,7 @@ With an object of type TEMPLATE you can define a template (e.g. an HTML file) wh
 should be used as a basis for your whole website. Inside the template
 file you can define markers, which later will be replaced with dynamic
 content by TYPO3.
+
 
 .. ### BEGIN~OF~TABLE ###
 
@@ -29,20 +35,15 @@ content by TYPO3.
          :ref:`cObject <data-type-cobject>`
 
    Description
-         This must be loaded with the template-code. Usually this is done
-         with a :ref:`FILE cObject <cobj-file>`. If it is not loaded with
-         code, the object returns nothing.
+         This must be loaded with the template-code.
 
-         **Example:** ::
+         .. warning::
 
-            page.10 = TEMPLATE
-            page.10 {
-               template = FILE
-               template.file = fileadmin/template.html
-            }
+            The content object type :typoscript:`FILE` was deprecated in TYPO3 9
+            and removed in TYPO3 10. The previously used method of loading the
+            template using a :typoscript:`FILE` object will no longer work!
 
-         This will use the file fileadmin/template.html as template for your
-         website.
+            See :doc:`t3core:Changelog/9.5/Deprecation-85970-FileContentObject`
 
 
 .. container:: table-row

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -321,9 +321,6 @@ cssInline.[array]
 
                 20 = TEXT
                 20.value = h1 span {color: blue;}
-
-                30 = FILE
-                30.file = EXT:mysite/Resources/Public/StyleSheets/styles.css
             }
 
 


### PR DESCRIPTION
FILE has been deprecated since TYPO3 9. Remove FILE from code snippets
and use alternatives.

Also, add warning to TEMPLATE that it will be removed in TYPO3 11

Resolves: #313
Related: #314
Releases: master, 10.4, 9.5