### PR TITLE
Add label for addPageCacheTags again

### DIFF
--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -70,6 +70,8 @@ setContentToCurrent
 
     Sets the current value to the incoming content of the function.
 
+.. _stdwrap-addpagecachetags:
+
 addPageCacheTags
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
A label existed previously (stdwrap-addpagecachetags) and is still being referenced from TSconfig reference (see warnings).