### PR TITLE
[Deprecation] #95349 - TypoScript: page.includeCSS/includeCSSLibs.import

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -512,8 +512,8 @@ includeCSS.[array]
          .. deprecated:: 11.5
             The option to use the `@import` syntax for including external CSS
             files through TypoScript has been deprecated. It is recommended to use
-            the :html:`<link>` tag or create a inlineCSS TypoScript manually
-            to load such a file with the `@import` syntax.
+            the :html:`<link>` tag or instead create an inline CSS entry with TypoScript
+            to load a file with the `@import` syntax.
 
          **import**: If set (boolean) then the `@import` way of including a
          stylesheet is used instead of :html:`<link>`

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -593,8 +593,8 @@ includeCSSLibs.[array]
          .. deprecated:: 11.5
             The option to use the @import syntax for including external CSS
             files through TypoScript has been deprecated. It is recommended to use
-            the :html:`<link>` tag or create a inlineCSS TypoScript manually
-            to load such a file with the `@import` syntax.
+            the :html:`<link>` tag or instead create an inline CSS entry with TypoScript
+            to load a file with the `@import` syntax.
 
          **import**: If set (boolean) then the @import way of including a
          stylesheet is used instead of :html:`<link>`

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -509,6 +509,12 @@ includeCSS.[array]
          will not be included. Extensive usage might cause huge numbers of
          temporary files to be created. See ->if for details.
 
+         .. deprecated:: 11.5
+            The option to use the `@import` syntax for including external CSS
+            files through TypoScript has been deprecated. It is recommended to use
+            the :html:`<link>` tag or create a inlineCSS TypoScript manually
+            to load such a file with the `@import` syntax.
+
          **import**: If set (boolean) then the `@import` way of including a
          stylesheet is used instead of :html:`<link>`
 
@@ -583,6 +589,12 @@ includeCSSLibs.[array]
          evaluate to TRUE for the file to be included. If they do not evaluate
          to TRUE, the file will not be included. Extensive usage might cause
          huge numbers of temporary files to be created. See ->if for details.
+
+         .. deprecated:: 11.5
+            The option to use the @import syntax for including external CSS
+            files through TypoScript has been deprecated. It is recommended to use
+            the :html:`<link>` tag or create a inlineCSS TypoScript manually
+            to load such a file with the `@import` syntax.
 
          **import**: If set (boolean) then the @import way of including a
          stylesheet is used instead of :html:`<link>`


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/master/Deprecation-95349-TypoScriptPageincludeCSSincludeCSSLibsimport.html
refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1522