### PR TITLE
add example with page id

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1141,6 +1141,10 @@ getTSFE
 
       [getTSFE().type == 98]
 
+   Current page id equals to 17. :ref:`PAGE`::
+
+      [getTSFE().id == 17]
+
 
 .. index:: Conditions; getenv
 .. _condition-function-getenv:

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1141,7 +1141,7 @@ getTSFE
 
       [getTSFE().type == 98]
 
-   Current page id equals to 17. :ref:`PAGE`::
+   Current page id equals to 17. However the recommended way is with :ref:`_condition-page`::
 
       [getTSFE().id == 17]
 

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1141,7 +1141,7 @@ getTSFE
 
       [getTSFE().type == 98]
 
-   Current page id equals to 17. However the recommended way is with :ref:`condition-page`::
+   Current page id equals to 17. However, :ref:`condition-page` should be preferred::
 
       [getTSFE().id == 17]
 

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1141,7 +1141,7 @@ getTSFE
 
       [getTSFE().type == 98]
 
-   Current page id equals to 17. However the recommended way is with :ref:`_condition-page`::
+   Current page id equals to 17. However the recommended way is with :ref:`condition-page`::
 
       [getTSFE().id == 17]
 


### PR DESCRIPTION
Only one member variable of $TSFE is listed.
Where should the other parts of $TSFE be described?


---------

    /**
     * The page id (int)
     * @var string
     */
    public $id = '';

    /**
     * The type (read-only)
     * @var int|string
     */
    public $type = '';

    /**
    /**
     * Page will not be cached. Write only TRUE. Never clear value (some other
     * code might have reasons to set it TRUE).
     * @var bool
     */
    public $no_cache = false;

    /**
     * The rootLine (all the way to tree root, not only the current site!)
     * @var array
     */
    public $rootLine = [];

    /**
     * The pagerecord
     * @var array
     */
    public $page = [];

    /**
     * This will normally point to the same value as id, but can be changed to
     * point to another page from which content will then be displayed instead.
     * @var int
     */
    public $contentPid = 0;
