### PR TITLE
Update config.linkVars section

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1274,8 +1274,8 @@ linkVars
 
          .. note::
 
-            Do **not** include the `type` parameter in the linkVars
-            list, as this can result in unexpected behavior.
+            Do **not** include the `type` and `L` parameter in the linkVars
+            list, as this will result in unexpected behavior.
 
    Examples
          .. code-block:: typoscript


### PR DESCRIPTION
Added the `L` parameter to the list of parameters not to be included in `config.linkVars`. This affects all TYPO3 versions >= 9.5