### PR TITLE
Mention traverse() result on missing array entry

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1005,13 +1005,15 @@ traverse
    Custom
 
 :aspect:`Description`
-   This function has two parameters:
+   This function gets a value from an array with arbitrary depth. It has two parameters:
 
    The first parameter
       Is the array to traverse
 
    The second parameter
       Is the path to traverse
+   
+   In case the path is not found in the array, an empty string is returned.
 
 :aspect:`Example`
    Traverse query parameters of current request along ``tx_news_pi1[news]``::


### PR DESCRIPTION
Releases: master, 10.4, 9.5

Source: https://github.com/TYPO3/TYPO3.CMS/blob/10.4/typo3/sysext/core/Classes/ExpressionLanguage/FunctionsProvider/DefaultFunctionsProvider.php#L128