### PR TITLE
Move data/gettext in with the functions

### DIFF
--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -1,12 +1,10 @@
-:orphan:
-
 .. include:: /Includes.rst.txt
-.. index:: Simple data types; getText
+.. index:: Function; getText
 .. _data-type-gettext:
 
-=======
-getText
-=======
+==============
+Data / getText
+==============
 
 :aspect:`Data type:`
    getText
@@ -816,7 +814,7 @@ TSFE
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
       lib.foo.data = TSFE : fe_user|user|username
-      
+
 .. deprecated:: 12.0
    The following properties within TypoScriptFrontendController (TSFE) have been deprecated:
 
@@ -825,7 +823,7 @@ TSFE
    *  :php:`extTarget`
    *  :php:`fileTarget`
    *  :php:`baseUrl`
-   
+
    Migrate the access to these properties to use the config property:
 
    You can access the TypoScript properties directly via

--- a/Documentation/Functions/Index.rst
+++ b/Documentation/Functions/Index.rst
@@ -25,29 +25,8 @@ Example:
             :ref:`data-type-string` /:ref:`stdWrap <stdwrap>`
 
 
-.. toctree::
-   :maxdepth: 5
-   :titlesonly:
+..  toctree::
+    :glob:
+    :titlesonly:
 
-   Cache
-   Calc
-   Encapslines
-   GetEnv
-   Htmlparser
-   HtmlparserTags
-   If
-   Imagelinkwrap
-   Imgresource
-   Makelinks
-   Numberformat
-   Numrows
-   OptionSplit
-   Parsefunc
-   Replacement
-   Round
-   Select
-   Split
-   Stdwrap
-   Strpad
-   Tags
-   Typolink
+    *


### PR DESCRIPTION
It is way to complex to be considered a datatype. 
Also it was invisible in the menu as it was made an orphan accidently.

Sort the functions by alphabet and display them as glob

Releases: main, 11.5