### PR TITLE
[TASK] Adjust default HMENU excludeDoktypes configuration

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -295,11 +295,12 @@ Options
          list of integers
 
    Default
-         5,6
+         6,254
 
    Description
          Enter the list of page document types (doktype) to exclude from menus.
-         By default pages that are "backend user access only" (6) are excluded.
+         By default pages that are "backend user access only" (6) or "folder"
+         (254) are excluded.
 
 
 


### PR DESCRIPTION
The doktype 5 does not exist anymore. With TYPO3 v10
the folder was added to the default excludeDoktypes
configuration.

See also: https://github.com/TYPO3/typo3/blob/master/typo3/sysext/frontend/Classes/ContentObject/Menu/AbstractMenuContentObject.php#L66