### PR TITLE
Add missing opening brace in code example

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -90,7 +90,7 @@ page
       # Check single page uid
       [traverse(page, "uid") == 2]
       # Check list of page uids
-      traverse(page, "uid") in [17,24]]
+      [traverse(page, "uid") in [17,24]]
       # Check list of page uids NOT in
       [traverse(page, "uid") not in [17,24]]
       # Check range of pages (example: page uid from 10 to 20)


### PR DESCRIPTION
Cherry-pick from [4a87cc128d679ff7e22e99059e0e59f27ff32497](https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/commit/4a87cc128d679ff7e22e99059e0e59f27ff32497)