### PR TITLE
[TASK] Correct spelling of TYPO3 versions

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -10,8 +10,8 @@ Conditions
 
    * For full explanations about conditions, especially about condition syntax, please refer to
      :ref:`the TypoScript Syntax chapter of the Core API <t3coreapi:typoscript-syntax-conditions>`.
-     The "new" condition syntax (since TYPO3 9.4) is based on the
-     `symfony expression language <https://symfony.com/doc/4.1/components/expression_language.html>`__
+     The "new" condition syntax (since TYPO3 v9.4) is based on the
+     `Symfony expression language <https://symfony.com/doc/5.4/components/expression_language.html>`__.
    * TypoScript also offers the :ref:`"if" function <if>` to create conditions.
 
 .. contents::
@@ -435,7 +435,7 @@ backend.user.userGroupList
 """"""""""""""""""""""""""
 
 .. versionadded:: 11.2
-   Starting with TYPO3 11.2 `backend.user.userGroupIds`,
+   Starting with TYPO3 v11.2 `backend.user.userGroupIds`,
    an array has been added. Use this instead of `like`
    expressions to test for the user group of the current
    backend user.
@@ -562,7 +562,7 @@ frontend.user.userGroupList
 """""""""""""""""""""""""""
 
 .. versionadded:: 11.2
-   Starting with TYPO3 11.2 `frontend.user.userGroupIds`,
+   Starting with TYPO3 v11.2 `frontend.user.userGroupIds`,
    an array has been added. Use this instead of `like`
    expressions to test for the user group of the current
    frontend user.
@@ -1233,7 +1233,7 @@ compatVersion
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
       [compatVersion("11.5")]
-         page.10.value = You are using TYPO3 11.5
+         page.10.value = You are using TYPO3 v11.5
       [end]
 
    Is same as:
@@ -1242,7 +1242,7 @@ compatVersion
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
       [compatVersion("11.5.0")]
-         page.10.value = You are using TYPO3 11.5
+         page.10.value = You are using TYPO3 v11.5
       [end]
 
    Another example:
@@ -1251,7 +1251,7 @@ compatVersion
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
       [compatVersion("11.5.1")]
-         page.10.value = You are using TYPO3 11.5
+         page.10.value = You are using TYPO3 v11.5
       [end]
 
 

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -148,8 +148,10 @@ slide
          order of elements in collect mode. If set, elements of the current
          page will be at the bottom.
 
-      **Note:** Up to Version 9 of TYPO3 the sliding stopped when reaching a folder. Beginning with TYPO3 10 this is not longer the case.
-      See :php:`$cObj->checkPid_badDoktypeList`.
+      .. note::
+         Up to version 9 of TYPO3 the sliding stopped when reaching a folder.
+         Beginning with TYPO3 v10 this is not longer the case.
+         See :php:`$cObj->checkPid_badDoktypeList`.
 
 .. ###### END~OF~TABLE ######
 

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -380,7 +380,7 @@ template
 
    .. warning::
 
-      The :typoscript:`FILE` object type has been removed in TYPO3 10. As the :typoscript:`.template`
+      The :typoscript:`FILE` object type has been removed in TYPO3 v10. As the :typoscript:`.template`
       property used :typoscript:`FILE`, you should generally check your code if
       using this and switch to using :ref:`.templateName <cobj-fluidtemplate-properties-templatename>`
       with :ref:`.templateRootPaths <cobj-fluidtemplate-properties-templaterootpaths>` or use

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -117,8 +117,8 @@ uidInList
 
    **Note:** :typoscript:`this` is a *special keyword* and replaced with the id of the
    *current record*.
-   
-   .. attention:: 
+
+   .. attention::
       :ref:`pidInList` defaults to :typoscript:`this`. Therefore by default only records
       from the current page are available for :typoscript:`uidInList`. If records
       should be fetched globally, :typoscript:`pidInList = 0` should also be set.
@@ -131,7 +131,7 @@ uidInList
          uidInList = 1,2,3
          pidInList = 0
       }
-      
+
       select.uidInList = this
 
 
@@ -145,7 +145,7 @@ pidInList
 
 :aspect:`Data type`
    *list of page\_ids* / :ref:`stdWrap`
-   
+
 :aspect:`Default`
    this
 
@@ -448,7 +448,7 @@ markers
 
    .. warning::
 
-      Since TYPO3 8 there is a problem combining orderBy with markers caused
+      Since TYPO3 v8 there is a problem combining orderBy with markers caused
       by the quoting of the fields, see :issue:`87799`.
 
 :aspect:`Example`


### PR DESCRIPTION
Related: TYPO3-Documentation/TYPO3CMS-Guide-HowToDocument#295

Additionally, link to current LTS version of Symfony expression language.

Releases: main, 11.5