### PR TITLE
Update config.linkVars section (10.4 branch)

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1283,8 +1283,8 @@ linkVars
 
          .. note::
 
-            Do **not** include the `type` parameter in the linkVars
-            list, as this can result in unexpected behavior.
+            Do **not** include the `type` and `L` parameter in the linkVars
+            list, as this will result in unexpected behavior.
 
    Examples
          ::


### PR DESCRIPTION
Added the `L` parameter to the list of parameters not to be included in `config.linkVars`.
This affects all TYPO3 versions >= 9.5

----

backport of #764 (Torben Hansen PR)