### PR TITLE
Fix wrong typolink syntax

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -619,7 +619,7 @@ page
 ..  t3-typolink-handler:: page.fragment
 
     :Data Type: string
-    :Example: `t3://page?uid=13&type=3#c123`
+    :Example: `t3://page?uid=13&type=3#123`
 
     The anchor or section to jump to. Must be prefixed with `#`.
 


### PR DESCRIPTION
The section parameter for typolink is not prefixed with a "c" in the database, that "c" is added during FE rendering.