### PR TITLE
Optimize the links on select page

### DIFF
--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -403,5 +403,6 @@ Condensed form:
        }
     }
 
+For more complete examples see :ref:`cobj-content`.
 
-See also: :ref:`if`, :ref:`select`, :t3-data-type:`wrap`, :ref:`stdWrap`, :ref:`data-type-cobject`
+See also: :ref:`if`, :ref:`cobj-content`, :t3-data-type:`wrap`, :ref:`stdWrap`, :ref:`data-type-cobject`

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -403,6 +403,11 @@ Condensed form:
        }
     }
 
-For more complete examples see :ref:`cobj-content`.
+See also:
 
-See also: :ref:`if`, :ref:`cobj-content`, :t3-data-type:`wrap`, :ref:`stdWrap`, :ref:`data-type-cobject`
+*   :ref:`cobj-content`: for more complete examples with select and rendering
+    the output with :typoscript:`renderObj`
+*   :t3-data-type:`wrap`: enclosing results within text, used in some of the
+    examples above
+*   :ref:`stdWrap`: for more functionality, can be used in some of the properties,
+    such as :typoscript:`pidInList`, :typoscript:`selectFields` etc.

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -405,8 +405,8 @@ Condensed form:
 
 See also:
 
-*   :ref:`cobj-content`: for more complete examples with select and rendering
-    the output with :typoscript:`renderObj`
+*   :ref:`cobj-content`: for more complete examples with :typoscript:`select`
+    and rendering the output with :typoscript:`renderObj`
 *   :t3-data-type:`wrap`: enclosing results within text, used in some of the
     examples above
 *   :ref:`stdWrap`: for more functionality, can be used in some of the properties,


### PR DESCRIPTION
- replace linking to "select" (the same) page with link to CONTENT object type
- point out additional examples on CONTENT page because this contains several examples with select and more context