### PR TITLE
Fix link in DatabaseQueryProcessor

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -51,7 +51,7 @@ Options:
 
 .. note:: all other options will be interpreted as in the TypoScript function
    "select", including :typoscript:`pidInList`, :typoscript:`orderBy`,
-   :typoscript:`where` etc. See the reference of ref:`select`.
+   :typoscript:`where` etc. See the reference of :ref:`select`.
 
 
 Example: Display haiku records


### PR DESCRIPTION
See the link "select" in the "Note" box:
https://docs.typo3.org/m/typo3/reference-typoscript/master/en-us/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.html#confval-dataProcessing