### PR TITLE
Replace links to start page (:doc: => :ref:)

### DIFF
--- a/Documentation/About.rst
+++ b/Documentation/About.rst
@@ -9,7 +9,7 @@ About This Manual
 
 This document is a complete reference to all objects types and properties of
 TypoScript as used in frontend TypoScript template building, and not in
-:doc:`TSconfig <t3tsconfig:Index>`.
+:ref:`TSconfig <t3tsconfig:start>`.
 
 .. seealso::
 
@@ -17,7 +17,7 @@ TypoScript as used in frontend TypoScript template building, and not in
       please refer to the
       :ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`
       chapter in "TYPO3 Explained"
-    * For an introduction to TypoScript Templates, see :doc:`t3ts45:Index`
+    * For an introduction to TypoScript Templates, see :ref:`t3ts45:start`
 
 .. _credits:
 

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -532,4 +532,4 @@ headlines. The copyright year will be taken from the TypoScript constant
 
     *   :ref:`dataProcessing` examples
     *   :ref:`t3coreapi:adding-your-own-content-elements`
-    *   :doc:`t3sitepackage:Index`
+    *   :ref:`t3sitepackage:start`

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -28,8 +28,8 @@ This document is a complete reference of all object types and properties of
 TypoScript as used in frontend TypoScript templates.
 
 Furthermore, you can find a quick guide to TypoScript templates at
-:doc:`t3ts45:Index`, insights into TYPO3 backend configuration with
-TypoScript in the :doc:`TSconfig <t3tsconfig:Index>` documentation and
+:ref:`t3ts45:start`, insights into TYPO3 backend configuration with
+TypoScript in the :ref:`TSconfig <t3tsconfig:start>` documentation and
 explanations of TypoScript syntax in the ":ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`"
 chapter of TYPO3 Explained.
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -48,7 +48,7 @@ Please read the following for an introduction:
 * :ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`
   chapter in "TYPO3 Explained" for an introduction to the TypoScript
   syntax
-* :doc:`t3ts45:Index` for an introduction to TypoScript Templating
+* :ref:`t3ts45:start` for an introduction to TypoScript Templating
 * The chapter :ref:`using-and-setting` describes how to use, set
   and extend TypoScript.
 
@@ -73,7 +73,7 @@ Best practice:
   :ref:`cobj-fluidtemplate` is available, which uses Fluid
   from inside TypoScript.
 
-  * See :doc:`t3sitepackage:Index` for a complete walkthrough of creating a
+  * See :ref:`t3sitepackage:start` for a complete walkthrough of creating a
     sitepackage, which is the basis for a custom theme for your site.
   * See :ref:`t3coreapi:adding-your-own-content-elements` for an
     introduction on how to create your own content element types using

--- a/Documentation/UsingSetting/Entering.rst
+++ b/Documentation/UsingSetting/Entering.rst
@@ -16,7 +16,7 @@ the TYPO3 backend.
 .. hint::
 
    It is best practice to use a Sitepackage extension to bundle
-   various configuration in an extension. See :doc:`t3sitepackage:Index`.
+   various configuration in an extension. See :ref:`t3sitepackage:start`.
 
 
 .. include:: /Images/AutomaticScreenshots/TemplatesRecords/TemplatesRecordListView.rst.txt


### PR DESCRIPTION
We now use the start label again to link to start pages

Related: TYPO3-Documentation/T3DocTeam#198