### PR TITLE
[TASK] Improve format description of GIFBUILDER

### DIFF
--- a/Documentation/Gifbuilder/ObjectNames/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Index.rst
@@ -122,6 +122,7 @@ different each time!
          the section "GIFBUILDER".
 
 
+.. _gifbuilder-format:
 
 .. container:: table-row
 
@@ -129,15 +130,18 @@ different each time!
          format
 
    Data type
-         "gif" / "jpg"
+         "gif" / "jpg" / "jpeg" / "png"
 
    Default
          gif
 
    Description
-         Output type.
+         File type of the output image.
 
-         "jpg"/"jpeg" = jpg-image
+         It is possible to define the quality of a JPG image globally via
+         :ref:`$TYPO3_CONF_VARS['GFX']['jpg_quality'] <t3coreapi:typo3ConfVars_gfx_jpg_quality>`
+         or via the :ref:`quality <gifbuilder-quality>` property on a per-image
+         basis.
 
 
 .. container:: table-row
@@ -188,6 +192,8 @@ different each time!
          text with the niceText option.
 
 
+.. _gifbuilder-quality:
+
 .. container:: table-row
 
    Property
@@ -197,7 +203,7 @@ different each time!
          positive integer (10-100)
 
    Description
-         JPG-quality (if ".format" = jpg/jpeg)
+         JPG-quality (if :ref:`.format <gifbuilder-format>` = jpg/jpeg)
 
 
 .. container:: table-row


### PR DESCRIPTION
A PNG file is also possible at least since TYPO3 v11. Additionally, a JPG can either be configured with "jpg" or "jpeg".

Releases: main, 12.4, 11.5