### PR TITLE
Update config.linkVars section (9.5 branch)

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1603,8 +1603,8 @@ linkVars
 
          .. note::
 
-            Do **not** include the `type` parameter in the linkVars
-            list, as this can result in unexpected behavior.
+            Do **not** include the `type` and `L` parameter in the linkVars
+            list, as this will result in unexpected behavior.
 
    Examples
          ::


### PR DESCRIPTION
Added the `L` parameter to the list of parameters not to be included in `config.linkVars`. 
This affects all TYPO3 versions >= 9.5

---- 

backport of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/764 (Torben Hansen PR)