### PR TITLE
[TASK] Recommend using traverse() to avoid errors

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1393,8 +1393,7 @@ site
 .. warning::
    It might seem straight-forward to use `site("configuration")["myCustomProperty"]` to access 
    configuration properties. However, if the property has not been set, this will trigger a runtime
-   exception, and your log will fill up quickly. Using `traverse()` will silence the error messages:
-   `traverse(site("configuration"), "myCustomProperty")`.
+   exception, and your log will fill up quickly. Using :ref:`condition-function-traverse` will silence the error messages.
 
 .. index:: Conditions; siteLanguage
 .. _condition-functions-in-frontend-context-function-siteLanguage:

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1388,8 +1388,13 @@ site
 
    Configuration property::
 
-      [site("configuration")["enabled"] == true]
+      [traverse(site("configuration"), "myCustomProperty") == true]
 
+.. warning::
+   It might seem straight-forward to use `site("configuration")["myCustomProperty"]` to access 
+   configuration properties. However, if the property has not been set, this will trigger a runtime
+   exception, and your log will fill up quickly. Using `traverse()` will silence the error messages:
+   `traverse(site("configuration"), "myCustomProperty")`.
 
 .. index:: Conditions; siteLanguage
 .. _condition-functions-in-frontend-context-function-siteLanguage:


### PR DESCRIPTION
The documentation was recommending `site("configuration")["myCustomProperty"]` to access  configuration properties in TypoScript conditions. However, if the property has not been set, this will trigger a runtime exception, and your log will fill up quickly. Using `traverse()` will silence the error messages: `traverse(site("configuration"), "myCustomProperty")`.

Releases: master, 10.4