### PR TITLE
[TASK] Adjust external includeCSSLibs example

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -623,8 +623,8 @@ includeCSSLibs.[array]
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
             includeCSSLibs {
-                twitter = https://twitter.com/styles/blogger.css
-                twitter.external = 1
+                bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css
+                bootstrap.external = 1
 
                 additional = EXT:site_package/Resources/Public/Css/additional_styles.css
                 additional.data-foo = bar


### PR DESCRIPTION
As Twitter has been renamed to some random letter and the referenced style is not available anymore, another example is used.

Releases: main, 12.4, 11.5