### PR TITLE
[BUGFIX] Use main branch for changelog docs

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -107,7 +107,7 @@ t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/12.4/e
 
 # TYPO3 system extensions
 ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/12.4/en-us/
-ext_core           = https://docs.typo3.org/c/typo3/cms-core/12.4/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
 # ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/12.4/en-us/
 # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/12.4/en-us/
 # ext_form           = https://docs.typo3.org/c/typo3/cms-form/12.4/en-us/


### PR DESCRIPTION
Only the main branch is relevant for the changelog. This change avoids the rendering error:

    intersphinx inventory 'https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/objects.inv

Releases: 12.4, 11.5