### PR TITLE
11LTS docs for config.absRefPrefix refer to 12LTS alternative

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -61,9 +61,6 @@ absRefPrefix
    the site root based on path prefixes and not based on host name variables
    from the server, making this value safe for multi-domain environments.
 
-   If the option :ref:`config.forceAbsoluteUrls <setup-config-forceAbsoluteUrls>`
-   is enabled, :typoscript:`absRefPrefix` is overridden.
-
    Using an URI in :typoscript:`absRefPrefix` will require additional conditions
    if you use different domains for your deployment stages in CI environments.
 


### PR DESCRIPTION
[11LTS docs for config.absRefPrefix](https://docs.typo3.org/m/typo3/reference-typoscript/11.5/en-us/Setup/Config/Index.html) states
`If the option config.forceAbsoluteUrls is enabled, absRefPrefix is overridden.`
However as [12LTS docs](https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/Setup/Config/Index.html#setup-config-forceabsoluteurls) state, `config.forceAbsoluteUrls`was introduced in 12.1, thus isn't available in 11