### PR TITLE
Fixed spelling of "includeJSFooterlibs"

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -756,7 +756,7 @@ includeJSLibs.[array]
    Description
          Adds JS library files to head of page.
 
-         Same as :ref:`includeJSFooterLibs <setup-page-includejsfooterlibs-array>`, except that this block gets
+         Same as :ref:`includeJSFooterlibs <setup-page-includejsfooterlibs-array>`, except that this block gets
          included inside :html:`<head>`.
          tag).
 


### PR DESCRIPTION
In accordance with the core code base, "libs" in "includeJSFooterlibs" must be lowercase.