### PR TITLE
[TASK] Dissolve Gifbuilder/Gifbuilder chapter

### DIFF
--- a/Documentation/Gifbuilder/Calc.rst
+++ b/Documentation/Gifbuilder/Calc.rst
@@ -1,25 +1,5 @@
 ..  include:: /Includes.rst.txt
-..  index:: GIFBUILDER
-..  _gifbuilder:
-
-==========
-GIFBUILDER
-==========
-
-:typoscript:`GIFBUILDER` is an object type, which is used in many situations for
-creating image files (for example, GIF, PNG or JPG). Wherever the
-->GIFBUILDER object type is mentioned, these are the properties that apply.
-
-Using TypoScript, you can define a "numerical array" of
-:ref:`GIFBUILDER objects <gifbuilder-object-names>` (like
-:ref:`TEXT <gifbuilder-text>`, :ref:`IMAGE <gifbuilder-image>`, etc.)
-and they will be rendered onto an image one by one.
-
-The name :typoscript:`GIFBUILDER` comes from the time when GIF was the only
-supported file format. PNG and JPG can be created as well today (configured with
-:ref:`$TYPO3_CONF_VARS['GFX'] <t3coreapi:typo3ConfVars_gfx>`).
-
-
+..  index:: GIFBUILDER; +calc
 .. _gifbuilder-calc:
 
 Note on (+calc)

--- a/Documentation/Gifbuilder/Index.rst
+++ b/Documentation/Gifbuilder/Index.rst
@@ -1,17 +1,31 @@
 ..  include:: /Includes.rst.txt
+..  _gifbuilder:
 ..  _gifbuilder-toc:
 
 ==========
 GIFBUILDER
 ==========
 
+:typoscript:`GIFBUILDER` is an object type, which is used in many situations for
+creating image files (for example, GIF, PNG or JPG). Wherever the
+->GIFBUILDER object type is mentioned, these are the properties that apply.
+
+Using TypoScript, you can define a "numerical array" of
+:ref:`GIFBUILDER objects <gifbuilder-object-names>` (like
+:ref:`TEXT <gifbuilder-text>`, :ref:`IMAGE <gifbuilder-image>`, etc.)
+and they will be rendered onto an image one by one.
+
+The name :typoscript:`GIFBUILDER` comes from the time when GIF was the only
+supported file format. PNG and JPG can be created as well today (configured with
+:ref:`$TYPO3_CONF_VARS['GFX'] <t3coreapi:typo3ConfVars_gfx>`).
+
+**Table of Contents:**
+
 ..  toctree::
     :maxdepth: 5
     :titlesonly:
     :glob:
 
-    Gifbuilder/Index
-    ObjectNames/Index
     Examples
-    NonGifbuilderObject/Index
-
+    Calc
+    ObjectNames/Index


### PR DESCRIPTION
Under the Gifbuilder folder there is another Gifbuilder folder with the introduction text. The first Gifbuilder folder holds only a TOC.

This patch changes that:
- The introduction text is moved to the start page.
- The text about +calc is moved parallel to the start page. This way it is more prominent as it is displayed in the navigation.
- The TOC now starts with the examples and the +calc chapter. So they are more prominent in the TOC. Then the object reference is following.

The link to the NonGifbuilderObject is a left-over: It was removed in a previous patch and forgotten to remove the link.

Releases: main, 12.4, 11.5