### PR TITLE
Subpart cache tags are now being propagated to page cache tags

### DIFF
--- a/Documentation/Functions/Cache.rst
+++ b/Documentation/Functions/Cache.rst
@@ -81,7 +81,7 @@ tags
     :Data type: :t3-data-type:`string` / :ref:`stdwrap`
 
     Can hold a comma-separated list of tags. These tags will be attached
-    to the entry added to the `cache_hash` cache (but not to
+    to the entry added to the `cache_hash` cache (and to
     `cache_pages` cache) and can be used to purge the cached content.
 
 


### PR DESCRIPTION
See https://review.typo3.org/c/Packages/TYPO3.CMS/+/80527

The 12.4 backport should be delayed until December 12th, in order to wait for the 12.4.9 release that'll contain mentioned bugfix.

Releases: main, 12.4