### PR TITLE
FIX: wrong level of 'sword' in TOC

### DIFF
--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -258,7 +258,7 @@ nonTypoTagUserFunc
 .. _parsefunc-sword:
 
 sword
-=====
+-----
 
 .. deprecated:: 11.5
    This functionality has been marked as deprecated as this feature only works


### PR DESCRIPTION
"sword" is rendered wrong in the TOC here: https://docs.typo3.org/m/typo3/reference-typoscript/11.5/en-us/Functions/Parsefunc.html