### PR TITLE
Move example with typeNum

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -884,9 +884,6 @@ getTSFE()
    .. code-block:: typoscript
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-      # True if current typenum is 98
-      [getTSFE().type == 98]
-
       # True if current page uid is 17. Use the page variable instead
       [getTSFE().id == 17]
 
@@ -1315,6 +1312,9 @@ request.getPageArguments()
       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
       [request.getPageArguments().get('foo_id') > 0]
+
+      # True if current typenum is 98
+      [request.getPageArguments()?.getPageType() == 98]
 
 
 .. index:: Conditions; session


### PR DESCRIPTION
Hello,

with following change:
https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/12.4/Deprecation-100405-PropertyTypoScriptFrontendController-type.html

you can not access $TSFE->type anymore. That's why I have moved the example to the new request.getPageAttributes() location.

But be careful:
Doing so, will result in an Exception while opening the ExtensionManager. I already have added a forge ticket: https://forge.typo3.org/issues/100595

Stefan