### PR TITLE
Deprecation: #95318 - TypoScript parseFunc.sword

### DIFF
--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -244,6 +244,13 @@ nonTypoTagUserFunc
 sword
 =====
 
+.. deprecated:: 11.5
+   This functionality has been marked as deprecated as this feature only works
+   in non_cached environments, which is not a recommended solution by TYPO3.
+
+   It is recommended to implement this functionality on the client-side via
+   JavaScript as a custom solution, when this feature is needed.
+
 :aspect:`Property`
    sword
 

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2137,6 +2137,13 @@ spamProtectEmailAddresses\_lastDotSubst
 sword\_noMixedCase
 ==================
 
+.. deprecated:: 11.5
+   This functionality has been marked as deprecated as this feature only works
+   in non_cached environments, which is not a recommended solution by TYPO3.
+
+   It is recommended to implement this functionality on the client-side via
+   JavaScript as a custom solution, when this feature is needed.
+
 .. container:: table-row
 
    Property
@@ -2157,6 +2164,14 @@ sword\_noMixedCase
 
 sword\_standAlone
 =================
+
+
+.. deprecated:: 11.5
+   This functionality has been marked as deprecated as this feature only works
+   in non_cached environments, which is not a recommended solution by TYPO3.
+
+   It is recommended to implement this functionality on the client-side via
+   JavaScript as a custom solution, when this feature is needed.
 
 .. container:: table-row
 


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/main/Deprecation-95318-TypoScriptParseFuncsword.html#deprecation-95318-typoscript-parsefunc-sword
references https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1522
references https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/495

releases: 11.5