### PR TITLE
Do not list "request" function as working in all contexts

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -490,11 +490,11 @@ typo3.devIpMask
 
 .. _condition-functions-in-all-contexts:
 
-Functions in all contexts
+Functions in frontend and backend context
 -------------------------
 
 Functions take over the logic of the old conditions which do more than a simple comparison check.
-The following functions are available in **any** context:
+The following functions are available in frontend and backend context, but not CLI.
 
 .. _condition-function-request:
 
@@ -747,6 +747,12 @@ request.getPageArguments()
    
    Allows migration from old condition syntax using `[globalVar = GP:singlepartner > 0]`
    to `[request.getPageArguments().get('singlepartner') > 0]`.
+   
+   
+Functions in all contexts
+-------------------------
+
+The following functions are available in **all** contexts: frontend, backend and CLI
 
 .. _condition-function-date:
 

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -494,7 +494,7 @@ Functions in frontend and backend context
 -------------------------
 
 Functions take over the logic of the old conditions which do more than a simple comparison check.
-The following functions are available in frontend and backend context, but not CLI.
+The following functions are available in frontend and backend context, but not CLI:
 
 .. _condition-function-request:
 

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -752,7 +752,7 @@ request.getPageArguments()
 Functions in all contexts
 -------------------------
 
-The following functions are available in **all** contexts: frontend, backend and CLI
+The following functions are available in **any** context:
 
 .. _condition-function-date:
 

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -491,7 +491,7 @@ typo3.devIpMask
 .. _condition-functions-in-all-contexts:
 
 Functions in frontend and backend context
--------------------------
+-----------------------------------------
 
 Functions take over the logic of the old conditions which do more than a simple comparison check.
 The following functions are available in frontend and backend context, but not CLI:


### PR DESCRIPTION
Request does not work in CLI context, so it shouldn't be listed under "available in all contexts". I didn't test whether the other functions listed there work in CLI context but at least we have one improvement.

Also see https://forge.typo3.org/issues/91654