### PR TITLE
[FEATURE] #19856 - Set special ATagParams for links to access restricted pages

### DIFF
--- a/Documentation/MenuObjects/Tmenu/Index.rst
+++ b/Documentation/MenuObjects/Tmenu/Index.rst
@@ -504,7 +504,7 @@ showAccessRestrictedPages
 
 ..  t3-menu-tmenu:: showAccessRestrictedPages
 
-    :Data type: integer (page id) / keyword "NONE"
+    :Data type: integer (page ID) / keyword "NONE"
 
 
     If set, pages in the menu will include pages with frontend user group
@@ -522,11 +522,15 @@ showAccessRestrictedPages
 
     **Properties:**
 
-    .addParam = Additional parameter for the URL, which can hold two
+    **.addParam**: Additional parameter for the URL, which can hold two
     markers; ###RETURN\_URL### which will be substituted with the link the
     page would have had if it had been accessible and ###PAGE\_ID###
-    holding the page id of the page coming from (could be used to look up
+    holding the page ID of the page coming from (could be used to look up
     which fe\_groups was required for access.
+
+    ..  versionadded:: 12.3
+
+    **.ATagParams**: Add custom attributes to the anchor tag.
 
     ..  rubric:: Example
 
@@ -535,10 +539,12 @@ showAccessRestrictedPages
 
         showAccessRestrictedPages = 22
         showAccessRestrictedPages.addParams = &return_url=###RETURN_URL###&pageId=###PAGE_ID###
+        showAccessRestrictedPages.ATagParams = class="restricted"
 
-    The example will link access restricted menu items to page id 22 with
-    the return URL in the GET var "return\_url" and the page id in the GET
-    var "pageId".
+    The example will link access restricted menu items to page ID 22 with
+    the return URL in the GET variable "return\_url" and the page ID in the GET
+    variable "pageId". Additionally, a CSS class "restricted" is added to the
+    anchor tag.
 
 additionalWhere
 ---------------

--- a/Documentation/MenuObjects/Tmenu/Index.rst
+++ b/Documentation/MenuObjects/Tmenu/Index.rst
@@ -542,7 +542,7 @@ showAccessRestrictedPages
         showAccessRestrictedPages.ATagParams = class="restricted"
 
     The example will link access restricted menu items to page ID 22 with
-    the return URL in the GET variable "return\_url" and the page ID in the GET
+    the return URL in the GET variable `return_url` and the page ID in the GET
     variable "pageId". Additionally, a CSS class "restricted" is added to the
     anchor tag.
 

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -2136,15 +2136,23 @@ typolinkLinkAccessRestrictedPages
          See :ref:`menu-common-properties-showaccessrestrictedpages`
          for menu objects as well (similar feature for menus)
 
+         **Property:**
+
+         ..  versionadded:: 12.3
+
+         **.ATagParams**: Add custom attributes to the anchor tag.
+
    Example
          .. code-block:: typoscript
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
             config.typolinkLinkAccessRestrictedPages = 29
+            config.typolinkLinkAccessRestrictedPages.ATagParams = class="restricted"
             config.typolinkLinkAccessRestrictedPages_addParams = &return_url=###RETURN_URL###&pageId=###PAGE_ID###
 
          Will create a link to page with id 29 and add GET parameters where the
-         return URL and original page id is a part of it.
+         return URL and original page id is a part of it. Additionally, a CSS
+         class "restricted" is added to the anchor tag.
 
 
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/395
Releases: main