### PR TITLE
Remove Flash fallback hint

### DIFF
--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -7,9 +7,7 @@ SVG
 ===
 
 With this object type you can insert a SVG. You can use XML data directly
-or reference a file. A flash fallback will be used for browsers which
-do not have native SVG support, so that it also works in e.g. IE
-6/7/8.
+or reference a file. 
 
 .. ### BEGIN~OF~TABLE ###
 


### PR DESCRIPTION
Adobe Flash does not exist anymore. Thus, no we don’t support Flash.
https://www.adobe.com/products/flashplayer/end-of-life.html

Lolli: flash svg fallback has been removed from core codebase in 2015 with https://review.typo3.org/c/Packages/TYPO3.CMS/+/38089/