### PR TITLE
Add example to remove the website title

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1793,7 +1793,7 @@ pageTitleSeparator
             config.pageTitleSeparator = *
             config.pageTitleSeparator.noTrimWrap = |||
             
-         If you want to get rid of the web page title, you must choose a separator that is not included in the web page title. 
+         If you want to remove the web page title from the displayed title, choose a separator that is not included in the web page title. 
          You then split the title from that character and return everything after it:
 
          .. code-block:: typoscript

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1792,6 +1792,20 @@ pageTitleSeparator
 
             config.pageTitleSeparator = *
             config.pageTitleSeparator.noTrimWrap = |||
+            
+         If you want to get rid of the web page title, you must choose a separator that is not included in the web page title. 
+         You then split the title from that character and return everything after it:
+
+         .. code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+            config.pageTitleSeparator = *
+            config.pageTitle.stdWrap {
+                split {
+                    token = *
+                    returnKey = 1
+                }
+            }       
 
 
 .. index:: config; removeDefaultCss

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1794,7 +1794,7 @@ pageTitleSeparator
             config.pageTitleSeparator.noTrimWrap = |||
             
          If you want to remove the web page title from the displayed title, choose a separator that is not included in the web page title. 
-         You then split the title from that character and return everything after it:
+         Then split the title from that character and return the second part only:
 
          .. code-block:: typoscript
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript


### PR DESCRIPTION
There is no config setting for removing the website title from the title tag.  With this workaround you can remove the website title and keep the page title, that also can be set by PageTitleProviders.