### PR TITLE
[TASK] Remove addQueryString.method

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -1473,7 +1473,6 @@ Creates a language menu:
          additionalParams = &L=0 || &L=1 || &L=2
          addQueryString = 1
          addQueryString.exclude = L,id
-         addQueryString.method = GET
      }
    }
 

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -183,18 +183,6 @@ addQueryString
    not check for any duplicate parameters! This is not a problem: Only
    the last parameter of the same name will be applied.
 
-   .method
-      If set to GET or POST, then the parsed query arguments
-      (GET or POST data) will be used. This setting is useful, if you use
-      URL processing extensions like Real URL, which translate part of the
-      path into query arguments.
-
-      It's also possible to get both, POST and GET data, on setting this to
-
-      "POST,GET" or "GET,POST". The last method in this sequence takes
-      precedence and overwrites the parts that are also present for the
-      first method.
-
    .exclude
       List of query arguments to exclude from the link. Typical examples
       are 'L' or 'cHash'.
@@ -203,7 +191,7 @@ addQueryString
 
       This property should not be used for cached contents without a valid
       cHash. Otherwise the page is cached for the first set of parameters
-      and subsubsequently taken from the cache no matter what parameters
+      and subsequently taken from the cache no matter what parameters
       are given. Additionally the security risk of cache poisoning has to
       be considered.
 


### PR DESCRIPTION
See https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Breaking-93041-RemoveTypoScriptOptionAddQueryStringmethod.html
See https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1082
