### PR TITLE
[BUGFIX] Add missing header for config.additionalHeaders

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -105,6 +105,9 @@ absRefPrefix
 
 .. _setup-config-additionalheaders:
 
+additionalHeaders
+=================
+
 .. t3-tlo-config:: additionalHeaders
 
    :Data type: numerically indexed array of "HTTP header entries".


### PR DESCRIPTION
Releases: main, 11.5