### PR TITLE
[BUGFIX] Add missing templateRootPath (sing) to FLUIDTEMPLATE

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -284,7 +284,7 @@ partialRootPath
     :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
     :sep:`|`
 
-    Sets a specific layout path, usually
+    Sets a specific partial path, usually
     :file:`EXT:some_extension/Resources/Private/Partials/` or a folder below that
     path.
 

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -217,11 +217,18 @@ layoutRootPath
 .. rst-class:: dl-parameters
 
 layoutRootPath
-   :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
-   :sep:`|`
+    :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
+    :sep:`|`
 
-   Sets a specific layout path; usually it is Layouts/ underneath the template
-   file.
+    Sets a specific layout path, usually
+    :file:`EXT:some_extension/Resources/Private/Layouts/` or a folder below that
+    path.
+
+    ..  note::
+        It is recommended to use
+        :ref:`cobj-fluidtemplate-properties-layoutrootpaths` (mind the
+        plural "s") as it can be easily extended by custom templates provided
+        by the sitepackage.
 
 
 .. index:: FLUIDTEMPLATE; layoutRootPaths
@@ -274,11 +281,18 @@ partialRootPath
 .. rst-class:: dl-parameters
 
 partialRootPath
-   :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
-   :sep:`|`
+    :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
+    :sep:`|`
 
-   Sets a specific partials path; usually it is Partials/ underneath the
-   template file.
+    Sets a specific layout path, usually
+    :file:`EXT:some_extension/Resources/Private/Partials/` or a folder below that
+    path.
+
+    ..  note::
+        It is recommended to use
+        :ref:`cobj-fluidtemplate-properties-partialrootpaths` (mind the
+        plural "s") as it can be easily extended by custom templates provided
+        by the sitepackage.
 
 
 .. index:: FLUIDTEMPLATE; partialRootPaths
@@ -472,7 +486,26 @@ templateName
 
 
 
+.. index:: FLUIDTEMPLATE; templateRootPath
+.. _cobj-fluidtemplate-properties-templaterootpath:
+templateRootPath
+----------------
 
+.. rst-class:: dl-parameters
+
+templateRootPath
+    :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
+    :sep:`|`
+
+    Sets a specific layout path, usually
+    :file:`EXT:some_extension/Resources/Private/Templates/` or a folder below that
+    path.
+
+    ..  note::
+        It is recommended to use
+        :ref:`cobj-fluidtemplate-properties-templaterootpaths` (mind the
+        plural "s") as it can be easily extended by custom templates provided
+        by the sitepackage.
 
 .. index:: FLUIDTEMPLATE; templateRootPaths
 .. _cobj-fluidtemplate-properties-templaterootpaths:
@@ -511,10 +544,6 @@ templateRootPaths
             }
          }
       }
-
-
-
-
 
 .. index:: FLUIDTEMPLATE; variables
 .. _cobj-fluidtemplate-properties-variables:

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -497,7 +497,7 @@ templateRootPath
     :sep:`|` :aspect:`Data type:` file path /:ref:`stdWrap <stdwrap>`
     :sep:`|`
 
-    Sets a specific layout path, usually
+    Sets a specific template path, usually
     :file:`EXT:some_extension/Resources/Private/Templates/` or a folder below that
     path.
 


### PR DESCRIPTION
While both partialRootPath and partialRootPaths (mind the plural s) have been described ever since and also the layoutRootPath and layoutRootPaths, templateRootPath (sing) was missing. I added templateRootPath and made the difference to templateRootPaths (plural) more clear I hope.

Releases: main, 11.5, 10.4