### PR TITLE
[TASK] #94956 - Use setContentObjectRenderer instead of public $cobj

### DIFF
--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -139,16 +139,17 @@ from TypoScript. Use this TypoScript configuration:
    page = PAGE
    page.10 = USER_INT
    page.10 {
-     userFunc = Vendor\ExtensionName\ExampleTime->printTime
+     userFunc = Vendor\SitePackage\UserFunctions\ExampleTime->printTime
    }
 
-The file typo3conf/ext/extension_name/Classes/ExampleTime.php might amongst other things
-contain:
+The file :file:`EXT:site_package/Classes/UserFunctions/ExampleTime.php` might
+amongst other things contain:
 
 .. code-block:: php
 
-   namespace Vendor\ExtensionName;
-   class ExampleTime {
+   namespace Vendor\SitePackage\UserFunctions;
+
+   final class ExampleTime {
      /**
       * Output the current time in red letters
       *
@@ -162,10 +163,10 @@ contain:
      }
    }
 
-Here page.10 will give back what the PHP function printTime()
-returned. Since we did not use a USER object, but a USER\_INT object,
-this function is executed on every page hit. So this example each time
-outputs the current time in red letters.
+Here :typoscript:`page.10` will give back what the PHP function :php:`printTime()`
+returned. Since we did not use a :typoscript:`USER` object, but a
+:typoscript:`USER_INT` object, this function is executed on every page hit.
+Thus, in this example, the current time is displayed in red letters each time.
 
 Example 2
 ---------
@@ -173,7 +174,7 @@ Example 2
 Now let us have a look at another example:
 
 We want to display all content element headers of a page in reversed
-order. To do that we use the following TypoScript:
+order. For this we use the following TypoScript:
 
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
@@ -183,17 +184,17 @@ order. To do that we use the following TypoScript:
 
    page.30 = USER
    page.30 {
-      userFunc = Vendor\ExtensionName\ExampleListRecords->listContentRecordsOnPage
+      userFunc = Vendor\SitePackage\UserFunctions\ExampleListRecords->listContentRecordsOnPage
       # reverseOrder is a boolean variable (see PHP code below)
       reverseOrder = 1
    }
 
-The file typo3conf/ext/extension_name/Classes/ExampleListRecords.php might amongst other
-things contain:
+The file :file:`EXT:site_package/Classes/UserFunctions/ExampleListRecords.php`
+might amongst other things contain:
 
 .. code-block:: php
 
-   namespace Vendor\ExtensionName;
+   namespace Vendor\SitePackage\UserFunctions;
 
    use TYPO3\CMS\Core\Database\ConnectionPool;
    use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -203,24 +204,30 @@ things contain:
     * Example of a method in a PHP class to be called from TypoScript
     *
     */
-   class ExampleListRecords {
-     /**
-      * Reference to the parent (calling) cObject set from TypoScript
-      *
-      * @var ContentObjectRenderer
-      */
-     public $cObj;
+   final class ExampleListRecords {
 
-     /**
-       * List the headers of the content elements on the page
+      /**
+       * Reference to the parent (calling) cObject set from TypoScript
        *
-       *
-       * @param	string		Empty string (no content to process)
-       * @param	array		TypoScript configuration
-       * @return	string		HTML output, showing content elements (in reverse order, if configured)
+       * @var ContentObjectRenderer
        */
-     public function listContentRecordsOnPage(string $content, array $conf): string
-     {
+      private $cObj;
+
+      public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
+      {
+         $this->cObj = $cObj;
+      }
+
+      /**
+        * List the headers of the content elements on the page
+        *
+        *
+        * @param  string Empty string (no content to process)
+        * @param  array  TypoScript configuration
+        * @return string HTML output, showing content elements (in reverse order, if configured)
+        */
+      public function listContentRecordsOnPage(string $content, array $conf): string
+      {
          $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
          $result = $connection->select(
              ['header'],
@@ -234,8 +241,12 @@ things contain:
              $output[] = $row['header'];
          }
          return implode($output, '<br />');
-     }
+      }
    }
+
+Since we need an instance of the :php:`ContentObjectRenderer` class, we are using
+the :php:`setContentObjectRenderer()` method to get it and store it in the
+:php:`cObj` class property for later use.
 
 :typoscript:`page.30` will give back what the function :php:`listContentRecordsOnPage()` of
 the class YourClass returned. This example returns some debug output
@@ -262,24 +273,24 @@ the local machine". You can make it available like this:
 
    page.20 = USER_INT
    page.20 {
-      userFunc = Vendor\ExtensionName\Hostname->getHostname
+      userFunc = Vendor\SitePackage\UserFunctions\Hostname->getHostname
    }
 
-Contents of :file:`typo3conf/ext/extension_name/Classes/Hostname.php`:
+Contents of :file:`EXT:site_package/Classes/UserFunctions/Hostname.php`:
 
 .. code-block:: php
 
-   namespace Vendor\ExtensionName;
+   namespace Vendor\SitePackage\UserFunctions;
 
-      class Hostname {
-         /**
-          * Return standard host name for the local machine
-          *
-          * @param  string          Empty string (no content to process)
-          * @param  array           TypoScript configuration
-          * @return string          HTML result
-          */
-         public function getHostname(string $content, array $conf): string
+   final class Hostname {
+      /**
+       * Return standard host name for the local machine
+       *
+       * @param  string Empty string (no content to process)
+       * @param  array  TypoScript configuration
+       * @return string HTML result
+       */
+      public function getHostname(string $content, array $conf): string
          {
             return gethostname() ?: '';
          }

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -281,6 +281,7 @@ the local machine". You can make it available like this:
 Contents of :file:`EXT:site_package/Classes/UserFunctions/Hostname.php`:
 
 .. code-block:: php
+   :caption: EXT:site_package/Classes/UserFunctions/Hostname.php
 
    namespace Vendor\SitePackage\UserFunctions;
 

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -194,6 +194,7 @@ The file :file:`EXT:site_package/Classes/UserFunctions/ExampleListRecords.php`
 might amongst other things contain:
 
 .. code-block:: php
+   :caption: EXT:site_package/Classes/UserFunctions/ExampleListRecords.php
 
    namespace Vendor\SitePackage\UserFunctions;
 

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -146,6 +146,7 @@ The file :file:`EXT:site_package/Classes/UserFunctions/ExampleTime.php` might
 amongst other things contain:
 
 .. code-block:: php
+   :caption:  EXT:site_package/Classes/UserFunctions/ExampleTime.php
 
    namespace Vendor\SitePackage\UserFunctions;
 

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -191,7 +191,7 @@ order. For this we use the following TypoScript:
    }
 
 The file :file:`EXT:site_package/Classes/UserFunctions/ExampleListRecords.php`
-might amongst other things contain:
+may contain amongst other things:
 
 .. code-block:: php
    :caption: EXT:site_package/Classes/UserFunctions/ExampleListRecords.php

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -1827,14 +1827,14 @@ postUserFunc
       page.10 = TEXT
       page.10 {
          value = Hello World!
-         stdWrap.postUserFunc = Your\NameSpace\YourClass->reverseString
+         stdWrap.postUserFunc = Vendor\SitePackage\UserFunctions\YourClass->reverseString
          stdWrap.postUserFunc.uppercase = 1
       }
 
       page.20 = TEXT
       page.20 {
          value = Hello World!
-         stdWrap.postUserFunc = Your\NameSpace\YourClass->reverseString
+         stdWrap.postUserFunc = Vendor\SitePackage\UserFunctions\YourClass->reverseString
          stdWrap.postUserFunc.uppercase = 1
          stdWrap.postUserFunc.typolink = 11
       }
@@ -1846,51 +1846,59 @@ postUserFunc
       :caption: EXT:site_package/Classes/UserFunctions/YourClass.php
 
       namespace Vendor\SitePackage\UserFunctions;
+
       /**
-         * Example of a method in a PHP class to be called from TypoScript
-         *
-         */
-      class YourClass
+       * Example of a method in a PHP class to be called from TypoScript
+       */
+      final class YourClass
       {
-         /**
-         * Reference to the parent (calling) cObject set from TypoScript
-         */
-         public $cObj;
+         /*
+          * Reference to the parent (calling) cObject set from TypoScript
+          *
+          * @var ContentObjectRenderer
+          */
+         private $cObj;
+
+         public function setContentObjectRenderer(ContentObjectRenderer $cObj): void
+         {
+             $this->cObj = $cObj;
+         }
 
          /**
-         * Custom method for data processing. Also demonstrates how this gives us the ability to use methods in the parent object.
-         *
-         * @param	string		When custom methods are used for data processing (like in stdWrap functions), the $content variable will hold the value to be processed. When methods are meant to just return some generated content (like in USER and USER_INT objects), this variable is empty.
-         * @param	array		TypoScript properties passed to this method.
-         * @return	string	The input string reversed. If the TypoScript property "uppercase" was set, it will also be in uppercase. May also be linked.
-         */
-         public function reverseString($content, $conf)
+          * Custom method for data processing. Also demonstrates how this gives us the
+          * ability to use methods in the parent object.
+          *
+          * @param  string When custom methods are used for data processing (like in stdWrap functions), the $content variable will hold the value to be processed. When methods are meant to just return some generated content (like in USER and USER_INT objects), this variable is empty.
+          * @param  array  TypoScript properties passed to this method.
+          * @return string The input string reversed. If the TypoScript property "uppercase" was set, it will also be in uppercase. May also be linked.
+          */
+         public function reverseString(string $content, array $conf): string
          {
             $content = strrev($content);
             if (isset($conf['uppercase']) && $conf['uppercase'] === '1') {
-            // Use the method caseshift() from ContentObjectRenderer.php.
-            $content = $this->cObj->caseshift($content, 'upper');
+               // Use the method caseshift() from ContentObjectRenderer
+               $content = $this->cObj->caseshift($content, 'upper');
             }
             if (isset($conf['typolink'])) {
-            // Use the method typoLink() from ContentObjectRenderer.php.
-            $content = $this->cObj->typoLink($content, ['parameter' => $conf['typolink']]);
+               // Use the method typoLink() from ContentObjectRenderer
+               $content = $this->cObj->typoLink($content, ['parameter' => $conf['typolink']]);
             }
             return $content;
          }
       }
 
-   For :typoscript:`page.10` the content, which is present when :typoscript:`postUserFunc` is
-   executed, will be given to the PHP function
-   :php:`reverseString()`. The result will be "!DLROW OLLEH".
+   For :typoscript:`page.10` the content, which is present when
+   :typoscript:`postUserFunc` is executed, will be given to the PHP function
+   :php:`reverseString()`. The result will be `!DLROW OLLEH`.
 
    The content of :typoscript:`page.20` will be processed by the function
    :php:`reverseString()` from the class :php:`YourClass`. This also returns
-   the text "!DLROW OLLEH", but wrapped into a link to the page
-   with the ID 11. The result will be :html:`<a href="index.php?id=11">!DLROW OLLEH</a>`.
+   the text `!DLROW OLLEH`, but wrapped into a link to the page with the ID 11.
+   The result will be :html:`<a href="/path/to/page/id/11">!DLROW OLLEH</a>`.
 
-   Note how in the second example :php:`$cObj`, the reference to the
+   Note how in the second example :php:`$this->cObj`, the reference to the
    calling :typoscript:`cObject`, is utilised to use functions from
-   :file:`ContentObjectRenderer.php`!
+   :php:`ContentObjectRenderer` class!
 
 
 .. index:: stdWrap; postUserFuncInt


### PR DESCRIPTION
See: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Deprecation-94956-PublicCObj.html

Additional changes:
- Adjust the extension name and namespace of the examples to be
  in sync with the caption of the code blocks
- Add some syntax highlighting where appropriate
- Declare classes as final as best practise

Releases: main, 11.5