### PR TITLE
Remove DC-tag example

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -1028,7 +1028,6 @@ meta
                    og:site_name = TYPO3
                    og:site_name.attribute = property
                    description = Inspiring people to share Normal
-                   dc.description = Inspiring people to share [DC tags]
                    og:description = Inspiring people to share [OpenGraph]
                    og:description.attribute = property
                    og:locale = en_GB


### PR DESCRIPTION
Dublin Core tags are not supported since the introduction of the Meta Tag API. Neither the core itself covers DC tags, nor does EXT:seo.