### PR TITLE
Unify layout of all ContentObjects Part 1

### DIFF
--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -26,8 +26,56 @@ be used as it has a special meaning: If the value of the "key"
 property is *not* found in the array of cObjects, then the cObject
 from the "default" property will be used.
 
+.. contents::
+   :local:
 
 .. ### BEGIN~OF~TABLE ###
+
+Properties
+==========
+
+
+1,2,3,4...
+------------
+
+.. container:: table-row
+
+   Property
+         *(array of cObjects)*
+
+   Data type
+         :ref:`cObject <data-type-cobject>`
+
+   Description
+         Array of cObjects. Use this to define cObjects for the different
+         values of "key". If "key" has a certain value, the according
+         cObject will be rendered. The cObjects can have any name, but not
+         the names of the other properties of the cObject CASE.
+
+cache
+-----
+
+.. include:: /DataTypes/Properties/Cache.rst.txt
+
+default
+-------
+
+.. container:: table-row
+
+   Property
+         default
+
+   Data type
+         :ref:`cObject <data-type-cobject>`
+
+   Description
+         Use this to define the rendering for *those* values of "key" that
+         do *not* match any of the values of the "array of cObjects". If no
+         default cObject is defined, an empty string will be returned for
+         the default case.
+
+if
+--
 
 .. container:: table-row
 
@@ -40,18 +88,8 @@ from the "default" property will be used.
    Description
          If "if" returns false, nothing is returned.
 
-
-.. container:: table-row
-
-   Property
-         setCurrent
-
-   Data type
-         string /:ref:`stdWrap <stdwrap>`
-
-   Description
-         Sets the "current"-value.
-
+key
+---
 
 .. container:: table-row
 
@@ -77,36 +115,22 @@ from the "default" property will be used.
    Default
          default
 
+setCurrent
+----------
 
 .. container:: table-row
 
    Property
-         *(array of cObjects)*
+         setCurrent
 
    Data type
-         :ref:`cObject <data-type-cobject>`
+         string /:ref:`stdWrap <stdwrap>`
 
    Description
-         Array of cObjects. Use this to define cObjects for the different
-         values of "key". If "key" has a certain value, the according
-         cObject will be rendered. The cObjects can have any name, but not
-         the names of the other properties of the cObject CASE.
+         Sets the "current"-value.
 
-
-.. container:: table-row
-
-   Property
-         default
-
-   Data type
-         :ref:`cObject <data-type-cobject>`
-
-   Description
-         Use this to define the rendering for *those* values of "key" that
-         do *not* match any of the values of the "array of cObjects". If no
-         default cObject is defined, an empty string will be returned for
-         the default case.
-
+stdWrap
+-------
 
 .. container:: table-row
 
@@ -119,8 +143,6 @@ from the "default" property will be used.
    Description
          stdWrap around any object that was rendered no matter what the "key"
          value is.
-
-.. include:: ../../DataTypes/Properties/Cache.rst.txt
 
 .. ###### END~OF~TABLE ######
 

--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -34,9 +34,8 @@ from the "default" property will be used.
 Properties
 ==========
 
-
-1,2,3,4...
-------------
+(array of cObjects)
+-------------------
 
 .. container:: table-row
 

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -131,7 +131,7 @@ Examples:
    }
 
 The previous example will print a simple :html:`<h1>` header, followed by the page
-content records and a footer element.
+content records and a :html:`footer` element.
 
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -130,7 +130,7 @@ Examples:
      30.value = <footer>Footer text</footer>
    }
 
-The previous example will print a simple h1 header, followed by the page
+The previous example will print a simple :html:`<h1>` header, followed by the page
 content records and a footer element.
 
 .. code-block:: typoscript

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -28,20 +28,16 @@ rendered non-cached! That way you cannot only render non-cached
 :ref:`USER_INT <cobj-user-int>` objects, but COA\_INT allows
 you to render *every* cObject non-cached.
 
