### PR TITLE
[BUGFIX] Use main branch for changelog docs (#840)

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -81,7 +81,7 @@ t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minute
 
 # TYPO3 system extensions
 ext_adminpanel     = https://docs.typo3.org/c/typo3/cms-adminpanel/11.5/en-us/
-ext_core           = https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/
+ext_core           = https://docs.typo3.org/c/typo3/cms-core/main/en-us/
 # ext_dashboard      = https://docs.typo3.org/c/typo3/cms-dashboard/main/en-us/
 # ext_felogin        = https://docs.typo3.org/c/typo3/cms-felogin/main/en-us/
 # ext_form           = https://docs.typo3.org/c/typo3/cms-form/main/en-us/


### PR DESCRIPTION
Only the main branch is relevant for the changelog. This change avoids the rendering error:

    intersphinx inventory 'https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://docs.typo3.org/c/typo3/cms-core/11.5/en-us/objects.inv

Releases: 12.4, 11.5