### PR TITLE
[BUGFIX] Switch stdWrap order of strtotime and stftime

### DIFF
--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -660,31 +660,6 @@ date
            date = Y-m-d H:i
         }
 
-strftime
-~~~~~~~~
-
-..  t3-function-stdwrap:: strftime
-
-    :Data type: :t3-data-type:`strftime-conf` / :ref:`stdWrap`
-
-    Very similar to "date", but using a different format. See the PHP manual (`strftime <https://www.php.net/strftime>`_) for the
-    format codes.
-
-    This formatting is useful if the locale is set in advance in the
-    :ref:`CONFIG <config>` object. See there.
-
-    Properties:
-
-    .charset
-        Can be set to the charset of the output string if you need to
-        convert it to UTF-8. Default is to take the intelligently guessed
-        charset from :php:`TYPO3\CMS\Core\Charset\CharsetConverter`.
-
-    .GMT
-        If set, the PHP function `gmstrftime()
-        <https://www.php.net/gmstrftime>`_ will be used instead of
-        `strftime() <https://www.php.net/strftime>`_.
-
 strtotime
 ~~~~~~~~~
 
@@ -716,6 +691,31 @@ strtotime
            strtotime = + 2 weekdays
            strftime = %Y-%m-%d
         }
+
+strftime
+~~~~~~~~
+
+..  t3-function-stdwrap:: strftime
+
+    :Data type: :t3-data-type:`strftime-conf` / :ref:`stdWrap`
+
+    Very similar to "date", but using a different format. See the PHP manual (`strftime <https://www.php.net/strftime>`_) for the
+    format codes.
+
+    This formatting is useful if the locale is set in advance in the
+    :ref:`CONFIG <config>` object. See there.
+
+    Properties:
+
+    .charset
+        Can be set to the charset of the output string if you need to
+        convert it to UTF-8. Default is to take the intelligently guessed
+        charset from :php:`TYPO3\CMS\Core\Charset\CharsetConverter`.
+
+    .GMT
+        If set, the PHP function `gmstrftime()
+        <https://www.php.net/gmstrftime>`_ will be used instead of
+        `strftime() <https://www.php.net/strftime>`_.
 
 age
 ~~~


### PR DESCRIPTION
The stdWrap functions are executed in a specific order. The documentation of the functions reflects this order. The strtotime is called before the stfrtime.

See: https://github.com/TYPO3/typo3/blob/11.5/typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php#L196-L199
Releases: main, 11.5