+.. contents::
+   :local:
 
 .. ### BEGIN~OF~TABLE ###
 
-.. container:: table-row
+Properties
+==========
 
-   Property
-         if
-
-   Data type
-         :ref:`->if <if>`
-
-   Description
-         If "if" returns false, the COA is **not** rendered.
-
+1,2,3,4...
+-----------
 
 .. container:: table-row
 
@@ -55,15 +51,27 @@ you to render *every* cObject non-cached.
          Numbered properties to define the different cObjects, which should be
          rendered.
 
+cache
+-----
+
+.. include:: ../../DataTypes/Properties/Cache.rst.txt
+
+if
+--
 
 .. container:: table-row
 
    Property
-         wrap
+         if
 
    Data type
-         :ref:`wrap <data-type-wrap>` /:ref:`stdWrap <stdwrap>`
+         :ref:`->if <if>`
 
+   Description
+         If "if" returns false, the COA is **not** rendered.
+
+stdWrap
+-------
 
 .. container:: table-row
 
@@ -73,7 +81,22 @@ you to render *every* cObject non-cached.
    Data type
          :ref:`->stdWrap <stdwrap>`
 
-.. include:: ../../DataTypes/Properties/Cache.rst.txt
+   Description
+         Executed on all rendered cObjects after property wrap.
+
+wrap
+-----
+
+.. container:: table-row
+
+   Property
+         wrap
+
+   Data type
+         :ref:`wrap <data-type-wrap>` /:ref:`stdWrap <stdwrap>`
+
+   Description
+         Wraps all rendered cObjects. Executed before property stdWrap.
 
 .. ###### END~OF~TABLE ######
 
@@ -107,7 +130,8 @@ Examples:
      30.value = <footer>Footer text</footer>
    }
 
-The previous example will print a simple h1 header, followed by the page content records and a footer element.
+The previous example will print a simple h1 header, followed by the page
+content records and a footer element.
 
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -340,7 +340,7 @@ Here is an example of the CONTENT object:
       where = {#colPos}=0
    }
 
-Since in the above example .renderObj is not set explicitly, TYPO3
+Since in the above example `.renderObj` is not set explicitly, TYPO3
 will automatically set :typoscript:`1.renderObj < tt_content`, so that `renderObj`
 will reference the TypoScript configuration of `tt_content`. The
 according TypoScript configuration will be copied to `renderObj`.

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -10,12 +10,6 @@
 CONTENT
 =======
 
-.. note::
-
-   * CONTENT is an object type (= complex data type).
-   * It is a specific :ref:`cObject <cobject>` data type.
-
-
 An object with the content type CONTENT is designed to generate content by allowing to
 finely select records and have them rendered.
 
@@ -29,8 +23,198 @@ is raised to the maximum timestamp value of the respective records.
    lists of records from a variety of tables without fine graining.
 
 
