### PR TITLE
[CI] Update used Ubuntu version to "latest"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
This avoids the errors when running with a backport tag in a PR:

"This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023."

"The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04(ubuntu-latest), or ubuntu-22.04 instead."