### PR TITLE
Breaking: #96708 - Removed support for accesskeys in HMENU

### DIFF
--- a/Documentation/MenuObjects/Tmenu/Index.rst
+++ b/Documentation/MenuObjects/Tmenu/Index.rst
@@ -45,18 +45,6 @@ TMENU
 .. container:: table-row
 
    Property
-         accessKey
-
-   Data type
-         boolean
-
-   Description
-         If set access-keys are set on the menu-links
-
-
-.. container:: table-row
-
-   Property
          target
 
    Data type


### PR DESCRIPTION
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.0/Breaking-96708-RemovedSupportForAccesskeysInHMENU.html

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1624