### PR TITLE
[Backport 11.5] Add example for select.join (#775)

### DIFF
--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -66,8 +66,7 @@ uidInList
 
       select.uidInList = this
 
-
-.. _select-pidInList:
+..  _select_pidInList:
 
 pidInList
 ---------
@@ -342,9 +341,28 @@ join, leftjoin, rightjoin
 :aspect:`Data type`
    :t3-data-type:`string` / :ref:`stdWrap`
 
-:aspect:`Description`
-   Enter the table name for JOIN, LEFT OUTER JOIN and RIGHT OUTER JOIN
+   Enter the JOIN clause without :sql:`JOIN`, :sql:`LEFT OUTER JOIN` and :sql:`RIGHT OUTER JOIN`
    respectively.
+
+   ..  rubric:: Example
+
+   Fetch related `sys_category` records stored in the MM intermediate table:
+
+   ..  code-block:: typoscript
+       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+       10 = CONTENT
+       10 {
+          table = sys_category
+          select {
+             pidInList = root,-1
+             selectFields = sys_category.*
+             join = sys_category_record_mm mm ON mm.uid_local = sys_category.uid
+             # ....
+           }
+       }
+
+   See :ref:`select_pidInList` for more examples.
 
 
 .. _select-markers:


### PR DESCRIPTION
- Add small example for select.join.
- Improve explanatory text

Previously, the explanatory text was slightly misleading because it instructed to use the table name where in fact an entire join clause (without the word "JOIN") can be used including aliasing the table and adding a constraint with "ON".