-Comprehensive example
-=====================
+.. contents::
+   :local:
+
+Properties
+==========
+
+.. index:: CONTENT; select
+.. _cobj-content-select:
+
+select
+------
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+         select
+
+   Data type
+         :ref:`select`
+
+   Description
+      The SQL-statement, a SELECT query, is set here,
+      including automatic visibility control.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; table
+.. _cobj-content-table:
+
+table
+-----
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+      table
+
+   Data type
+      *table name* /:ref:`stdwrap`
+
+   Description
+      The table, the content should come from. Any table can be used;
+      a check for a table prefix is not done.
+
+      In standard configuration this will be `tt_content`.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; renderObj
+.. _cobj-content-renderObj:
+
+renderObj
+---------
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+      renderObj
+
+   Data type
+      :ref:`data-type-cObject`
+
+   Default
+      :typoscript:`< [table name]`
+
+   Description
+      The cObject used for rendering the records resulting from the query in
+      .select.
+
+      If :typoscript:`renderObj` is not set explicitly, then :typoscript:`< [table name]` is used. So
+      in this case the configuration of the according table is being copied.
+      See the notes on the example below.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; slide
+.. _cobj-content-slide:
+
+slide
+-----
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+      slide
+
+   Data type
+      integer /:ref:`stdWrap`
+
+   Description
+      If set and no content element is found by the select command, the
+      rootLine will be traversed back until some content is found.
+
+      Possible values are :typoscript:`-1` (slide back up to the siteroot), :typoscript:`1` (only
+      the current level) and :typoscript:`2` (up from one level back).
+
+      Use :typoscript:`-1` in combination with collect.
+
+      slide.collect
+         (integer /:ref:`stdWrap`) If set, all content elements found
+         on the current and parent pages will be collected. Otherwise, the sliding
+         would stop after the first hit. Set this value to the amount of levels
+         to collect on, or use :typoscript:`-1` to collect up to the siteroot.
+
+      slide.collectFuzzy
+         (boolean /:ref:`stdWrap`) Only useful in collect mode. If
+         no content elements have been found for the specified depth in collect
+         mode, traverse further until at least one match has occurred.
+
+      slide.collectReverse
+         (boolean /:ref:`stdWrap`) Reverse
+         order of elements in collect mode. If set, elements of the current
+         page will be at the bottom.
+
+      **Note:** Up to Version 9 of TYPO3 the sliding stopped when reaching a folder. Beginning with TYPO3 10 this is not longer the case.
+      See :php:`$cObj->checkPid_badDoktypeList`.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; wrap
+.. _cobj-content-wrap:
+
+wrap
+----
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+      wrap
+
+   Data type
+      :ref:`wrap <data-type-wrap>` /:ref:`stdWrap`
+
+   Description
+      Wrap the whole content.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; stdWrap
+.. _cobj-content-stdWrap:
+
+stdWrap
+-------
+
+.. ### BEGIN~OF~TABLE ###
+
+.. container:: table-row
+
+   Property
+      stdWrap
+
+   Data type
+      :ref:`stdwrap`
+
+   Description
+      Apply `stdWrap` functionality.
+
+.. ###### END~OF~TABLE ######
+
+
+.. index:: CONTENT; cache
+.. _cobj-content-cache:
+
+cache
+-----
+
+.. ### BEGIN~OF~TABLE ###
+
+.. include:: ../../DataTypes/Properties/Cache.rst.txt
+
+.. ###### END~OF~TABLE ######
+
+Examples
+========
+
+CONTENT explained in detail
+----------------------------
 
 See PHP class :php:`\TYPO3\CMS\Frontend\ContentObject\ContentContentObject`
 for details on code level.
