### PR TITLE
add .after and .afterWrap properties

### DIFF
--- a/Documentation/MenuObjects/Tmenuitem/Index.rst
+++ b/Documentation/MenuObjects/Tmenuitem/Index.rst
@@ -76,8 +76,27 @@ stdWrap.data = field : [field name].
 
    Description
          wrap around the ".before"-code
+         
+.. container:: table-row
+
+   Property
+         after
+
+   Data type
+         HTML /:ref:`stdWrap <stdwrap>`
 
 
+.. container:: table-row
+
+   Property
+         afterWrap
+
+   Data type
+         wrap
+
+   Description
+         wrap around the ".after"-code         
+         
 .. container:: table-row
 
    Property


### PR DESCRIPTION
Add description to .after and .afterWrap properties (that seemed absent in documentation since 4.5?)  in order to solve https://forge.typo3.org/issues/91965

Please review it! I am not sure if I put them in the correct place that respects the TypoScript execution order!

Please backport it if you want