### PR TITLE
Bugfix: name extTarget correctly

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -47,7 +47,7 @@ Output:
 
 .. _typolink-extTarget:
 
-target
+extTarget
 ======
 
 :aspect:`Property`


### PR DESCRIPTION
This one drove me crazy. :) The property is named `target` but it is ought to be `extTarget` 