### PR TITLE
Mention returnLast option 'result' (#708)

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -475,6 +475,22 @@ returnLast
 .. index:: typolink; section
 .. _typolink-section:
 
+    ..  versionadded:: 11.4
+
+    If set to ``result``, it will return the json_encoded output of the
+    internal ``LinkResult`` object.
+
+    ..  code-block:: json
+
+        {
+            "href": "/my-page",
+            "target": null,
+            "class": null,
+            "title": null,
+            "linkText": "My page",
+            "additionalAttributes": []
+        }
+
 section
 -------
 


### PR DESCRIPTION
Related: https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/11.4/Feature-94889-AddResultOptionToTypolinkReturnLastParameter.html
Releases: main, 11.5