### PR TITLE
[BUGFIX] Correct property name of features.skipDefaultArguments

### DIFF
--- a/Documentation/TopLevelObjects/Module.rst
+++ b/Documentation/TopLevelObjects/Module.rst
@@ -105,7 +105,7 @@ features.skipDefaultArguments
 
 .. rst-class:: dl-parameters
 
-features.enableNamespacedArgumentsForBackend
+features.skipDefaultArguments
    :sep:`|` :aspect:`Data type:` boolean
    :sep:`|`
 


### PR DESCRIPTION
Releases: 11.5