### PR TITLE
Minor typo

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -49,7 +49,7 @@ Options:
    Array of DataProcessors to be applied to all fetched records.
 
 
-.. note:: all other options will be interpreted as in the TypoScript function
+.. note:: All other options will be interpreted as in the TypoScript function
    "select", including :typoscript:`pidInList`, :typoscript:`orderBy`,
    :typoscript:`where` etc. See the reference of :ref:`select`.
 


### PR DESCRIPTION
Sentences should start uppercase.