@@ -138,192 +322,10 @@ See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`,
 :ref:`data-type-cobject`
 
 
-.. index:: CONTENT; select
-.. _cobj-content-select:
-
-select
-======
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-         select
-
-   Data type
-         :ref:`select`
-
-   Description
-      The SQL-statement, a SELECT query, is set here,
-      including automatic visibility control.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; table
-.. _cobj-content-table:
-
-table
-=====
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-      table
-
-   Data type
-      *table name* /:ref:`stdwrap`
-
-   Description
-      The table, the content should come from. Any table can be used;
-      a check for a table prefix is not done.
-
-      In standard configuration this will be `tt_content`.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; renderObj
-.. _cobj-content-renderObj:
-
-renderObj
-=========
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-      renderObj
-
-   Data type
-      :ref:`data-type-cObject`
-
-   Default
-      :typoscript:`< [table name]`
-
-   Description
-      The cObject used for rendering the records resulting from the query in
-      .select.
-
-      If :typoscript:`renderObj` is not set explicitly, then :typoscript:`< [table name]` is used. So
-      in this case the configuration of the according table is being copied.
-      See the notes on the example below.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; slide
-.. _cobj-content-slide:
-
-slide
-=====
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-      slide
-
-   Data type
-      integer /:ref:`stdWrap`
-
-   Description
-      If set and no content element is found by the select command, the
-      rootLine will be traversed back until some content is found.
-
-      Possible values are :typoscript:`-1` (slide back up to the siteroot), :typoscript:`1` (only
-      the current level) and :typoscript:`2` (up from one level back).
-
-      Use :typoscript:`-1` in combination with collect.
-
-      slide.collect
-         (integer /:ref:`stdWrap`) If set, all content elements found
-         on the current and parent pages will be collected. Otherwise, the sliding
-         would stop after the first hit. Set this value to the amount of levels
-         to collect on, or use :typoscript:`-1` to collect up to the siteroot.
-
-      slide.collectFuzzy
-         (boolean /:ref:`stdWrap`) Only useful in collect mode. If
-         no content elements have been found for the specified depth in collect
-         mode, traverse further until at least one match has occurred.
-
-      slide.collectReverse
-         (boolean /:ref:`stdWrap`) Reverse
-         order of elements in collect mode. If set, elements of the current
-         page will be at the bottom.
-
-      **Note:** Up to Version 9 of TYPO3 the sliding stopped when reaching a folder. Beginning with TYPO3 10 this is not longer the case.
-      See :php:`$cObj->checkPid_badDoktypeList`.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; wrap
-.. _cobj-content-wrap:
-
-wrap
-====
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-      wrap
-
-   Data type
-      :ref:`wrap <data-type-wrap>` /:ref:`stdWrap`
-
-   Description
-      Wrap the whole content.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; stdWrap
-.. _cobj-content-stdWrap:
-
-stdWrap
-=======
-
-.. ### BEGIN~OF~TABLE ###
-
-.. container:: table-row
-
-   Property
-      stdWrap
-
-   Data type
-      :ref:`stdwrap`
-
-   Description
-      Apply `stdWrap` functionality.
-
-.. ###### END~OF~TABLE ######
-
-
-.. index:: CONTENT; cache
-.. _cobj-content-cache:
-
-cache
-=====
-
-.. ### BEGIN~OF~TABLE ###
-
-.. include:: ../../DataTypes/Properties/Cache.rst.txt
-
-.. ###### END~OF~TABLE ######
-
-
 .. _cobj-content-examples:
 
-CONTENT object example 1
-========================
+Display all tt_content records from this page
+----------------------------------------------
 
 Here is an example of the CONTENT object:
 
@@ -335,6 +337,7 @@ Here is an example of the CONTENT object:
    1.select {
       pidInList = this
       orderBy = sorting
+      where = {#colPos}=0
    }
 
 Since in the above example .renderObj is not set explicitly, TYPO3
@@ -343,7 +346,7 @@ will reference the TypoScript configuration of `tt_content`. The
 according TypoScript configuration will be copied to `renderObj`.
 
 
-CONTENT object example 2
+Apply special rendering
 ========================
 
 Here is an example of record-rendering objects:

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -219,21 +219,6 @@ CONTENT explained in detail
 See PHP class :php:`\TYPO3\CMS\Frontend\ContentObject\ContentContentObject`
 for details on code level.
 
-Preamble:
-
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-   # Note: TypoScript (TS) is just another way to define an array of settings which
-   #       is later on INTERPRETED by TYPO3. TypoScript can be written in ANY order
-   #       as long as it leads to the same array. Actual execution order is TOTALLY
-   #       INDEPENDENT of TypoScript code order.
-   #
-   #       The order of TS in this example however tries to reflect execution order.
-   #       The denoted steps are taking place in that order at execution time.
-
-Condensed form:
-
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -8,8 +8,17 @@
 FILES
 =====
 
-A content object of type FILES was integrated with the File Abstraction Layer (FAL)
-and is there to output information about files.
+A content object of type FILES was integrated with the File Abstraction Layer
+(FAL) and is there to output information about files.
+
+.. contents::
+   :local:
+
+Properties
+==========
+
+files
+------
 
 .. container:: table-row
 
@@ -30,6 +39,8 @@ and is there to output information about files.
             page.10 = FILES
             page.10.files = 12,15,16
 
+references
+-----------
 
 .. container:: table-row
 
@@ -78,6 +89,8 @@ and is there to output information about files.
 
          This will fetch all items related to the page.media field.
 
+collections
+------------
 
 .. container:: table-row
 
@@ -91,6 +104,8 @@ and is there to output information about files.
          Comma-separated list of sys_file_collection UIDs, which
          are loaded into the FILES object.
 
+folders
+--------
 
 .. container:: table-row
 
@@ -137,6 +152,8 @@ and is there to output information about files.
                }
             }
 
+sorting
+--------
 
 .. container:: table-row
 
@@ -155,6 +172,8 @@ and is there to output information about files.
          files should be sorted. Possible values are "asc" for ascending and
          "desc" for descending. Ascending is the default.
 
+begin
+------
 
 .. container:: table-row
 
@@ -168,6 +187,8 @@ and is there to output information about files.
          The first item to return. If not set (default), items beginning
          with the first one are returned.
 
+maxItems
+---------
 
 .. container:: table-row
 
@@ -183,6 +204,8 @@ and is there to output information about files.
          number of available items, no items beyond the last available item will
          be returned - output won't continue with the first available item.
 
+renderObj
+----------
 
 .. container:: table-row
 
@@ -211,6 +234,8 @@ and is there to output information about files.
 
          This returns the size of the current file.
 
+stdWrap
+--------
 
 .. container:: table-row
 
@@ -230,6 +255,8 @@ and is there to output information about files.
 Special key: "references"
 =========================
 
+table
+------
 
 .. container:: table-row
 
@@ -242,6 +269,8 @@ Special key: "references"
    Description
          The table name of the table having the file field.
 
+uid
+----
 
 .. container:: table-row
 
@@ -254,6 +283,8 @@ Special key: "references"
    Description
          The UID of the record from which to fetch the referenced files.
 
+fieldName
+----------
 
 .. container:: table-row
 
@@ -273,13 +304,13 @@ Special key: "references"
 .. _cobj-files-examples:
 
 Examples:
-"""""""""
+==========
 
 
 .. _cobj-files-examples-files:
 
 Usage with files
-================
+-----------------
 
 In this example, we first load files using several of the methods
 explained above (using sys_file UIDs, collection UIDs, and folders).
@@ -304,7 +335,7 @@ the file size of all files that were found:
 .. _cobj-files-examples-references:
 
 Usage with references
-=====================
+----------------------
 
 In this second example, we use "references" to get the images related
 to a given page (in this case, the current page). We start with the
@@ -338,7 +369,7 @@ the file itself or from the reference to it (title):
 .. _cobj-files-examples-sliding:
 
 Usage with sliding
-==================
+--------------------
 
 One usual feature is to use images attached to pages and use
 them up and down the page tree, a process called "sliding".

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -9,7 +9,7 @@ FILES
 =====
 
 A content object of type FILES uses the File Abstraction Layer
-(FAL) and is there to output information about files.
+(FAL) and is used to display information about files.
 
 .. contents::
    :local:

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -304,7 +304,7 @@ fieldName
 .. _cobj-files-examples:
 
 Examples
-==========
+=========
 
 
 .. _cobj-files-examples-files:

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -8,7 +8,7 @@
 FILES
 =====
 
-A content object of type FILES was integrated with the File Abstraction Layer
+A content object of type FILES uses the File Abstraction Layer
 (FAL) and is there to output information about files.
 
 .. contents::

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -303,7 +303,7 @@ fieldName
 
 .. _cobj-files-examples:
 
-Examples:
+Examples
 ==========
 
 


### PR DESCRIPTION
- Use Headlines
- Content Menü
- Sections for Properties and Examples