### PR TITLE
[TASK] Add example with path to stdWrap.insertData

### DIFF
--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -666,6 +666,18 @@ path
 
       lib.foo.data = path : EXT:rsaauth/resources/rsaauth.js
 
+   It can also be helpful in combination with
+   :ref:`stdWrap.insertData <stdwrap-insertdata>`:
+
+   .. code-block:: typoscript
+      :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+      page.headerData.10 = TEXT
+      page.headerData.10 {
+        value = <link rel="preload" href="{path : EXT:site/Resources/Public/Fonts/Roboto.woff2}" as="font" type="font/woff2" crossorigin="anonymous">
+        insertData = 1
+      }
+
 .. _data-type-gettext-register:
 
 register

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -1767,6 +1767,11 @@ insertData
       10.value = This is the page title: {page:title}
       10.stdWrap.insertData = 1
 
+      # TEXT is already stdWrap'able, so we can also use insertData right away
+      20 = TEXT
+      20.value = <link rel="preload" href="{path : EXT:site/Resources/Public/Fonts/Roboto.woff2}" as="font" type="font/woff2" crossorigin="anonymous">
+      20.insertData = 1
+
 .. warning::
    Never use this on content that can be edited in the backend. This allows editors to disclose
    normally hidden information. Never use this to insert data into wraps.

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -1767,7 +1767,7 @@ insertData
       10.value = This is the page title: {page:title}
       10.stdWrap.insertData = 1
 
-      # TEXT is already stdWrap'able, so we can also use insertData right away
+      # TEXT is already stdWrapable, so we can also use insertData right away
       20 = TEXT
       20.value = <link rel="preload" href="{path : EXT:site/Resources/Public/Fonts/Roboto.woff2}" as="font" type="font/woff2" crossorigin="anonymous">
       20.insertData = 1


### PR DESCRIPTION
This is helpful when migrating to typo3/cms-composer-installers v4+.

Related: https://forge.typo3.org/issues/99203
Releases: main, 11.5