### PR TITLE
Remove .dataProcessing from FilesProcessor docs

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FilesProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FilesProcessor.rst
@@ -148,14 +148,6 @@ Options:
 
     The variable name to be used in the Fluid template.
 
-..  t3-data-processor-files:: dataProcessing
-
-    :Required: false
-    :type: array of :ref:`dataProcessing`
-    :default: ""
-
-    Array of data processors to be applied to all fetched records.
-
 
 Example 1: Render the images stored in field image
 ==================================================


### PR DESCRIPTION
I'm not quite sure here. But if I do understand the code correctly, the .dataProcessing subkey inside a FilesProcessor configuration is not interpreted (unlike DatabaseQueryProcessor). It wouldn't even be clear, how the resulting data would get passed alongside the fal objects.