### PR TITLE
fix addQueryString option in HMENU language

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -1518,6 +1518,7 @@ Creates a language menu:
          parameter.data = page:uid
          additionalParams = &L=0 || &L=1 || &L=2
          addQueryString = 1
+         addQueryString.method = GET
          addQueryString.exclude = L,id
      }
    }


### PR DESCRIPTION
addQueryString.method needs to be set to GET to properly work in the language menu, at least in v10
Without it, no params are added to the link