### PR TITLE
[BUGFIX] Add missing caption to GIFBUILDER's OUTLINE.color property

### DIFF
--- a/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
@@ -29,7 +29,7 @@ color
 
 ..  t3-gifbuilder-outline:: color
 
-    :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Color of the outline.
 


### PR DESCRIPTION
Releases: main, 12.4, 11.5