### PR TITLE
[BUGFIX] Correct spelling of config.doctype

### DIFF
--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -228,7 +228,7 @@ layout.layoutKey.element
     -  :html:`###SELFCLOSINGTAGSLASH###` renders the closing slash of the tag,
        depending on the setting of
        :ref:`config.xhtmlDoctype <setup-config-xhtmldoctype>` and
-       :ref:`config.Doctype <setup-config-doctype>`
+       :ref:`config.doctype <setup-config-doctype>`
 
     -  :html:`###SOURCECOLLECTION###` the additional sources of the image
        depending on the different usage in responsive webdesign. The


### PR DESCRIPTION
Releases: 12.4, 11.5