### PR TITLE
Add warning for using the DatabaseQueryProcessor

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -53,6 +53,11 @@ Options:
    "select", including :typoscript:`pidInList`, :typoscript:`orderBy`,
    :typoscript:`where` etc. See the reference of :ref:`select`.
 
+.. warning:: Be careful when the DatabaseQueryProcessor, as you may run
+   into issues with language and/or versioning overlays, that currently
+   can not be resolved. See `here <https://forge.typo3.org/issues/85284#note-5>`__
+   for more information.
+
 
 Example: Display haiku records
 ==============================

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -53,7 +53,7 @@ Options:
    "select", including :typoscript:`pidInList`, :typoscript:`orderBy`,
    :typoscript:`where` etc. See the reference of :ref:`select`.
 
-.. warning:: Be careful when the DatabaseQueryProcessor, as you may run
+.. warning:: Be careful when using the DatabaseQueryProcessor, as you may run
    into issues with language and/or versioning overlays, that currently
    can not be resolved. See `here <https://forge.typo3.org/issues/85284#note-5>`__
    for more information.

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -53,8 +53,8 @@ Options:
    "select", including :typoscript:`pidInList`, :typoscript:`orderBy`,
    :typoscript:`where` etc. See the reference of :ref:`select`.
 
-.. warning:: Be careful when using the DatabaseQueryProcessor, as you may run
-   into issues with language and/or versioning overlays, that currently
+.. warning:: When using the DatabaseQueryProcessor, you may encounter
+   issues with language and/or versioning overlays, that currently
    can not be resolved. See `here <https://forge.typo3.org/issues/85284#note-5>`__
    for more information.
 


### PR DESCRIPTION
The DatabaseQueryProcessor currently has issues with language/ version overlays, that cannot be easily resolved (complexity: nightmare). Thus, bugs like https://forge.typo3.org/issues/85284 or https://forge.typo3.org/issues/88071 occur.

See https://forge.typo3.org/issues/85284#note-5 for a more detailed explanation.