### PR TITLE
[Backport 11.5] [TASK] Adjust external includeCSSLibs example (#789)

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -637,8 +637,8 @@ includeCSSLibs.[array]
          .. code-block:: typoscript
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-            includeCSSLibs.twitter = https://twitter.com/styles/blogger.css
-            includeCSSLibs.twitter.external = 1
+            includeCSSLibs.bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css
+            includeCSSLibs.bootstrap.external = 1
 
 
 


### PR DESCRIPTION
As Twitter has been renamed to some random letter and the referenced style is not available anymore, another example is used.

Releases: main, 12.4, 11.5