### PR TITLE
[TASK] Use confval instead of custom t3-gifbuilder-... directives (#915)

### DIFF
--- a/Documentation/Gifbuilder/Examples.rst
+++ b/Documentation/Gifbuilder/Examples.rst
@@ -455,5 +455,5 @@ create much better quality images:
     use the :ref:`SCALE <gifbuilder-scale>`
     function in GIFBUILDER as the last object in the list to scale them
     down to the desired size. (It will render fonts with anti-aliasing even
-    without the :t3-gifbuilder-text:`niceText` property of the GIFBUILDER
+    without the :ref:`gifbuilder-text-niceText` property of the GIFBUILDER
     :ref:`TEXT <gifbuilder-text>` object enabled as a side effect).

--- a/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
@@ -34,7 +34,7 @@ Properties
 inputLevels
 -----------
 
-..  t3-gifbuilder-adjust:: inputLevels
+..  confval:: inputLevels
 
     :Data type: low, high (int<0,255>, int<0, 255>)
 
@@ -65,7 +65,7 @@ inputLevels
 outputLevels
 ------------
 
-..  t3-gifbuilder-adjust:: outputLevels
+..  confval:: outputLevels
 
     :Data type: low, high (int<0,255>, int<0, 255>)
 
@@ -97,10 +97,10 @@ outputLevels
 autoLevels
 ----------
 
-..  t3-gifbuilder-adjust:: autoLevels
+..  confval:: autoLevels
 
-    Sets the :t3-gifbuilder-adjust:`inputLevels` and
-    :t3-gifbuilder-adjust:`outputLevels` automatically.
+    Sets the :ref:`inputLevels <gifbuilder-adjust-inputLevels>` and
+    :ref:`outputLevels <gifbuilder-adjust-outputLevels>` automatically.
 
     **Example:**
 

--- a/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
@@ -41,7 +41,7 @@ Properties
 align
 -----
 
-..  t3-gifbuilder-box:: align
+..  confval:: align
 
     :Data type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: l, t
@@ -88,7 +88,7 @@ align
 color
 -----
 
-..  t3-gifbuilder-box:: color
+..  confval:: color
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
@@ -101,7 +101,7 @@ color
 dimensions
 ----------
 
-..  t3-gifbuilder-box:: dimensions
+..  confval:: dimensions
 
     :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
@@ -118,7 +118,7 @@ dimensions
 opacity
 -------
 
-..  t3-gifbuilder-box:: opacity
+..  confval:: opacity
 
     :Data type: positive integer (1-100) / :ref:`stdWrap <stdwrap>`
     :Default: 100

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -7,7 +7,7 @@ CROP
 ====
 
 ..  note::
-    This object resets :t3-gifbuilder-property:`workArea` to the
+    This object resets :ref:`gifbuilder-properties-workArea` to the
     new dimensions of the image!
 
 Properties
@@ -21,7 +21,7 @@ Properties
 align
 -----
 
-..  t3-gifbuilder-crop:: align
+..  confval:: align
 
     :Data type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: l, t
@@ -68,7 +68,7 @@ align
 backColor
 ---------
 
-..  t3-gifbuilder-crop:: backColor
+..  confval:: backColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: The original background color
@@ -80,11 +80,11 @@ backColor
 crop
 ----
 
-..  t3-gifbuilder-crop:: crop
+..  confval:: crop
 
     :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` /:ref:`stdWrap <stdwrap>`
 
     x,y is the offset of the crop frame from the position specified by
-    :t3-gifbuilder-crop:`align`.
+    :ref:`align <gifbuilder-crop-align>`.
 
     w,h are the dimensions of the frame.

--- a/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
@@ -61,7 +61,7 @@ Effects
 blur
 ----
 
-..  t3-gifbuilder-effect:: blur
+..  confval:: blur
 
     :Data type: integer (1-99)
     :Default: 0
@@ -82,7 +82,7 @@ blur
 charcoal
 --------
 
-..  t3-gifbuilder-effect:: charcoal
+..  confval:: charcoal
 
     :Data type: integer (0-100)
     :Default: 0
@@ -104,7 +104,7 @@ charcoal
 colors
 ------
 
-..  t3-gifbuilder-effect:: colors
+..  confval:: colors
 
     :Data type: integer (2-255)
 
@@ -124,7 +124,7 @@ colors
 edge
 ----
 
-..  t3-gifbuilder-effect:: edge
+..  confval:: edge
 
     :Data type: integer (0-99)
     :Default: 0
@@ -147,7 +147,7 @@ edge
 emboss
 ------
 
-..  t3-gifbuilder-effect:: emboss
+..  confval:: emboss
 
     Creates a relief effect: Creates highlights or shadows that replace
     light and dark boundaries in the image.
@@ -166,7 +166,7 @@ emboss
 flip
 ----
 
-..  t3-gifbuilder-effect:: flip
+..  confval:: flip
 
     Vertical flipping.
 
@@ -184,7 +184,7 @@ flip
 flop
 ----
 
-..  t3-gifbuilder-effect:: flop
+..  confval:: flop
 
     Horizontal flipping.
 
@@ -202,7 +202,7 @@ flop
 gamma
 -----
 
-..  t3-gifbuilder-effect:: gamma
+..  confval:: gamma
 
     :Data type: double (0.5 - 3.0)
     :Default: 1.0
@@ -223,13 +223,13 @@ gamma
 gray
 ----
 
-..  t3-gifbuilder-effect:: gray
+..  confval:: gray
 
     The image is converted to gray tones.
 
     **Example:**
 
-    This gives the image a slight :t3-gifbuilder-effect:`wave` and
+    This gives the image a slight :ref:`gifbuilder-effect-wave` and
     renders it in gray.
 
     ..  code-block:: typoscript
@@ -244,7 +244,7 @@ gray
 invert
 ------
 
-..  t3-gifbuilder-effect:: invert
+..  confval:: invert
 
     Invert the colors.
 
@@ -262,7 +262,7 @@ invert
 rotate
 ------
 
-..  t3-gifbuilder-effect:: rotate
+..  confval:: rotate
 
     :Data type: integer (0-360)
     :Default: 0
@@ -286,7 +286,7 @@ rotate
 sharpen
 -------
 
-..  t3-gifbuilder-effect:: sharpen
+..  confval:: sharpen
 
     :Data type: integer (0-99)
     :Default: 0
@@ -307,7 +307,7 @@ sharpen
 shear
 -----
 
-..  t3-gifbuilder-effect:: shear
+..  confval:: shear
 
     :Data type: integer (-90 - 90)
     :Default: 0
@@ -331,7 +331,7 @@ shear
 solarize
 --------
 
-..  t3-gifbuilder-effect:: solarize
+..  confval:: solarize
 
     :Data type: integer (0-99)
     :Default: 0
@@ -356,7 +356,7 @@ solarize
 swirl
 -----
 
-..  t3-gifbuilder-effect:: swirl
+..  confval:: swirl
 
     :Data type: integer (0-1000)
     :Default: 0
@@ -377,7 +377,7 @@ swirl
 wave
 ----
 
-..  t3-gifbuilder-effect:: wave
+..  confval:: wave
 
     :Data type: integer,integer (both 0-99)
     :Default: 0,0

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -38,7 +38,7 @@ Properties
 color
 -----
 
-..  t3-gifbuilder-ellipse:: color
+..  confval:: color
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
@@ -51,7 +51,7 @@ color
 dimensions
 ----------
 
-..  t3-gifbuilder-ellipse:: dimensions
+..  confval:: dimensions
 
     :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
@@ -23,7 +23,7 @@ Properties
 blur
 ----
 
-..  t3-gifbuilder-emboss:: blur
+..  confval:: blur
 
     :Data type: integer (1-99) / :ref:`stdWrap <stdwrap>`
 
@@ -36,7 +36,7 @@ blur
 highColor
 ---------
 
-..  t3-gifbuilder-emboss:: highColor
+..  confval:: highColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
@@ -48,7 +48,7 @@ highColor
 intensity
 ---------
 
-..  t3-gifbuilder-emboss:: intensity
+..  confval:: intensity
 
     :Data type: integer (0-100) / :ref:`stdWrap <stdwrap>`
 
@@ -61,7 +61,7 @@ intensity
 lowColor
 --------
 
-..  t3-gifbuilder-emboss:: lowColor
+..  confval:: lowColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
@@ -73,7 +73,7 @@ lowColor
 opacity
 -------
 
-..  t3-gifbuilder-emboss:: opacity
+..  confval:: opacity
 
     :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
@@ -81,7 +81,7 @@ opacity
     speaking: Opacity = Transparency^-1. For example, 100% opacity = 0%
     transparency.
 
-    Only active with a value for :t3-gifbuilder-emboss:`blur`.
+    Only active with a value for :ref:`gifbuilder-emboss-blur`.
 
 
 ..  _gifbuilder-emboss-offset:
@@ -89,7 +89,7 @@ opacity
 offset
 ------
 
-..  t3-gifbuilder-emboss:: offset
+..  confval:: offset
 
     :Data type: x,y / :ref:`stdWrap <stdwrap>`
 
@@ -101,7 +101,7 @@ offset
 textObjNum
 ----------
 
-..  t3-gifbuilder-emboss:: textObjNum
+..  confval:: textObjNum
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
@@ -21,7 +21,7 @@ Properties
 align
 -----
 
-..  t3-gifbuilder-image:: align
+..  confval:: align
 
     :Data type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: 1,1
@@ -68,7 +68,7 @@ align
 file
 ----
 
-..  t3-gifbuilder-image:: file
+..  confval:: file
 
     :Data type: :t3-data-type:`imgResource`
 
@@ -80,7 +80,7 @@ file
 mask
 ----
 
-..  t3-gifbuilder-image:: mask
+..  confval:: mask
 
     :Data type: :t3-data-type:`imgResource`
 
@@ -92,7 +92,7 @@ mask
 offset
 ------
 
-..  t3-gifbuilder-image:: offset
+..  confval:: offset
 
     :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
@@ -105,7 +105,7 @@ offset
 tile
 ----
 
-..  t3-gifbuilder-image:: tile
+..  confval:: tile
 
     :Data type: x,y / :ref:`stdWrap <stdwrap>`
     :Default: 1,1

--- a/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
@@ -27,7 +27,7 @@ Properties
 color
 -----
 
-..  t3-gifbuilder-outline:: color
+..  confval:: color
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
@@ -39,7 +39,7 @@ color
 textObjNum
 ----------
 
-..  t3-gifbuilder-outline:: textObjNum
+..  confval:: textObjNum
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 
@@ -57,7 +57,7 @@ textObjNum
 thickness
 ---------
 
-..  t3-gifbuilder-outline:: thickness
+..  confval:: thickness
 
     :Data type: x,y / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/ObjectNames/Scale/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Scale/Index.rst
@@ -9,7 +9,7 @@ SCALE
 This scales the GIFBUILDER object to the provided dimensions.
 
 ..  note::
-    This object resets :t3-gifbuilder-property:`workArea` to the new dimensions
+    This object resets :ref:`gifbuilder-properties-workArea` to the new dimensions
     of the image!
 
 
@@ -25,7 +25,7 @@ Properties
 height
 ------
 
-..  t3-gifbuilder-scale:: height
+..  confval:: height
 
     :Data type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
@@ -37,7 +37,7 @@ height
 params
 ------
 
-..  t3-gifbuilder-scale:: params
+..  confval:: params
 
     :Data type: GraphicsMagick/ImageMagick parameters
 
@@ -49,7 +49,7 @@ params
 width
 -----
 
-..  t3-gifbuilder-scale:: width
+..  confval:: width
 
     :Data type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
@@ -20,7 +20,7 @@ Properties
 blur
 ----
 
-..  t3-gifbuilder-shadow:: blur
+..  confval:: blur
 
     :Data type: integer (1-99) / :ref:`stdWrap <stdwrap>`
 
@@ -33,7 +33,7 @@ blur
 color
 -----
 
-..  t3-gifbuilder-shadow:: color
+..  confval:: color
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
@@ -45,7 +45,7 @@ color
 intensity
 ---------
 
-..  t3-gifbuilder-shadow:: intensity
+..  confval:: intensity
 
     :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
@@ -58,7 +58,7 @@ intensity
 offset
 ------
 
-..  t3-gifbuilder-shadow:: offset
+..  confval:: offset
 
     :Data type: x,y / :ref:`stdWrap <stdwrap>`
 
@@ -70,7 +70,7 @@ offset
 opacity
 -------
 
-..  t3-gifbuilder-shadow:: opacity
+..  confval:: opacity
 
     :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
@@ -78,7 +78,7 @@ opacity
     speaking: Opacity = Transparency^-1. E.g. 100% opacity = 0%
     transparency.
 
-    Only active with a value for :t3-gifbuilder-shadow:`blur`.
+    Only active with a value for :ref:`gifbuilder-shadow-blur`.
 
 
 ..  _gifbuilder-shadow-textObjNum:
@@ -86,7 +86,7 @@ opacity
 textObjNum
 ----------
 
-..  t3-gifbuilder-shadow:: textObjNum
+..  confval:: textObjNum
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -21,12 +21,12 @@ Properties
 align
 -----
 
-..  t3-gifbuilder-text:: align
+..  confval:: align
 
     :Data type: align / :ref:`stdWrap <stdwrap>`
     :Default: left
 
-    The alignment of the :t3-gifbuilder-text:`text`.
+    The alignment of the :ref:`gifbuilder-text-text`.
 
     Possible values:
 
@@ -40,17 +40,17 @@ align
 angle
 -----
 
-..  t3-gifbuilder-text:: angle
+..  confval:: angle
 
     :Data type: :t3-data-type:`degree`
     :Default: 0
     :Range: -90 to 90
 
-    The rotation degree of the :t3-gifbuilder-text:`text`.
+    The rotation degree of the :ref:`gifbuilder-text-text`.
 
     ..  note::
-        The angle is not available, if :t3-gifbuilder-text:`spacing`
-        / :t3-gifbuilder-text:`wordSpacing` is set.
+        The angle is not available, if :ref:`gifbuilder-text-spacing`
+        / :ref:`gifbuilder-text-wordSpacing` is set.
 
 
 ..  _gifbuilder-text-antiAlias:
@@ -58,7 +58,7 @@ angle
 antiAlias
 ---------
 
-..  t3-gifbuilder-text:: antiAlias
+..  confval:: antiAlias
 
     :Data type: boolean
     :Default: 1 (true)
@@ -67,10 +67,10 @@ antiAlias
 
     ..  note::
         This option is not available, if
-        :t3-gifbuilder-text:`niceText` is enabled.
+        :ref:`gifbuilder-text-niceText` is enabled.
 
         Setting this option to :typoscript:`0` will not work, if
-        :t3-gifbuilder-text:`fontColor` is set to black (or #000000).
+        :ref:`gifbuilder-text-fontColor` is set to black (or #000000).
 
 
 ..  _gifbuilder-text-breakSpace:
@@ -78,7 +78,7 @@ antiAlias
 breakSpace
 ----------
 
-..  t3-gifbuilder-text:: breakSpace
+..  confval:: breakSpace
 
     :Data type: float
     :Default: 1.0
@@ -92,7 +92,7 @@ breakSpace
 breakWidth
 ----------
 
-..  t3-gifbuilder-text:: breakWidth
+..  confval:: breakWidth
 
     :Data type: integer / :ref:`stdWrap <stdwrap>`
 
@@ -105,12 +105,12 @@ breakWidth
 doNotStripHTML
 --------------
 
-..  t3-gifbuilder-text:: doNotStripHTML
+..  confval:: doNotStripHTML
 
     :Data type: boolean
     :Default: 0 (false)
 
-    If set, HTML tags inserted in the :t3-gifbuilder-text:`text` are
+    If set, HTML tags inserted in the :ref:`gifbuilder-text-text` are
     **not** removed. Any other HTML code will be removed by default!
 
 
@@ -119,7 +119,7 @@ doNotStripHTML
 emboss
 ------
 
-..  t3-gifbuilder-text:: emboss
+..  confval:: emboss
 
     :Data type: GIFBUILDER object :ref:`->EMBOSS <gifbuilder-emboss>`
 
@@ -129,7 +129,7 @@ emboss
 fontColor
 ---------
 
-..  t3-gifbuilder-text:: fontColor
+..  confval:: fontColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
@@ -142,7 +142,7 @@ fontColor
 fontFile
 --------
 
-..  t3-gifbuilder-text:: fontFile
+..  confval:: fontFile
 
     :Data type: resource / :ref:`stdWrap <stdwrap>`
     :Default: Nimbus (Arial clone)
@@ -156,7 +156,7 @@ fontFile
 fontSize
 --------
 
-..  t3-gifbuilder-text:: fontSize
+..  confval:: fontSize
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 12
@@ -169,7 +169,7 @@ fontSize
 hide
 ----
 
-..  t3-gifbuilder-text:: hide
+..  confval:: hide
 
     :Data type: boolean / :ref:`stdWrap <stdwrap>`
     :Default: 0 (false)
@@ -186,17 +186,17 @@ hide
 iterations
 ----------
 
-..  t3-gifbuilder-text:: iterations
+..  confval:: iterations
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 1
 
-    How many times the :t3-gifbuilder-text:`text` should be "printed"
+    How many times the :ref:`gifbuilder-text-text` should be "printed"
     onto it self. This will add the effect of bold text.
 
     ..  note::
         This option is not available, if
-        :t3-gifbuilder-text:`niceText` is enabled.
+        :ref:`gifbuilder-text-niceText` is enabled.
 
 
 ..  _gifbuilder-text-maxWidth:
@@ -204,16 +204,16 @@ iterations
 maxWidth
 --------
 
-..  t3-gifbuilder-text:: maxWidth
+..  confval:: maxWidth
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 
-    Sets the maximum width in pixels, the :t3-gifbuilder-text:`text`
-    must be. Reduces the :t3-gifbuilder-text:`fontSize`, if the
+    Sets the maximum width in pixels, the :ref:`gifbuilder-text-text`
+    must be. Reduces the :ref:`gifbuilder-text-fontSize`, if the
     text does not fit within this width.
 
     Does not support setting alternative font sizes in
-    :t3-gifbuilder-text:`splitRendering` options.
+    :ref:`gifbuilder-text-splitRendering` options.
 
 
 ..  _gifbuilder-text-niceText:
@@ -221,7 +221,7 @@ maxWidth
 niceText
 --------
 
-..  t3-gifbuilder-text:: niceText
+..  confval:: niceText
 
     :Data type: boolean / :ref:`stdWrap <stdwrap>`
 
@@ -232,7 +232,7 @@ niceText
     The principle of this function is to create a black/white image file in
     twice or more times the size of the actual image file and then print the
     text onto this in a scaled dimension. Afterwards GraphicsMagick/ImageMagick
-    scales down the mask and masks the :t3-gifbuilder-text:`fontColor` down on
+    scales down the mask and masks the :ref:`gifbuilder-text-fontColor` down on
     the original image file through the temporary mask.
 
     The fact that the font is actually rendered in the double size and
@@ -246,7 +246,7 @@ niceText
 after
 ~~~~~
 
-..  t3-gifbuilder-text:: niceText.after
+..  confval:: niceText.after
 
     GraphicsMagick/ImageMagick parameters after scale.
 
@@ -256,7 +256,7 @@ after
 before
 ~~~~~~
 
-..  t3-gifbuilder-text:: niceText.before
+..  confval:: niceText.before
 
     GraphicsMagick/ImageMagick parameters before scale.
 
@@ -266,7 +266,7 @@ before
 scaleFactor
 ~~~~~~~~~~~
 
-..  t3-gifbuilder-text:: niceText.scaleFactor
+..  confval:: niceText.scaleFactor
 
     :Data type: integer (2-5)
 
@@ -278,7 +278,7 @@ scaleFactor
 sharpen
 ~~~~~~~
 
-..  t3-gifbuilder-text:: niceText.sharpen
+..  confval:: niceText.sharpen
 
     :Data type: integer (0-99)
 
@@ -291,12 +291,12 @@ sharpen
 offset
 ------
 
-..  t3-gifbuilder-text:: offset
+..  confval:: offset
 
     :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
 
-    The offset of the :t3-gifbuilder-text:`text`.
+    The offset of the :ref:`gifbuilder-text-text`.
 
 
 ..  _gifbuilder-text-outline:
@@ -304,7 +304,7 @@ offset
 outline
 -------
 
-..  t3-gifbuilder-text:: outline
+..  confval:: outline
 
     :Data type: GIFBUILDER object :ref:`->OUTLINE <gifbuilder-outline>`
 
@@ -314,7 +314,7 @@ outline
 shadow
 ------
 
-..  t3-gifbuilder-text:: shadow
+..  confval:: shadow
 
     :Data type: GIFBUILDER object :ref:`->SHADOW <gifbuilder-shadow>`
 
@@ -324,7 +324,7 @@ shadow
 spacing
 -------
 
-..  t3-gifbuilder-text:: spacing
+..  confval:: spacing
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 0
@@ -337,7 +337,7 @@ spacing
 splitRendering
 --------------
 
-..  t3-gifbuilder-text:: splitRendering
+..  confval:: splitRendering
 
     :Data type: integer / *(array of keys)*
 
@@ -358,7 +358,7 @@ splitRendering
 [array]
 ~~~~~~~
 
-..  t3-gifbuilder-text:: splitRendering.[array]
+..  confval:: splitRendering.[array]
 
     :Data type: integer
 
@@ -375,7 +375,7 @@ splitRendering
         *   **fontSize:** Alternative font size for this rendering.
 
         *   **color:** Alternative color for this rendering, works *only*
-            without :t3-gifbuilder-text:`niceText`.
+            without :ref:`gifbuilder-text-niceText`.
 
         *   **xSpaceBefore:** x space before this part.
 
@@ -407,7 +407,7 @@ splitRendering
     **Limitations:**
 
     *   The pixel compensation values are not corrected for scale factor used
-        with :t3-gifbuilder-text:`niceText`. Basically this means
+        with :ref:`gifbuilder-text-niceText`. Basically this means
         that when :typoscript:`niceText` is used, these values will have only
         the half effect.
 
@@ -442,7 +442,7 @@ splitRendering
 compX
 ~~~~~
 
-..  t3-gifbuilder-text:: splitRendering.compX
+..  confval:: splitRendering.compX
 
     :Data type: integer
 
@@ -454,7 +454,7 @@ compX
 compY
 ~~~~~
 
-..  t3-gifbuilder-text:: splitRendering.compY
+..  confval:: splitRendering.compY
 
     :Data type: integer
 
@@ -466,7 +466,7 @@ compY
 text
 ----
 
-..  t3-gifbuilder-text:: text
+..  confval:: text
 
     :Data type: string / :ref:`stdWrap <stdwrap>`
 
@@ -482,12 +482,12 @@ text
 textMaxLength
 -------------
 
-..  t3-gifbuilder-text:: textMaxLength
+..  confval:: textMaxLength
 
     :Data type: integer
     :Default: 100
 
-    The maximum length of the :t3-gifbuilder-text:`text`. This is just a
+    The maximum length of the :ref:`gifbuilder-text-text`. This is just a
     natural break that prevents incidental rendering of very long texts!
 
 
@@ -496,7 +496,7 @@ textMaxLength
 wordSpacing
 -----------
 
-..  t3-gifbuilder-text:: wordSpacing
+..  confval:: wordSpacing
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: :ref:`spacing <gifbuilder-text-spacing>` * 2

--- a/Documentation/Gifbuilder/ObjectNames/Workarea/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Workarea/Index.rst
@@ -20,7 +20,7 @@ Properties
 clear
 -----
 
-..  t3-gifbuilder-workarea:: clear
+..  confval:: clear
 
     :Data type: string
 
@@ -35,7 +35,7 @@ clear
 set
 ---
 
-..  t3-gifbuilder-workarea:: set
+..  confval:: set
 
     :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 

--- a/Documentation/Gifbuilder/Properties.rst
+++ b/Documentation/Gifbuilder/Properties.rst
@@ -14,7 +14,7 @@ Properties
 1,2,3,4...
 ==========
 
-..  t3-gifbuilder-property:: 1,2,3,4...
+..  confval:: 1,2,3,4...
 
     :Data type: :ref:`Gifbuilder Object <gifbuilder-object-names>` + .if (:ref:`->if <if>`)
 
@@ -29,7 +29,7 @@ Properties
 backColor
 =========
 
-..  t3-gifbuilder-property:: backColor
+..  confval:: backColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: white
@@ -47,7 +47,7 @@ charRangeMap
 [array]
 -------
 
-..  t3-gifbuilder-property:: charRangeMap.[array]
+..  confval:: charRangeMap.[array]
 
     :Data type: string
 
@@ -64,10 +64,10 @@ charRangeMap
     **The key:**
 
     The value of the array key will be the key used when forcing the
-    configuration into :t3-gifbuilder-text:`splitRendering`
+    configuration into :ref:`gifbuilder-text-splitRendering`
     configuration of the individual
     :ref:`GIFBUILDER objects <gifbuilder-object-names>`.
-    In the :t3-gifbuilder-property:`charRangeMap.[array].pixelSpaceFontSizeRef`
+    In the :ref:`gifbuilder-properties-charRangeMap-array`
     example below the key is :typoscript:`123`.
 
     ..  note::
@@ -81,7 +81,7 @@ charRangeMap
 [array].charMapConfig
 ---------------------
 
-..  t3-gifbuilder-property:: charRangeMap.[array].charMapConfig
+..  confval:: charRangeMap.[array].charMapConfig
 
     :Data type: :ref:`TEXT <gifbuilder-text>` / :ref:`splitRendering.[array] <gifbuilder-text-splitRendering>` configuration
 
@@ -94,14 +94,14 @@ charRangeMap
 [array].fontSizeMultiplicator
 -----------------------------
 
-..  t3-gifbuilder-property:: charRangeMap.[array].fontSizeMultiplicator
+..  confval:: charRangeMap.[array].fontSizeMultiplicator
 
     :Data type: double
 
     If set, this will take the font size of the
     :ref:`GIFBUILDER TEXT object <gifbuilder-text>` and multiply with this
-    amount (xx.xx) and override the :t3-gifbuilder-text:`fontSize` property
-    inside :t3-gifbuilder-property:`charRangeMap.[array].charMapConfig`.
+    amount (xx.xx) and override the :ref:`gifbuilder-text-fontSize` property
+    inside :ref:`gifbuilder-properties-charRangeMap-charMapConfig`.
 
 
 ..  _gifbuilder-properties-charRangeMap-pixelSpaceFontSizeRef:
@@ -109,7 +109,7 @@ charRangeMap
 [array].pixelSpaceFontSizeRef
 -----------------------------
 
-..  t3-gifbuilder-property:: charRangeMap.[array].pixelSpaceFontSizeRef
+..  confval:: charRangeMap.[array].pixelSpaceFontSizeRef
 
     :Data type: double
 
@@ -153,7 +153,7 @@ charRangeMap
 format
 ======
 
-..  t3-gifbuilder-property:: format
+..  confval:: format
 
     :Data type: "gif" / "jpg" / "jpeg" / "png"
     :Default: gif
@@ -162,7 +162,7 @@ format
 
     It is possible to define the quality of a JPG image globally via
     :ref:`$TYPO3_CONF_VARS['GFX']['jpg_quality'] <t3coreapi:typo3ConfVars_gfx_jpg_quality>`
-    or via the :t3-gifbuilder-property:`quality` property on a per-image basis.
+    or via the :ref:`gifbuilder-properties-quality` property on a per-image basis.
 
 
 .. _gifbuilder-properties-maxHeight:
@@ -170,7 +170,7 @@ format
 maxHeight
 =========
 
-..  t3-gifbuilder-property:: maxHeight
+..  confval:: maxHeight
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 
@@ -182,7 +182,7 @@ maxHeight
 maxWidth
 ========
 
-..  t3-gifbuilder-property:: maxWidth
+..  confval:: maxWidth
 
     :Data type: positive integer / :ref:`stdWrap <stdwrap>`
 
@@ -194,7 +194,7 @@ maxWidth
 offset
 ======
 
-..  t3-gifbuilder-property:: offset
+..  confval:: offset
 
     :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
@@ -207,11 +207,11 @@ offset
 quality
 =======
 
-..  t3-gifbuilder-property:: quality
+..  confval:: quality
 
     :Data type: positive integer (10-100)
 
-    JPG quality (if :t3-gifbuilder-property:`format` = jpg/jpeg)
+    JPG quality (if :ref:`gifbuilder-properties-format` = jpg/jpeg)
 
 
 .. _gifbuilder-properties-reduceColors:
@@ -219,7 +219,7 @@ quality
 reduceColors
 ============
 
-..  t3-gifbuilder-property:: reduceColors
+..  confval:: reduceColors
 
     :Data type: integer (1-255) / :ref:`stdWrap <stdwrap>`
 
@@ -231,7 +231,7 @@ reduceColors
 transparentBackground
 =====================
 
-..  t3-gifbuilder-property:: transparentBackground
+..  confval:: transparentBackground
 
     :Data type: boolean / :ref:`stdWrap <stdwrap>`
 
@@ -239,7 +239,7 @@ transparentBackground
     color found at position 0,0 of the image (upper left corner) transparent.
 
     If you render text, you should leave the
-    :t3-gifbuilder-text:`niceText` option **off** as the result will
+    :ref:`gifbuilder-text-niceText` option **off** as the result will
     probably be more precise without the :typoscript:`niceText` antialiasing
     hack.
 
@@ -249,7 +249,7 @@ transparentBackground
 transparentColor
 ================
 
-..  t3-gifbuilder-property:: transparentColor
+..  confval:: transparentColor
 
     :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
 
@@ -261,7 +261,7 @@ transparentColor
 closest
 -------
 
-..  t3-gifbuilder-property:: transparentColor.closest
+..  confval:: transparentColor.closest
 
     :Data Type: boolean
 
@@ -270,7 +270,7 @@ closest
 
     ..  note::
         You may experience that this does not work, if you render text with the
-        :t3-gifbuilder-text:`niceText` option.
+        :ref:`gifbuilder-text-niceText` option.
 
 
 .. _gifbuilder-properties-workArea:
@@ -278,7 +278,7 @@ closest
 workArea
 ========
 
-..  t3-gifbuilder-property:: workArea
+..  confval:: workArea
 
     :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
@@ -294,7 +294,7 @@ workArea
 XY
 ==
 
-..  t3-gifbuilder-property:: XY
+..  confval:: XY
 
     :Data type: x,y :ref:`+calc <gifbuilder-calc>` (1-2000) / :ref:`stdWrap <stdwrap>`
     :Default: 120,50

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -75,20 +75,6 @@ t3-function-strpad = t3-function-strpad // t3-function-strpad // Function strPad
 t3-function-tags = t3-function-tags // t3-function-tags // Function tags
 t3-function-typolink = t3-function-typolink // t3-function-typolink // Function typolink
 
-t3-gifbuilder-adjust = t3-gifbuilder-adjust // t3-gifbuilder-adjust // GIFBUILDER object ADJUST
-t3-gifbuilder-box = t3-gifbuilder-box // t3-gifbuilder-box // GIFBUILDER object BOX
-t3-gifbuilder-crop = t3-gifbuilder-crop // t3-gifbuilder-crop // GIFBUILDER object CROP
-t3-gifbuilder-effect = t3-gifbuilder-effect // t3-gifbuilder-effect // GIFBUILDER object EFFECT
-t3-gifbuilder-ellipse = t3-gifbuilder-ellipse // t3-gifbuilder-ellipse // GIFBUILDER object ELLIPSE
-t3-gifbuilder-emboss = t3-gifbuilder-emboss // t3-gifbuilder-emboss // GIFBUILDER object EMBOSS
-t3-gifbuilder-image = t3-gifbuilder-image // t3-gifbuilder-image // GIFBUILDER object IMAGE
-t3-gifbuilder-outline = t3-gifbuilder-outline // t3-gifbuilder-outline // GIFBUILDER object OUTLINE
-t3-gifbuilder-property = t3-gifbuilder-property // t3-gifbuilder-property // GIFBUILDER property
-t3-gifbuilder-scale = t3-gifbuilder-scale // t3-gifbuilder-scale // GIFBUILDER object SCALE
-t3-gifbuilder-shadow = t3-gifbuilder-shadow // t3-gifbuilder-shadow // GIFBUILDER object SHADOW
-t3-gifbuilder-text = t3-gifbuilder-text // t3-gifbuilder-text // GIFBUILDER object TEXT
-t3-gifbuilder-workarea = t3-gifbuilder-workarea // t3-gifbuilder-workarea // GIFBUILDER object WORKAREA
-
 t3-menu-tmenu = t3-menu-tmenu // t3-menu-tmenu // TMENU
 t3-menu-tmenu-state = t3-menu-tmenu-state // t3-menu-tmenu-state // TMENU state
 t3-menu-tmenu-item = t3-menu-tmenu-item // t3-menu-tmenu-item // TMENU item


### PR DESCRIPTION
This eases the migration to the PHP-based documentation rendering.