### PR TITLE
Rephrase description of 'includeNotInMenu'

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -305,7 +305,7 @@ into account.
          boolean /:ref:`stdWrap <stdwrap>`
 
    Description
-         If set, pages with the checkbox "Not in menu" checked will be included
+         If set, pages with the checkbox "Page enabled in menus" disabled will still be included
          in menus.
 
 


### PR DESCRIPTION
Making it more clear which checkbox is meant by providing the exact name from the backend.