### PR TITLE
Indent code snippet correctly

### DIFF
--- a/Documentation/DataTypes/Properties/GetText.rst
+++ b/Documentation/DataTypes/Properties/GetText.rst
@@ -335,7 +335,7 @@ fullRootLine
       - Page tree root [-2]
       |- 1. page before [-1]
          |- Site root (root template here!) [0]
-         |- Here you are! [1]
+            |- Here you are! [1]
 
 
    A "slide" parameter can be added just as for the


### PR DESCRIPTION
In the example, "Here you are!" should be a subpage of "Site root"
- otherwise the description would be incorrect.