### PR TITLE
Add note for pidInList validation

### DIFF
--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -154,7 +154,18 @@ pidInList
       Allows to disable the :sql:`pid` constraint completely. Requirements: 
       :ts:`uidInList` *must* be set or the table *must* have the prefix 
       "static\_\*".
+      
+   .. note::
+      Check the doktype of your backend page. If you are trying to fetch records from
+      e.g. a folder, the :php:`$cObj->checkPid_badDoktypeList` method will insert the
+      following SQL into your query:
 
+      .. code-block:: sql
+
+      [...]WHERE (`your_requested_table_name`.`uid` = 0) AND [...]
+
+      Which will always result in an empty query result!
+   
 :aspect:`Default`
    :ts:`this`
 

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -157,14 +157,14 @@ pidInList
       
    .. note::
       Check the doktype of your backend page. If you are trying to fetch records from
-      e.g. a folder, the :php:`$cObj->checkPid_badDoktypeList` method will insert the
+      e.g. a sys_folder, the :php:`$cObj->checkPid_badDoktypeList` method will insert the
       following SQL into your query:
 
       .. code-block:: sql
 
       [...]WHERE (`your_requested_table_name`.`uid` = 0) AND [...]
 
-      Which will always result in an empty query result!
+      Which might result in an empty query result, depending on your records.
    
 :aspect:`Default`
    :ts:`this`

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -157,7 +157,7 @@ pidInList
       
    .. note::
       Check the doktype of your backend page. If you are trying to fetch records from
-      e.g. a sys_folder, the :php:`$cObj->checkPid_badDoktypeList` method will insert the
+      a sys_folder for example, the :php:`$cObj->checkPid_badDoktypeList` method will insert the
       following SQL into your query:
 
       .. code-block:: sql


### PR DESCRIPTION
When I worked with this property, I always got the line 
```sql
(`<table_name>`.`uid`= 0)
``` 
inserted into my query and it took me a long time to figure out, where this statement was from.
When you specify a bad doktype page id, which does not meet the criteria for [this method](https://github.com/TYPO3/TYPO3.CMS/blob/10.4/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php#L6765), the line is inserted.

Please add more notes like these.