### PR TITLE
Add reference to changelog of `tree.pagelayout` condition

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -187,6 +187,7 @@ tree.pagelayout
 """""""""""""""
 
 .. versionadded:: 11.0
+   :doc:`Changelog/11.0/Feature-88276-TypoScriptConditionForPageLayout`
 
 :aspect:`Variable`
    tree.pagelayout


### PR DESCRIPTION
With this PR, a reference to the changelog entry of the `tree.pagelayout` condition is added.

Releases: main, 11.5