### PR TITLE
only tt_content is used as standard

### DIFF
--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -37,12 +37,14 @@ temp, styles & lib
 
 .. index:: Top-level objects; tt_content
 .. _tlo-tt:
+.. _tlo-tt_content:
 
-====
-tt_*
-====
 
-``tt_``, e.g. ``tt_content`` (from “content (default)”) is used to render content from tables.
+==========
+tt_content
+==========
+
+``tt_content``,  (from “content (default)”) is used to render content from tt_content or other tables
 
 
 .. index:: Top-level objects; resources


### PR DESCRIPTION
Maybe it has been intended to use tt_* tables for content rendering 20 years ago. But no other table than tt_content has been used.  Other tables like tt_address have to be defined, before they can be used.

https://stackoverflow.com/questions/52973130/display-tt-address-records-when-inserted-via-insert-record-in-typo3-8-7

Other table names not starting with tt* could be used as well.