### PR TITLE
[TASK] GIFBUILDER's TEXT.text property allows a fixed string

### DIFF
--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -19,7 +19,7 @@ Properties
          text
 
    Data type
-         ->stdWrap
+         string / :ref:`stdWrap <stdwrap>`
 
    Description
          This is text text-string on the image file. The item is rendered only


### PR DESCRIPTION
Proven by the example introduced with #824.

Releases: main, 12.4, 11.5