### PR TITLE
[TASK] Avoid info about TSFE->lastImgResourceInfo

### DIFF
--- a/Documentation/ContentObjects/ImgResource/Index.rst
+++ b/Documentation/ContentObjects/ImgResource/Index.rst
@@ -10,12 +10,6 @@ Objects of type IMG_RESOURCE returns a reference to an image, possibly
 wrapped with :t3-cobj-img-resource:`stdWrap`. Can
 for example be used for putting background images in tables or
 table rows or to import an image in your own include scripts.
-
-The array :php:`$GLOBALS['TSFE']->lastImgResourceInfo` is set to the info
-array of the resulting image resource (if any) and contains width,
-height and so on (similar to how :php:`$GLOBALS['TSFE']->lastImageInfo`
-does for the cObject IMAGE).
-
 Depending on your use case you might prefer using the cObject
 :ref:`IMAGE <cobj-image>`, which creates a complete :html:`img` tag.
 


### PR DESCRIPTION
Remove this note - this was a workaround from the old days and isn't in use anymore, especially with images being rendered using fluid or similar.

Releases: main