### PR TITLE
Use hint to hint at HMENU options

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/MenuProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/MenuProcessor.rst
@@ -69,7 +69,7 @@ Options
 
     Name for the variable in the Fluid template.
 
-..  attention::
+..  hint::
     Additionally, all :ref:`HMENU options <cobj-hmenu-options>` are available.
 
 


### PR DESCRIPTION
Attention should be used for caveats where things can go wrong.