### PR TITLE
Add example to request.getQueryParams with check if query param is de…

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -617,9 +617,15 @@ request.getQueryParams()
       Value: ``1``
 
 :aspect:`Example`
-   ::
+   Check if query parameter skipSessionUpdate equals 1::
 
       [request.getQueryParams()['skipSessionUpdate'] == 1]
+      
+   Safely check query parameter array to avoid error logs in case key is not
+   defined (see :ref:`condition-function-traverse`). This will check if
+   `tx_news_pi1['news'] > 0`::
+   
+      [traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0]
 
 .. _condition-function-request-getParsedBody():
 


### PR DESCRIPTION
Add an example to request.getQueryParams with check if query param is defined

Releases: master, 10.4, 9.5