### PR TITLE
Changing the order of the Content-supplying properties of stdWrap part

### DIFF
--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -14,26 +14,8 @@ When a data type is set to "*type* /stdWrap" it means that the value
 is parsed through the stdWrap function with the properties of the
 value as parameters.
 
-.. _stdwrap-examples:
-
-Example
-=======
-
-Example with the property "value" of the content object ":ref:`cobj-text`":
-
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-   10 = TEXT
-   10.value = some text
-   10.stdWrap.case = upper
-
-Here the content of the object "10" is uppercased before it is
-returned.
-
-
-..  index:: Function stdWrap; Content-supplying properties
-.. _stdwrap-content-supplying:
+.. contents:: Table of contents
+   :local:
 
 Content-supplying properties of stdWrap
 =======================================
@@ -68,9 +50,6 @@ The above example could be rewritten to this:
 Now the line :typoscript:`10.value = some text` is obsolete, because the whole
 value is "imported" from the field called "header" from the
 :php:`$cObj->data-array`.
-
-.. contents:: Table of contents
-   :local:
 
 Properties
 ==========
@@ -1741,3 +1720,24 @@ debugData
 ..  attention::
 
     Only for debugging during development, otherwise output can break.
+
+.. _stdwrap-examples:
+
+Example
+=======
+
+Example with the property "value" of the content object ":ref:`cobj-text`":
+
+.. code-block:: typoscript
+   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+   10 = TEXT
+   10.value = some text
+   10.stdWrap.case = upper
+
+Here the content of the object "10" is uppercased before it is
+returned.
+
+
+..  index:: Function stdWrap; Content-supplying properties
+.. _stdwrap-content-supplying:

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -14,6 +14,61 @@ When a data type is set to "*type* /stdWrap" it means that the value
 is parsed through the stdWrap function with the properties of the
 value as parameters.
 
+.. _stdwrap-examples:
+
+Example
+=======
+
+Example with the property "value" of the content object ":ref:`cobj-text`":
+
+.. code-block:: typoscript
+   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+   10 = TEXT
+   10.value = some text
+   10.stdWrap.case = upper
+
+Here the content of the object "10" is uppercased before it is
+returned.
+
+
+..  index:: Function stdWrap; Content-supplying properties
+.. _stdwrap-content-supplying:
+
+Content-supplying properties of stdWrap
+=======================================
+
+stdWrap contains properties which determine what is applied. The properties
+are listed below.
+
+  ..  note::
+    The properties are parsed in the listed order. The
+    properties :typoscript:`data`, :typoscript:`field`, :typoscript:`current`, :typoscript:`cObject`
+    (in that order!) are special as they are used to import content
+    from variables or arrays.
+
+If you want to study this further please refer to
+:file:`typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php`,
+where you will find the function :php:`stdWrap()` and the array :php:`$stdWrapOrder`,
+which represents the exact order of execution.
+
+Note that the :typoscript:`stdWrap` property "orderedStdWrap" allows you to execute
+multiple :typoscript:`stdWrap` functions in a freely selectable order.
+
+The above example could be rewritten to this:
+
+.. code-block:: typoscript
+   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+   10 = TEXT
+   10.value = some text
+   10.stdWrap.case = upper
+   10.stdWrap.field = header
+
+Now the line :typoscript:`10.value = some text` is obsolete, because the whole
+value is "imported" from the field called "header" from the
+:php:`$cObj->data-array`.
+
 .. contents:: Table of contents
    :local:
 
@@ -1686,58 +1741,3 @@ debugData
 ..  attention::
 
     Only for debugging during development, otherwise output can break.
-
-
-.. _stdwrap-examples:
-
-Example
-=======
-
-Example with the property "value" of the content object ":ref:`cobj-text`":
-
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-   10 = TEXT
-   10.value = some text
-   10.stdWrap.case = upper
-
-Here the content of the object "10" is uppercased before it is
-returned.
-
-
-..  index:: Function stdWrap; Content-supplying properties
-.. _stdwrap-content-supplying:
-
-Content-supplying properties of stdWrap
-=======================================
-
-stdWrap contains properties which determine what is applied. The properties
-are listed below.
-
-The properties are parsed in the listed order. The
-properties :typoscript:`data`, :typoscript:`field`, :typoscript:`current`, :typoscript:`cObject`
-(in that order!) are special as they are used to import content
-from variables or arrays.
-
-If you want to study this further please refer to
-:file:`typo3/sysext/frontend/Classes/ContentObject/ContentObjectRenderer.php`,
-where you will find the function :php:`stdWrap()` and the array :php:`$stdWrapOrder`,
-which represents the exact order of execution.
-
-Note that the :typoscript:`stdWrap` property "orderedStdWrap" allows you to execute
-multiple :typoscript:`stdWrap` functions in a freely selectable order.
-
-The above example could be rewritten to this:
-
-.. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-   10 = TEXT
-   10.value = some text
-   10.stdWrap.case = upper
-   10.stdWrap.field = header
-
-Now the line :typoscript:`10.value = some text` is obsolete, because the whole
-value is "imported" from the field called "header" from the
-:php:`$cObj->data-array`.


### PR DESCRIPTION
releases: main

Remark: In my opinion the "Example" and "Content-supplying properties" part, at the end of the site, should be moved back to the top, like in for example the 10.x version of the TYPO3 Documentation. Because if it is so far down, hardly anyone reads it, but especially the part with the order is very important. If you see this differently or have suggestions for improvement through mistakes, then let me know.

https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/Functions/Stdwrap.html