### PR TITLE
[TASK] Replace "t3-data-type" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -242,7 +242,7 @@ Expanded form:
     // STEP 6: Return 'totalResult'
 
 
-See also: :ref:`if`, :ref:`select`, :t3-data-type:`wrap`, :ref:`stdWrap`,
+See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`,
 :ref:`data-type-cobject`
 
 

--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -23,7 +23,7 @@ extensionName
 
 ..  t3-cobj-extbaseplugin:: extensionName
 
-    :Data type: :ref:`string`
+    :Data type: :ref:`data-type-string`
 
     The :ref:`extension name <t3coreapi:extension-naming-extensionName>`.
 
@@ -33,7 +33,7 @@ pluginName
 
 ..  t3-cobj-extbaseplugin:: pluginName
 
-    :Data type: :ref:`string`
+    :Data type: :ref:`data-type-string`
 
     The plugin name.
 

--- a/Documentation/ContentObjects/Hmenu/Categories.rst
+++ b/Documentation/ContentObjects/Hmenu/Categories.rst
@@ -66,7 +66,7 @@ special.relation
          special.relation
 
    Data type
-         :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
    Default
          special.categories
@@ -88,7 +88,7 @@ special.sorting
          special.sorting
 
    Data type
-         :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
    Description
          Which field from the "pages" table should be used for sorting.

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -99,7 +99,7 @@ layoutKey
 
 ..  t3-cobj-image:: layoutKey
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: default
 
     Defines the render layout for the IMAGE. The render layout is the HTML Code for the IMAGE itself.
@@ -195,7 +195,7 @@ layout.layoutKey.element
 
 ..  t3-cobj-image:: layout.layoutKey.element
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     The outer element definition for the HTML rendering of the image.
     Possible markers are mainly all parameters which can be defined in the
@@ -476,7 +476,7 @@ linkWrap
 
 ..  t3-cobj-image:: linkWrap
 
-    :Data type: :t3-data-type:`wrap` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     (before ".wrap")
 

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -45,7 +45,7 @@ src
 
 ..  t3-cobj-svg:: src
 
-    :Data type: :t3-data-type:`resource` /:ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-resource` /:ref:`stdWrap <stdwrap>`
 
     SVG file resource, can also be referenced via :file:`EXT:` prefix to
     point to files of extensions.

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -44,7 +44,7 @@ userFunc
 
 ..  t3-cobj-user:: userFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     The name of the function, which should be called. If you specify the
     name with a '->' in it, then it is interpreted as a call to a method in

--- a/Documentation/DataTypes/Index.rst
+++ b/Documentation/DataTypes/Index.rst
@@ -1,7 +1,7 @@
-.. include:: /Includes.rst.txt
-.. index:: Simple data types
-.. _data-types:
-.. _data-types-reference:
+..  include:: /Includes.rst.txt
+..  index:: Simple data types
+..  _data-types:
+..  _data-types-reference:
 
 =================
 Simple data types
@@ -19,23 +19,30 @@ RGB-values have to be provided.
 The following is a list of available data types, their usage, purpose and
 examples.
 
-.. contents::
-   :local:
+..  contents::
+    :local:
+
+..  index:: Simple data types; align
+..  _data-type-align:
 
 align
 =====
 
-..  t3-data-type:: align
+..  confval:: align
 
     :Default: :typoscript:`left`
     :Allowed values: :typoscript:`left`, :typoscript:`center`, :typoscript:`right`
 
     Decides about alignment.
 
+
+..  index:: Simple data types; boolean
+..  _data-type-boolean:
+
 boolean
 =======
 
-..  t3-data-type:: boolean
+..  confval:: boolean
 
     Possible values for boolean variables are `1` and `0`
     meaning TRUE and FALSE.
@@ -55,10 +62,14 @@ boolean
        dummy.enable = 1   # true,  preferred notation
        dummy.enable =     # false, because the value is empty
 
+
+..  index:: Simple data types; case
+..  _data-type-case:
+
 case
 ====
 
-..  t3-data-type:: case
+..  confval:: case
 
 
     Do a case conversion.
@@ -90,15 +101,19 @@ case
 
     Result:
 
-    ..  code-block:: html
+    ..  code-block:: text
         :caption: Example Output
 
         HELLO WORLD!
 
+
+..  index:: Simple data types; date-conf
+..  _data-type-date-conf:
+
 date-conf
 =========
 
-..  t3-data-type:: date-conf
+..  confval:: date-conf
 
     Used to format a date, see PHP function :php:`date()`. See the
     documentation of `allowed date time formats in
@@ -111,19 +126,27 @@ date-conf
 
         page.10.date-conf = d-m-y
 
+
+..  index:: Simple data types; degree
+..  _data-type-degree:
+
 degree
 ======
 
-..  t3-data-type:: degree
+..  confval:: degree
 
     `-90` to `90`, integers
 
     Example: `45`
 
+
+..  index:: Simple data types; dir
+..  _data-type-dir:
+
 dir
 ===
 
-..  t3-data-type:: dir
+..  confval:: dir
 
     ..  rubric:: Syntax
 
@@ -146,10 +169,14 @@ dir
 
         page.10.dir = fileadmin/files/ | pdf,gif,jpg | name | r | true
 
+
+..  index:: Simple data types; function name
+..  _data-type-function-name:
+
 function name
 =============
 
-..  t3-data-type:: function name
+..  confval:: function name
 
     Indicates a function or method in a class to call. See more information at
     the :ref:`USER cObject <cobj-user>`.
@@ -161,7 +188,7 @@ function name
     TypoScript configuration and :php:`$content`, some content to be processed and
     returned.
 
-    ..  Which entry in TYPO3_CONF_VARS enables the user-prefix to be changed? This
+    ..  todo: Which entry in TYPO3_CONF_VARS enables the user-prefix to be changed? This
         should be mentioned. Looks like this entry has gone and this info no
         longer valid.
 
@@ -171,27 +198,31 @@ function name
     instead. See the document "Inside TYPO3" for more information on extending
     classes in TYPO3!
 
-    .. Where is this feature mentioned? We should add a reference here.
+    ..  todo: Where is this feature mentioned? We should add a reference here.
 
     ..  rubric:: Examples
 
     Method in namespaced class. This is the preferred version:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         Your\NameSpace\YourClass->reverseString
 
     Single Function:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         user_reverseString
 
     Method in class without namespace:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         user_yourClass->reverseString
+
+
+..  index:: Simple data types; getText
+..  _data-type-getText:
 
 getText
 =======
@@ -199,10 +230,14 @@ getText
 The getText data type is some kind of tool box allowing to retrieve
 values from a variety of sources. Read more: :ref:`data-type-gettext`
 
+
+..  index:: Simple data types; GraphicColor
+..  _data-type-GraphicColor:
+
 GraphicColor
 ============
 
-..  t3-data-type:: GraphicColor
+..  confval:: GraphicColor
 
     ..  rubric:: Syntax:
 
@@ -228,10 +263,14 @@ GraphicColor
     *   :typoscript:`red : *0.8` ("red" is darkened by factor 0.8)
     *   :typoscript:`#ffeecc : +16` ("ffeecc" is going to #fffedc because 16 is added)
 
+
+..  index:: Simple data types; imageExtension
+..  _data-type-imageExtension:
+
 imageExtension
 ==============
 
-..  t3-data-type:: imageExtension
+..  confval:: imageExtension
 
     Image extensions can be anything among the allowed types defined in the
     global variable :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.
@@ -246,21 +285,25 @@ imageExtension
 
     web *(gif or jpg ..)*
 
+
+..  index:: Simple data types; imgResource
+..  _data-type-imgResource:
+
 imgResource
 ===========
 
-.. todo: This seems to be a duplicate of Documentation/Functions/Imgresource.rst?
+..  todo: This seems to be a duplicate of Documentation/Functions/Imgresource.rst?
 
-..  t3-data-type:: imgResource
+..  confval:: imgResource
 
-    #.  A :t3-data-type:`resource` plus imgResource properties.
+    #.  A :confval:`resource` plus imgResource properties.
 
         Filetypes can be anything among the allowed types defined in the
         configuration variable
         :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.  Standard is
         pdf, gif, jpg, jpeg, tif, bmp, ai, pcx, tga, png.
 
-    #.  A GIFBUILDER object. See the object reference for :ref:`gifbuilder` below.
+    #.  A GIFBUILDER object. See the object reference for :ref:`gifbuilder`.
 
     ..  rubric:: Examples
 
@@ -286,10 +329,14 @@ imgResource
             # GIFBUILDER properties here...
         }
 
+
+..  index:: Simple data types; integer
+..  _data-type-integer:
+
 integer
 =======
 
-..  t3-data-type:: integer
+..  confval:: integer
 
     ..  rubric:: Examples
 
@@ -297,12 +344,16 @@ integer
 
 
     This data type is sometimes used generally though another type would have
-    been more appropriate, like :t3-data-type:`pixels`.
+    been more appropriate, like :ref:`pixels <data-type-pixels>`.
+
+
+..  index:: Simple data types; path
+..  _data-type-path:
 
 path
 ====
 
-..  t3-data-type:: path
+..  confval:: path
 
 
     Path relative to the root directory from which we operate.
@@ -315,11 +366,14 @@ path
 
         page.10.settings.somePath = fileadmin/stuff/
 
+
+..  index:: Simple data types; pixels
+..  _data-type-pixels:
+
 pixels
 ======
 
-..  t3-data-type:: pixels
-
+..  confval:: pixels
 
     pixel-distance
 
@@ -330,22 +384,30 @@ pixels
 
         page.10.someWidth = 345
 
+
+..  index:: Simple data types; positive integer
+..  _data-type-positive-integer:
+
 positive integer
 ================
 
-..  t3-data-type:: positive integer
+..  confval:: positive integer
 
 
-    Positive :t3-data-type:`integer`.
+    Positive :confval:`integer`.
 
     ..  rubric:: Examples
 
     42, 8, 9
 
+
+..  index:: Simple data types; resource
+..  _data-type-resource:
+
 resource
 ========
 
-..  t3-data-type:: resource
+..  confval:: resource
 
     If the value contains a "/", it is expected to be a reference (absolute or
     relative) to a file in the file system. There is no support for wildcard
@@ -360,20 +422,24 @@ resource
 
        page.10.settings.someFile = fileadmin/picture.gif
 
-.. index:: Simple data types; strftime-conf
-.. _data-type-strftime-conf:
+..  index:: Simple data types; strftime-conf
+..  _data-type-strftime-conf:
 
 strftime-conf
 =============
 
-..  t3-data-type:: strftime-conf
+..  confval:: strftime-conf
 
     See function `strftime on php.net <https://www.php.net/manual/en/function.strftime>`__.
+
+
+..  index:: Simple data types; string
+..  _data-type-string:
 
 string
 ======
 
-..  t3-data-type:: string
+..  confval:: string
 
 
     Sometimes used generally though another type would have been more
@@ -383,10 +449,14 @@ string
 
     The quick brown fox jumps over the lazy dog.
 
+
+..  index:: Simple data types; tag
+..  _data-type-tag:
+
 tag
 ===
 
-..  t3-data-type:: tag
+..  confval:: tag
 
     An HTML tag.
 
@@ -397,14 +467,14 @@ tag
 
         page.10.settings.bodyTag = <body lang="de">
 
-.. index:: Simple data types; tag-params
-.. _data-type-tag-params:
+
+..  index:: Simple data types; tag-params
+..  _data-type-tag-params:
 
 tag-params
 ==========
 
-..  t3-data-type:: tag-params
-
+..  confval:: tag-params
 
     Parameters for a tag.
 
@@ -418,13 +488,13 @@ tag-params
         page.10.settings.someParams = border="0" framespacing="0"
 
 
-.. index:: Simple data types; target
-.. _data-type-target:
+..  index:: Simple data types; target
+..  _data-type-target:
 
 target
 ======
 
-..  t3-data-type:: target
+..  confval:: target
 
     ..  rubric:: Examples
 
@@ -436,13 +506,14 @@ target
     This is normally the same value as the name of the root-level object
     that defines the frame.
 
-.. index:: Simple data types; wrap
-.. _data-type-wrap:
+
+..  index:: Simple data types; wrap
+..  _data-type-wrap:
 
 wrap
 ====
 
-..  t3-data-type:: wrap
+..  confval:: wrap
 
     :Syntax: <...> \| </...>
 

--- a/Documentation/Functions/Cache.rst
+++ b/Documentation/Functions/Cache.rst
@@ -34,7 +34,7 @@ key
 
 ..  t3-function-cache:: key
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     The cache identifier that is used to store the rendered content into
     the cache and to read it from there.
@@ -78,7 +78,7 @@ tags
 
 ..  t3-function-cache:: tags
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Can hold a comma-separated list of tags. These tags will be attached
     to the entry added to the `cache_hash` cache (and to

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -140,7 +140,7 @@ date
    date
 
 :aspect:`Description:`
-   Can be used with a colon and :t3-data-type:`date-conf`.
+   Can be used with a colon and :ref:`data-type-date-conf`.
 
 :aspect:`Default:`
    :typoscript:`d/m Y`

--- a/Documentation/Functions/Encapslines.rst
+++ b/Documentation/Functions/Encapslines.rst
@@ -70,7 +70,7 @@ remapTag.[*tagname*]
 
 ..  t3-function-encapslines:: remapTag
 
-    :Data type: array of :t3-data-type:`string`
+    :Data type: array of :ref:`data-type-string`
 
     Enter a new tag name here if you wish the tag name of any encapsulation
     to be unified to a single tag name.
@@ -130,7 +130,7 @@ removeWrapping
 
 ..  t3-function-encapslines:: removeWrapping
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, then all existing wrapping will be removed.
 
@@ -210,7 +210,7 @@ defaultAlign
 
 ..  t3-function-encapslines:: defaultAlign
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If set, this value is set as the default "align" value of the wrapping
     tags, both from :t3-function-encapslines:`encapsTagList` and

--- a/Documentation/Functions/Htmlparser.rst
+++ b/Documentation/Functions/Htmlparser.rst
@@ -28,7 +28,7 @@ stripEmptyTags
 
 ..  t3-function-htmlparser:: stripEmptyTags
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     Passes the content to PHPs :php:`strip_tags()`.
 
@@ -37,7 +37,7 @@ stripEmptyTags.keepTags
 
 ..  t3-function-htmlparser:: stripEmptyTags.keepTags
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     Comma separated list of tags to keep when applying :php:`strip_tags()`.
 
@@ -46,7 +46,7 @@ tags.[tagname]
 
 ..  t3-function-htmlparser:: tags
 
-    :Data type: :t3-data-type:`boolean` / string of :ref:`htmlparser-tags`
+    :Data type: :ref:`data-type-boolean` / string of :ref:`htmlparser-tags`
 
     Either set this property to `0` or `1` to allow or deny the tag. If you
     enter :ref:`htmlparser-tags` properties, those will automatically overrule
@@ -110,7 +110,7 @@ keepNonMatchedTags
 
 ..  t3-function-htmlparser:: keepNonMatchedTags
 
-    :Data type: :t3-data-type:`boolean` / "protect"
+    :Data type: :ref:`data-type-boolean` / "protect"
 
     If set (:typoscript:`1`), then all tags are kept regardless of tags present as
     keys in :php:`$tags`-array.

--- a/Documentation/Functions/HtmlparserTags.rst
+++ b/Documentation/Functions/HtmlparserTags.rst
@@ -19,7 +19,7 @@ overrideAttribs
 
 ..  t3-function-htmlparser-tags:: overrideAttribs
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If set, this string is preset as the attributes of the tag.
 
@@ -48,7 +48,7 @@ fixAttrib.[attribute].set
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].set
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     Force the attribute value to this value.
 
@@ -57,7 +57,7 @@ fixAttrib.[attribute].unset
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].unset
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, the attribute is unset.
 
@@ -66,7 +66,7 @@ fixAttrib.[attribute].default
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].default
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If no attribute exists by this name, this value is set as default
     value (if this value is not blank)
@@ -76,7 +76,7 @@ fixAttrib.[attribute].always
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].always
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, the attribute is always processed. Normally an attribute is
     processed only if it exists
@@ -86,7 +86,7 @@ fixAttrib.[attribute].trim
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].trim
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -96,7 +96,7 @@ fixAttrib.[attribute].intval
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].intval
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -106,7 +106,7 @@ fixAttrib.[attribute].upper
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].upper
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -118,7 +118,7 @@ fixAttrib.[attribute].lower
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].lower
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -149,7 +149,7 @@ fixAttrib.[attribute].removeIfFalse
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].removeIfFalse
 
-    :Data type: :t3-data-type:`boolean` / :typoscript:`blank` string
+    :Data type: :ref:`data-type-boolean` / :typoscript:`blank` string
 
     If set, then the attribute is removed if it is false (= :typoscript:`0`).
     If this value is set to :typoscript:`blank` then the value must be a blank string
@@ -160,7 +160,7 @@ fixAttrib.[attribute].removeIfEquals
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].removeIfEquals
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If the attribute value matches the value set here, then it is removed.
 
@@ -169,7 +169,7 @@ fixAttrib.[attribute].casesensitiveComp
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].casesensitiveComp
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, the comparison in :t3-function-htmlparser-tags:`fixAttrib.[attribute].removeIfEquals`
     and :t3-function-htmlparser-tags:`fixAttrib.[attribute].list` will be case-sensitive.
@@ -180,7 +180,7 @@ fixAttrib.[attribute].prefixRelPathWith
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].prefixRelPathWith
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If the value of the attribute seems to be a relative URL (no scheme
     like "http" and no "/" as first char) then the value of this property
@@ -197,7 +197,7 @@ fixAttrib.[attribute].userFunc
 
 ..  t3-function-htmlparser-tags:: fixAttrib.[attribute].userFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     User function for processing of the attribute. The return value
     of this function will be used as the new tag value.
@@ -231,7 +231,7 @@ protect
 
 ..  t3-function-htmlparser-tags:: protect
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, the tag :html:`<>` is converted to :html:`&lt;` and :html:`&gt;`
 
@@ -240,7 +240,7 @@ remap
 
 ..  t3-function-htmlparser-tags:: remap
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If set, the tagname is remapped to this tagname
 
@@ -249,7 +249,7 @@ rmTagIfNoAttrib
 
 ..  t3-function-htmlparser-tags:: rmTagIfNoAttrib
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, then the tag is removed if no attributes happened to be there.
 

--- a/Documentation/Functions/If.rst
+++ b/Documentation/Functions/If.rst
@@ -93,7 +93,7 @@ directReturn
 
 ..  t3-function-if:: directReturn
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If this property exists, no other conditions will be checked. Instead
     the true/false of this value is returned. Can be used to set
@@ -148,7 +148,7 @@ isFalse
 
 ..  t3-function-if:: isFalse
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If the content is "false", which is empty or zero.
 
@@ -224,7 +224,7 @@ isPositive
 
 ..  t3-function-if:: isPositive
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
 
     Returns true, if the content is positive.
 
@@ -233,7 +233,7 @@ isTrue
 
 ..  t3-function-if:: isTrue
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If the content is "true", which is not empty string and not zero.
 
@@ -242,7 +242,7 @@ negate
 
 ..  t3-function-if:: negate
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     This property is checked after all other properties. If set, it

--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -22,7 +22,7 @@ enable
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.enable
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -43,7 +43,7 @@ width
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.width
 
-    :Data type: :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -57,7 +57,7 @@ height
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.height
 
-    :Data type: :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -97,7 +97,7 @@ sample
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.sample
 
-    :Data type: :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -115,7 +115,7 @@ title
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.title
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Specifies the html-page-title of the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -126,7 +126,7 @@ bodyTag
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.bodyTag
 
-    :Data type: :t3-data-type:`tag` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-tag` / :ref:`stdwrap`
 
     This is the `<body>`-tag of the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -149,7 +149,7 @@ wrap
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.wrap
 
-    :Data type: :t3-data-type:`wrap`
+    :Data type: :ref:`data-type-wrap`
 
     This wrap is placed around the `<img>`-tag in the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -159,7 +159,7 @@ target
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.target
 
-    :Data type: :t3-data-type:`target` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-target` / :ref:`stdwrap`
 
     :Default: :typoscript:`thePicture`
 
@@ -185,7 +185,7 @@ JSwindow
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.JSwindow
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -203,7 +203,7 @@ JSwindow.expand
     :Default: 0
 
     :typoscript:`x` and :typoscript:`x` are of data type
-    :t3-data-type:`integer`. The values are added to the width and height
+    :ref:`data-type-integer`. The values are added to the width and height
     of the preview image when calculating the width and height of the
     preview window.
 
@@ -212,14 +212,14 @@ JSwindow.newWindow
 
 ..  t3-function-imagelinkwrap:: JSwindow.newWindow
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     :Default: 0
 
-    If the :ref:`Doctype <setup-config-doctype>` allows the :t3-data-type:`target`
+    If the :ref:`Doctype <setup-config-doctype>` allows the :ref:`data-type-target`
     attribute then the image will be opened in a window with the name given
     by `target`. If that windows is kept open and the next image with the
-    same :t3-data-type:`target` attribute is to be shown then it will appear
+    same :ref:`data-type-target` attribute is to be shown then it will appear
     in the same preview window.
     If :typoscript:`JSwindow.newWindow` is set to True,
     then a unique hash value is used as `target` value for each image.
@@ -231,7 +231,7 @@ JSwindow.altUrl
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.JSwindow.altUrl
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If this returns anything then it is used as URL of the preview window.
     Otherwise the default "showpic" script will be used.
@@ -242,7 +242,7 @@ JSwindow.altUrl\_noDefaultParams
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.JSwindow.altUrl_noDefaultParams
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -268,7 +268,7 @@ directImageLink
 
 ..  t3-function-imagelinkwrap:: imageLinkWrap.directImageLink
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     :Default: 0
 

--- a/Documentation/Functions/Imgresource.rst
+++ b/Documentation/Functions/Imgresource.rst
@@ -25,7 +25,7 @@ ext
 
 ..  t3-function-imgresource:: ext
 
-    :Data type: :t3-data-type:`imageExtension` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-imageExtension` / :ref:`stdwrap`
 
     :Default: web
 
@@ -41,7 +41,7 @@ width
 
 ..  t3-function-imgresource:: width
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     If both the width and the height are set and one of the numbers is
     appended by an :typoscript:`m`, the proportions will be preserved and thus
@@ -101,7 +101,7 @@ height
 
 ..  t3-function-imgresource:: height
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     See :t3-function-imgresource:`width`
 
@@ -110,7 +110,7 @@ params
 
 ..  t3-function-imgresource:: params
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     GraphicsMagick/ImageMagick command-line:
 
@@ -121,7 +121,7 @@ sample
 
 ..  t3-function-imgresource:: sample
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, `-sample` is used to scale images instead of `-geometry`. Sample
@@ -132,7 +132,7 @@ noScale
 
 ..  t3-function-imgresource:: noScale
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If set, the image itself will never be scaled. Only width and height
@@ -165,7 +165,7 @@ crop
 
 ..  t3-function-imgresource:: crop
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: not-set (when file/image is a file_reference the crop value of
 
     It is possible to define an area that should be taken (cropped) from the image.
@@ -195,7 +195,7 @@ cropVariant
 
 ..  t3-function-imgresource:: cropVariant
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
     :Default: default
 
     Since it's possible to define certain :ref:`crop variants <t3coreapi:cropvariants>`
@@ -222,7 +222,7 @@ frame
 
 ..  t3-function-imgresource:: frame
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Chooses the frame in a PDF or GIF file.
 
@@ -233,7 +233,7 @@ import
 
 ..  t3-function-imgresource:: import
 
-    :Data type: :t3-data-type:`path` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-path` / :ref:`stdwrap`
 
     *value* should be set to the path of the file
 
@@ -258,7 +258,7 @@ treatIdAsReference
 
 ..  t3-function-imgresource:: treatIdAsReference
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If set, given UIDs are interpreted as UIDs to sys_file_reference
@@ -270,7 +270,7 @@ maxW
 
 ..  t3-function-imgresource:: maxW
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Maximum width
 
@@ -279,7 +279,7 @@ maxH
 
 ..  t3-function-imgresource:: maxH
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Maximum height
 
@@ -288,7 +288,7 @@ minW
 
 ..  t3-function-imgresource:: minW
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Minimum width (overrules maxW/maxH)
 
@@ -297,7 +297,7 @@ minH
 
 ..  t3-function-imgresource:: minH
 
-    :Data type: :t3-data-type:`pixels` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Minimum height (overrules maxW/maxH)
 
@@ -306,7 +306,7 @@ stripProfile
 
 ..  t3-function-imgresource::    stripProfile
 
-    :Data type:    :t3-data-type:`boolean`
+    :Data type:    :ref:`data-type-boolean`
     :Default:    0
 
     If set, the GraphicsMagick/ImageMagick-command will use a
@@ -338,7 +338,7 @@ m.mask
 
 ..  t3-function-imgresource:: m.mask
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     The mask with which the image is masked onto :typoscript:`m.bgImg`. Both :typoscript:`m.mask`
     and :typoscript:`m.bgImg` **is scaled to fit** the size of the imgResource image!
@@ -350,7 +350,7 @@ m.bgImg
 
 ..  t3-function-imgresource:: m.bgImg
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     **Note:** Both :typoscript:`m.mask` and :typoscript:`m.bgImg` must be valid images.
 
@@ -359,7 +359,7 @@ m.bottomImg
 
 ..  t3-function-imgresource:: m.bottomImg
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     An image masked by :typoscript:`m.bottomImg_mask` onto :typoscript:`m.bgImg` before the
     imgResources is masked by :typoscript:`m.mask`.
@@ -377,7 +377,7 @@ m.bottomImg\_mask
 
 ..  t3-function-imgresource:: m.bottomImg_mask
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     (optional)
 

--- a/Documentation/Functions/Index.rst
+++ b/Documentation/Functions/Index.rst
@@ -22,7 +22,7 @@ Example:
             value
 
       Data type
-            :t3-data-type:`string` /:ref:`stdWrap <stdwrap>`
+            :ref:`data-type-string` /:ref:`stdWrap <stdwrap>`
 
 
 ..  toctree::

--- a/Documentation/Functions/Makelinks.rst
+++ b/Documentation/Functions/Makelinks.rst
@@ -49,7 +49,7 @@ http.extTarget
 
 ..  t3-function-makelinks:: http.extTarget
 
-    :Data type: :t3-data-type:`target`
+    :Data type: :ref:`data-type-target`
     :Default: \_top
 
     The target of the link.
@@ -62,7 +62,7 @@ http.wrap
 
 ..  t3-function-makelinks:: http.wrap
 
-    :Data type: :t3-data-type:`wrap` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-wrap` / :ref:`stdwrap`
 
     Wrap around the link.
 
@@ -73,7 +73,7 @@ http.ATagBeforeWrap
 
 ..  t3-function-makelinks:: http.ATagBeforeWrap
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with :typoscript:`http.wrap` and then the
@@ -111,7 +111,7 @@ http.ATagParams
 
 ..  t3-function-makelinks:: http.ATagParams
 
-    :Data type: :t3-data-type:`tag-params` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-tag-params` / :ref:`stdwrap`
 
     Additional parameters
 
@@ -142,7 +142,7 @@ mailto.wrap
 
 ..  t3-function-makelinks:: mailto.wrap
 
-    :Data type: :t3-data-type:`wrap` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-wrap` / :ref:`stdwrap`
 
     Wrap around the link.
 
@@ -153,7 +153,7 @@ mailto.ATagBeforeWrap
 
 ..  t3-function-makelinks:: mailto.ATagBeforeWrap
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with mailto :typoscript:`wrap` and then the
@@ -167,7 +167,7 @@ mailto.ATagParams
 
 ..  t3-function-makelinks:: mailto.ATagParams
 
-    :Data type: :t3-data-type:`tag-params` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-tag-params` / :ref:`stdwrap`
 
     Additional parameters
 

--- a/Documentation/Functions/Numberformat.rst
+++ b/Documentation/Functions/Numberformat.rst
@@ -31,7 +31,7 @@ decimals
 
 ..  t3-function-numberformat:: decimals
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
 
     Number of decimals the formatted number will have.
@@ -44,7 +44,7 @@ dec\_point
 
 ..  t3-function-numberformat:: dec_point
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: .
 
     Character that divides the decimals from the rest of the number.
@@ -54,7 +54,7 @@ thousands\_sep
 
 ..  t3-function-numberformat:: thousands_sep
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: ,
 
     Character that divides the thousands of the number.

--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -34,11 +34,11 @@ externalBlocks
 
     **.[tagname]** {
 
-    *  **callRecursive:** :t3-data-type:`boolean`. If set, the content of the block is
+    *  **callRecursive:** :ref:`data-type-boolean`. If set, the content of the block is
        directed into parseFunc again. Otherwise the content is passed
        through with no other processing than :ref:`stdwrap` (see below).
 
-    *  **callRecursive.dontWrapSelf:** :t3-data-type:`boolean`. If set, the tags of the
+    *  **callRecursive.dontWrapSelf:** :ref:`data-type-boolean`. If set, the tags of the
        block is *not* wrapped around the content returned from parseFunc.
 
     *  **callRecursive.alternativeWrap:** Alternative wrapping instead of
@@ -49,15 +49,15 @@ externalBlocks
     *  **stdWrap:** :ref:`stdwrap` processing of the whole block (regardless of
        whether callRecursive was set.)
 
-    *  **stripNLprev:** :t3-data-type:`boolean`. Strips off last line break of the previous
+    *  **stripNLprev:** :ref:`data-type-boolean`. Strips off last line break of the previous
        outside block.
 
-    *  **stripNLnext:** :t3-data-type:`boolean`. Strips off first line break of the next
+    *  **stripNLnext:** :ref:`data-type-boolean`. Strips off first line break of the next
        outside block.
 
-    *  **stripNL:** :t3-data-type:`boolean`. Does both of the above.
+    *  **stripNL:** :ref:`data-type-boolean`. Does both of the above.
 
-    *  **HTMLtableCells:** :t3-data-type:`boolean`. If set, then the content is expected
+    *  **HTMLtableCells:** :ref:`data-type-boolean`. If set, then the content is expected
        to be a table and every table-cell is traversed.
 
     Below, "default" means all cells and "1", "2", "3", ... overrides
@@ -65,7 +65,7 @@ externalBlocks
 
     *  **HTMLtableCells.[default/1/2/3/...]** {
 
-       *  **callRecursive:** :t3-data-type:`boolean`. The content is parsed through current
+       *  **callRecursive:** :ref:`data-type-boolean`. The content is parsed through current
           parseFunc.
 
        *  **stdWrap:** :ref:`stdwrap` processing of the content in the cell.
@@ -73,7 +73,7 @@ externalBlocks
        *  **tagStdWrap:** -> The :html:`<TD>` tag is processed by :ref:`stdwrap`.
 
 
-    *  **HTMLtableCells.addChr10BetweenParagraphs:** :t3-data-type:`boolean`. If set, then
+    *  **HTMLtableCells.addChr10BetweenParagraphs:** :ref:`data-type-boolean`. If set, then
        all appearances of :html:`</P><P>` will have a :php:`chr(10)` inserted between them.
 
     ..  rubric:: Example
@@ -151,7 +151,7 @@ userFunc
 
 ..  t3-function-parsefunc:: userFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     This passes the non-tag content to a function of your own choice.
     Similar to e.g. :t3-function-stdwrap:`postUserFunc` in :ref:`stdWrap`.
@@ -177,7 +177,7 @@ nonTypoTagUserFunc
 
 ..  t3-function-parsefunc:: nonTypoTagUserFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     Like :t3-function-parsefunc:`userFunc`.
     Differences is (like :t3-function-parsefunc:`nonTypoTagStdWrap`)
@@ -191,7 +191,7 @@ makelinks
 
 ..  t3-function-parsefunc:: makelinks
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     Convert web addresses prefixed with `http://` and mail addresses
     prefixed with `mailto:` to links.

--- a/Documentation/Functions/Replacement.rst
+++ b/Documentation/Functions/Replacement.rst
@@ -25,7 +25,7 @@ search
 
 ..  t3-function-replacement:: search
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Defines the string that shall be replaced.
 
@@ -34,7 +34,7 @@ replace
 
 ..  t3-function-replacement:: replace
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Defines the string to be used for the replacement.
 
@@ -43,7 +43,7 @@ useRegExp
 
 ..  t3-function-replacement:: useRegExp
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     Defines that the search and replace strings are considered as PCRE
@@ -65,7 +65,7 @@ useOptionSplitReplace
 
 ..  t3-function-replacement:: useOptionSplitReplace
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     This property allows to use :ref:`optionsplit` for the replace

--- a/Documentation/Functions/Round.rst
+++ b/Documentation/Functions/Round.rst
@@ -27,7 +27,7 @@ roundType
 
 ..  t3-function-round:: roundType
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: round
 
     Round method which should be used.
@@ -48,7 +48,7 @@ decimals
 
 ..  t3-function-round:: decimals
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
 
     Number of decimals the rounded value will have. Only used with the
@@ -60,7 +60,7 @@ round
 
 ..  t3-function-round:: round
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     Set round = 1 to enable rounding.

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -136,7 +136,7 @@ recursive
 
 ..  t3-function-select:: recursive
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
     :Default: 0
 
     Number of recursive levels for the pidInList.
@@ -178,7 +178,7 @@ max
 
 ..  t3-function-select:: max
 
-    :Data type: :t3-data-type:`integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+    :Data type: :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
     Max records
 
@@ -189,7 +189,7 @@ begin
 
 ..  t3-function-select::    begin
 
-    :Data type:    :t3-data-type:`integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+    :Data type:    :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
     Begin with record number *value*.
 
@@ -225,7 +225,7 @@ languageField
 
 ..  t3-function-select:: languageField
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     This defaults to whatever is defined in TCA "ctrl"-section in the
     "languageField". Change it to overwrite the behaviour in your query.
@@ -240,7 +240,7 @@ includeRecordsWithoutDefaultTranslation
 
 ..  t3-function-select:: includeRecordsWithoutDefaultTranslation
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
     :Default: 0
 
     If content language overlay is activated and the option :typoscript:`languageField` is not disabled,
@@ -252,7 +252,7 @@ selectFields
 
 ..  t3-function-select:: selectFields
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :Default: \*
 
     List of fields to select, or :php:`count(*)`.
@@ -267,7 +267,7 @@ join, leftjoin, rightjoin
 
 ..  t3-function-select:: join, leftjoin, rightjoin
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Enter the JOIN clause without :sql:`JOIN`, :sql:`LEFT OUTER JOIN` and :sql:`RIGHT OUTER JOIN`
     respectively.
@@ -310,7 +310,7 @@ markers
     <markername>.value (value)
        Sets the value directly.
 
-    <markername>.commaSeparatedList (:t3-data-type:`boolean`)
+    <markername>.commaSeparatedList (:ref:`data-type-boolean`)
        If set, the value is interpreted as a comma-separated list of values.
        Each value in the list is individually escaped and quoted.
 
@@ -429,7 +429,7 @@ See also:
 
 *   :ref:`cobj-content`: for more complete examples with :typoscript:`select`
     and rendering the output with :typoscript:`renderObj`
-*   :t3-data-type:`wrap`: enclosing results within text, used in some of the
+*   :ref:`data-type-wrap`: enclosing results within text, used in some of the
     examples above
 *   :ref:`stdWrap`: for more functionality, can be used in some of the properties,
     such as :typoscript:`pidInList`, :typoscript:`selectFields` etc.

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -26,7 +26,7 @@ token
 
 ..  t3-function-split:: token
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     String or character (token) used to split the value.
 
@@ -35,7 +35,7 @@ max
 
 ..  t3-function-split:: max
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Maximum number of splits.
 
@@ -44,7 +44,7 @@ min
 
 ..  t3-function-split:: min
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Minimum number of splits.
 
@@ -53,7 +53,7 @@ returnKey
 
 ..  t3-function-split:: returnKey
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Instead of parsing the split result, return the element of the
     index with this number immediately and stop processing of the split
@@ -64,7 +64,7 @@ returnCount
 
 ..  t3-function-split:: returnCount
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     Counts all elements resulting from the split, returns their number
     and stops processing of the split function.

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -66,7 +66,7 @@ setContentToCurrent
 
 ..  t3-function-stdwrap:: setContentToCurrent
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Sets the current value to the incoming content of the function.
 
@@ -77,7 +77,7 @@ addPageCacheTags
 
 ..  t3-function-stdwrap:: addPageCacheTags
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Comma-separated list of cache tags, which should be added to the page
     cache.
@@ -105,7 +105,7 @@ setCurrent
 
 ..  t3-function-stdwrap:: setCurrent
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Sets the "current"-value. This is normally set from some outside
     routine, so be careful with this. But it might be handy to do this
@@ -181,7 +181,7 @@ current
 
 ..  t3-function-stdwrap:: current
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Sets the content to the "current"-value (see :ref:`->split <split>`)
 
@@ -208,7 +208,7 @@ preUserFunc
 
 ..  t3-function-stdwrap:: preUserFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -232,7 +232,7 @@ override
 
 ..  t3-function-stdwrap:: override
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If `override` returns something else than "" or zero (trimmed), the
     content is loaded with this!
@@ -251,7 +251,7 @@ ifNull
 
 ..  t3-function-stdwrap:: ifNull
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If the content is null (:php:`NULL` type in PHP), the content is overridden
     with the value defined here.
@@ -277,7 +277,7 @@ ifEmpty
 
 ..  t3-function-stdwrap:: ifEmpty
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If the trimmed content is empty at this point, the content is loaded
     with :typoscript:`ifEmpty`. Zeros are treated as empty values!
@@ -287,7 +287,7 @@ ifBlank
 
 ..  t3-function-stdwrap:: ifBlank
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Same as :typoscript:`ifEmpty` but the check is done against ''. Zeros are not
     treated as blank values!
@@ -297,7 +297,7 @@ listNum
 
 ..  t3-function-stdwrap:: listNum
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Explodes the current content :t3-function-stdwrap:`listNum.splitChar`
     (Default: `,`) and returns the object specified by `listNum`.
@@ -342,7 +342,7 @@ listNum
 
 ..  t3-function-stdwrap:: listNum.splitChar
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
     :Default: `,` (comma)
 
     .. rubric:: Examples
@@ -368,7 +368,7 @@ trim
 
 ..  t3-function-stdwrap:: trim
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     If set, the PHP-function :php:`trim()` will be used to remove whitespaces
     around the value.
@@ -397,7 +397,7 @@ required
 
 ..  t3-function-stdwrap:: required
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     This flag requires the content to be set to some value after any
     content-import and treatment that might have happened until now
@@ -434,7 +434,7 @@ csConv
 
 ..  t3-function-stdwrap:: csConv
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Convert the charset of the string from the charset given as value to
     the current rendering charset of the frontend (UTF-8).
@@ -525,7 +525,7 @@ HTMLparser
 
 ..  t3-function-stdwrap:: HTMLparser
 
-    :Data type: :t3-data-type:`boolean` / :ref:`htmlparser` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`htmlparser` / :ref:`stdWrap`
 
     This object allows you to parse the HTML-content and perform all kinds of
     advanced filtering on the content.
@@ -561,7 +561,7 @@ prioriCalc
 
 ..  t3-function-stdwrap:: prioriCalc
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Calculation of the value using operators -+\*/%^ plus respects
     priority to + and - operators and parenthesis levels ().
@@ -595,7 +595,7 @@ char
 
 ..  t3-function-stdwrap:: char
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
 
     Content is set to :php:`chr(*value*)`. This returns a one-character
     string containing the character specified by ascii code. Reliable
@@ -612,7 +612,7 @@ intval
 
 ..  t3-function-stdwrap:: intval
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     PHP function :php:`intval()` returns an integer:
 
@@ -625,7 +625,7 @@ hash
 
 ..  t3-function-stdwrap:: hash
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Returns a hashed value of the current content. Set to one of the
     algorithms which are available in PHP. For a list of supported
@@ -667,7 +667,7 @@ date
 
 ..  t3-function-stdwrap:: date
 
-    :Data type: :t3-data-type:`date-conf` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-date-conf` / :ref:`stdWrap`
 
     The content should be data-type "UNIX-time". Returns the content
     formatted as a date. See the PHP manual (`datetime.format <https://www.php.net/manual/en/datetime.createfromformat.php>`_)
@@ -707,7 +707,7 @@ strtotime
 
 ..  t3-function-stdwrap:: strtotime
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     Allows conversion of formatted dates to timestamp, e.g. to perform date calculations.
 
@@ -739,7 +739,7 @@ strftime
 
 ..  t3-function-stdwrap:: strftime
 
-    :Data type: :t3-data-type:`strftime-conf` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-strftime-conf` / :ref:`stdWrap`
 
     Very similar to "date", but using a different format. See the PHP manual (`strftime <https://www.php.net/strftime>`_) for the
     format codes.
@@ -770,7 +770,7 @@ formattedDate
 
 ..  t3-function-stdwrap:: formattedDate
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     The function renders date and time based on formats/patterns defined by
     the International Components for Unicode standard (ICU). ICU-based date and
@@ -845,7 +845,7 @@ age
 
 ..  t3-function-stdwrap:: age
 
-    :Data type: :t3-data-type:`boolean` or :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` or :ref:`data-type-string` / :ref:`stdWrap`
 
     If enabled with a "1" (number, integer) the content is seen as a date
     (UNIX-time) and the difference from present time and the content-time
@@ -883,7 +883,7 @@ case
 
 ..  t3-function-stdwrap:: case
 
-    :Data type: :t3-data-type:`case` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-case` / :ref:`stdWrap`
 
     Converts case
 
@@ -894,7 +894,7 @@ bytes
 
 ..  t3-function-stdwrap:: bytes
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     :Default: iec, 1024
 
@@ -1071,7 +1071,7 @@ cropHTML
 
 ..  t3-function-stdwrap:: cropHTML
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Crops the content to a certain length. In contrast to :typoscript:`stdWrap.crop` it
     respects HTML tags. It does not crop inside tags and closes open tags.
@@ -1086,7 +1086,7 @@ stripHtml
 
 ..  t3-function-stdwrap:: stripHtml
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Strips all HTML tags.
 
@@ -1095,7 +1095,7 @@ crop
 
 ..  t3-function-stdwrap:: crop
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Crops the content to a certain length.
 
@@ -1138,7 +1138,7 @@ rawUrlEncode
 
 ..  t3-function-stdwrap:: rawUrlEncode
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Passes the content through the PHP function `rawurlencode() <https://www.php.net/rawurlencode>`_.
 
@@ -1147,7 +1147,7 @@ htmlSpecialChars
 
 ..  t3-function-stdwrap:: htmlSpecialChars
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Passes the content through the PHP function `htmlspecialchars() <https://www.php.net/htmlspecialchars>`_.
 
@@ -1159,7 +1159,7 @@ encodeForJavaScriptValue
 
 ..  t3-function-stdwrap:: encodeForJavaScriptValue
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Encodes content to be used safely inside strings in JavaScript.
     Characters, which can cause problems inside JavaScript strings, are
@@ -1186,7 +1186,7 @@ doubleBrTag
 
 ..  t3-function-stdwrap:: doubleBrTag
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     All double-line-breaks are substituted with this value.
 
@@ -1195,7 +1195,7 @@ br
 
 ..  t3-function-stdwrap:: br
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Pass the value through the PHP function `nl2br() <https://www.php.net/nl2br>`_. This
     converts each line break to a :html:`<br />` or a :html:`<br>` tag depending on doctype.
@@ -1205,7 +1205,7 @@ brTag
 
 ..  t3-function-stdwrap:: brTag
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     All ASCII codes of "10" (line feed, LF) are substituted with the
     *value*, which has been provided in this property.
@@ -1225,7 +1225,7 @@ keywords
 
 ..  t3-function-stdwrap:: keywords
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Splits the content by characters "," ";" and php:`chr(10)` (return), trims
     each value and returns a comma-separated list of the values.
@@ -1271,7 +1271,7 @@ wrapAlign
 
 ..  t3-function-stdwrap:: wrapAlign
 
-    :Data type: :t3-data-type:`align` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-align` / :ref:`stdWrap`
 
     Wraps content with :typoscript:`<div style=text-align:[*value*];"> | </div>`
     *if* align is set.
@@ -1446,7 +1446,7 @@ insertData
 
 ..  t3-function-stdwrap:: insertData
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     If set, then the content string is parsed like :typoscript:`dataWrap` above.
 
@@ -1477,7 +1477,7 @@ postUserFunc
 
 ..  t3-function-stdwrap:: postUserFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -1581,7 +1581,7 @@ postUserFuncInt
 
 ..  t3-function-stdwrap:: postUserFuncInt
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -1602,7 +1602,7 @@ prefixComment
 
 ..  t3-function-stdwrap:: prefixComment
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Prefixes content with an HTML comment with the second part of input
     string (divided by "\|") where first part is an integer telling how
@@ -1624,7 +1624,7 @@ htmlSanitize
 
 ..  t3-function-stdwrap:: htmlSanitize
 
-    :Data type: :t3-data-type:`boolean` / array with key "build"
+    :Data type: :ref:`data-type-boolean` / array with key "build"
 
     The property controls the sanitization and removal of XSS from markup. It
     strips tags, attributes and values that are not explicitly allowed.
@@ -1685,7 +1685,7 @@ debug
 
 ..  t3-function-stdwrap:: debug
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints content with :php:`HTMLSpecialChars()` and :html:`<pre></pre>`:
     Useful for debugging which value :typoscript:`stdWrap` actually ends up with,
@@ -1700,7 +1700,7 @@ debugFunc
 
 ..  t3-function-stdwrap:: debugFunc
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints the content directly to browser with the :php:`debug()` function.
 
@@ -1715,7 +1715,7 @@ debugData
 
 ..  t3-function-stdwrap:: debugData
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdWrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints the current data-array, :php:`$cObj->data`, directly to browser. This
     is where :typoscript:`field` gets data from.

--- a/Documentation/Functions/Strpad.rst
+++ b/Documentation/Functions/Strpad.rst
@@ -24,7 +24,7 @@ length
 
 ..  t3-function-strpad:: length
 
-    :Data type: :t3-data-type:`integer` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     :Default: 0
 
@@ -37,7 +37,7 @@ padWith
 
 ..  t3-function-strpad:: padWith
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: (space character)
 
 

--- a/Documentation/Functions/Tags.rst
+++ b/Documentation/Functions/Tags.rst
@@ -51,10 +51,10 @@ Properties
 
     **Special properties for each content object:**
 
-    **[cObject].stripNL:** :t3-data-type:`boolean` option, which tells :typoscript:`parseFunc` that
+    **[cObject].stripNL:** :ref:`data-type-boolean` option, which tells :typoscript:`parseFunc` that
     newlines before and after the content of the tag should be stripped.
 
-    **[cObject].breakoutTypoTagContent:** :t3-data-type:`boolean` option, which tells
+    **[cObject].breakoutTypoTagContent:** :ref:`data-type-boolean` option, which tells
     :ref:`parseFunc` that this block of content is breaking up the nonTypoTag
     content and that the content after this must be re-wrapped.
 

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -86,7 +86,7 @@ no\_cache
 
 ..  t3-function-typolink:: no_cache
 
-    :Data type: :t3-data-type:`boolean` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     Adds `&no_cache=1` to the link
 
@@ -95,7 +95,7 @@ additionalParams
 
 ..  t3-function-typolink:: additionalParams
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     This is parameters that are added to the end of the URL. This must be
     code ready to insert after the last parameter.
@@ -126,7 +126,7 @@ addQueryString
 
 ..  t3-function-typolink:: addQueryString
 
-    :Data type: :t3-data-type:`boolean` / :t3-data-type:`string`
+    :Data type: :ref:`data-type-boolean` / :ref:`data-type-string`
 
     Add the current query string to the start of the link.
 
@@ -171,7 +171,7 @@ addQueryString.exclude
 
 ..  t3-function-typolink:: addQueryString.exclude
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     List of query arguments to exclude from the link. Typical examples are
     :typoscript:`L` or :typoscript:`cHash`.
@@ -205,7 +205,7 @@ ATagBeforeWrap
 
 ..  t3-function-typolink:: ATagBeforeWrap
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with :typoscript:`wrap` and then the
@@ -216,7 +216,7 @@ parameter
 
 ..  t3-function-typolink:: parameter
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     This is the main data that is used for creating the link. It can be
     the id of a page, the URL of some external page, an email address or
@@ -354,7 +354,7 @@ forceAbsoluteUrl
 
 ..  t3-function-typolink:: forceAbsoluteUrl
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     :Default: :php:`false`
 
@@ -394,7 +394,7 @@ title
 
 ..  t3-function-typolink:: title
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Sets the title parameter of the A-tag.
 
@@ -403,7 +403,7 @@ JSwindow\_params
 
 ..  t3-function-typolink:: JSwindow_params
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     Preset values for opening the window. This example lists almost all
     possible attributes:
@@ -418,7 +418,7 @@ returnLast
 
 ..  t3-function-typolink:: returnLast
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     If set to "url", then it will return the URL of the link
     (:php:`$this->lastTypoLinkUrl`).
@@ -449,7 +449,7 @@ section
 
 ..  t3-function-typolink:: section
 
-    :Data type: :t3-data-type:`string` / :ref:`stdwrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If this value is present, it's prepended with a "#" and placed after
     any internal URL to another page in TYPO3.
@@ -478,7 +478,7 @@ linkAccessRestrictedPages
 
 ..  t3-function-typolink:: linkAccessRestrictedPages
 
-    :Data type: :t3-data-type:`boolean`
+    :Data type: :ref:`data-type-boolean`
 
     If set, typolinks pointing to access restricted pages will still link
     to the page even though the page cannot be accessed.
@@ -488,7 +488,7 @@ userFunc
 
 ..  t3-function-typolink:: userFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     This passes the link-data compiled by the typolink function to a user-
     defined function for final manipulation.

--- a/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
@@ -90,7 +90,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the box.

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -70,7 +70,7 @@ backColor
 
 ..  confval:: backColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: The original background color
 
     Background color.

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -40,7 +40,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the ellipse.

--- a/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
@@ -38,7 +38,7 @@ highColor
 
 ..  confval:: highColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Upper border color.
 
@@ -63,7 +63,7 @@ lowColor
 
 ..  confval:: lowColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Lower border color.
 

--- a/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
@@ -70,7 +70,7 @@ file
 
 ..  confval:: file
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     The image file.
 
@@ -82,7 +82,7 @@ mask
 
 ..  confval:: mask
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     Optional mask image for the image file.
 

--- a/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
@@ -29,7 +29,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Color of the outline.
 

--- a/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
@@ -35,7 +35,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     The color of the shadow.
 

--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -42,7 +42,7 @@ angle
 
 ..  confval:: angle
 
-    :Data type: :t3-data-type:`degree`
+    :Data type: :ref:`data-type-degree`
     :Default: 0
     :Range: -90 to 90
 
@@ -131,7 +131,7 @@ fontColor
 
 ..  confval:: fontColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     The font color.

--- a/Documentation/Gifbuilder/Properties.rst
+++ b/Documentation/Gifbuilder/Properties.rst
@@ -31,7 +31,7 @@ backColor
 
 ..  confval:: backColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: white
 
     Background color of the image.
@@ -257,7 +257,7 @@ transparentColor
 
 ..  confval:: transparentColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Specify a color that should be transparent.
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,8 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-type = t3-data-type // t3-data-type // Data type
-
 t3-data-processor-csv = t3-data-processor-csv // t3-data-processor-csv // Data processor CommaSeparatedValueProcessor
 t3-data-processor-db = t3-data-processor-db // t3-data-processor-db // Data processor DatabaseQueryProcessor
 t3-data-processor-files = t3-data-processor-files // t3-data-processor-files // Data processor FilesProcessor

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -56,7 +56,7 @@ absRefPrefix
 
 .. t3-tlo-config:: absRefPrefix
 
-   :Data type: :t3-data-type:`string`
+   :Data type: :ref:`data-type-string`
    :Special value: "auto"
 
    If set the string is prepended to all relative links that TYPO3 generates.
@@ -295,7 +295,7 @@ cache\_clearAtMidnight
          cache\_clearAtMidnight
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          false
@@ -319,7 +319,7 @@ cache\_period
          cache\_period
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          86400 *(= 24 hours)*
@@ -345,7 +345,7 @@ compressCss
          compressCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -391,7 +391,7 @@ compressJs
          compressJs
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -440,7 +440,7 @@ concatenateCss
          concatenateCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -483,7 +483,7 @@ concatenateJs
          concatenateJs
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -597,7 +597,7 @@ debug
          debug
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set then debug information in the TypoScript code is sent.
@@ -618,7 +618,7 @@ disableAllHeaderCode
          disableAllHeaderCode
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          false
@@ -669,7 +669,7 @@ disableBodyTag
          disableBodyTag
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0 (false)
@@ -698,7 +698,7 @@ disableCanonical
          disableCanonical
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          When the system extension SEO is installed, canonical tags are generated
@@ -720,7 +720,7 @@ disableHrefLang
          disableHrefLang
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          When the system extension SEO is installed, hreflang tags are generated
@@ -739,7 +739,7 @@ disablePrefixComment
          disablePrefixComment
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, the stdWrap property :t3-function-stdwrap:`prefixComment` will be disabled, thus
@@ -760,7 +760,7 @@ disablePreviewNotification
          disablePreviewNotification
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -781,7 +781,7 @@ disableLanguageHeader
          disableLanguageHeader
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -807,7 +807,7 @@ doctype
          doctype
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          If set, then a document type declaration (and an XML prologue) will be
@@ -849,7 +849,7 @@ enableContentLengthHeader
          enableContentLengthHeader
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          1
@@ -918,7 +918,7 @@ forceAbsoluteUrls
          forceAbsoluteUrls
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -950,7 +950,7 @@ forceTypeValue
          forceTypeValue
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Description
          Force the `&type` value of all TYPO3 generated links to a specific value
@@ -974,7 +974,7 @@ headerComment
          headerComment
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          The content is added before the "TYPO3 Content Management Framework"
@@ -1052,7 +1052,7 @@ htmlTag\_setParams
          htmlTag\_setParams
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Sets the attributes for the :html:`<html>` tag on the page. If you set
@@ -1109,7 +1109,7 @@ index\_descrLgd
          index\_descrLgd
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          200
@@ -1132,7 +1132,7 @@ index\_enable
          index\_enable
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          Enables cached pages to be indexed.
@@ -1153,7 +1153,7 @@ index\_externals
          index\_externals
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, external media linked to on the pages is indexed as well.
@@ -1174,7 +1174,7 @@ index\_metatags
          index\_metatags
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          true
@@ -1197,7 +1197,7 @@ inlineStyle2TempFile
          inlineStyle2TempFile
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          1
@@ -1309,7 +1309,7 @@ message\_preview
          message\_preview
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Alternative message in HTML that appears when the preview function is
@@ -1329,7 +1329,7 @@ message\_preview\_workspace
          message\_preview\_workspace
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Alternative message in HTML that appears when the preview function is
@@ -1372,7 +1372,7 @@ moveJsFromHeaderToFooter
          moveJsFromHeaderToFooter
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, all JavaScript (includes and inline) will be moved to the
@@ -1393,7 +1393,7 @@ MP\_defaults
          MP\_defaults
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Allows you to set a list of page id numbers which will always have a
@@ -1426,7 +1426,7 @@ MP\_disableTypolinkClosestMPvalue
          MP\_disableTypolinkClosestMPvalue
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, the typolink function will not try to find the closest MP
@@ -1446,7 +1446,7 @@ MP\_mapRootPoints
       MP\_mapRootPoints
 
    Data type
-      list of PIDs / :t3-data-type:`string`
+      list of PIDs / :ref:`data-type-string`
 
    Description
       Defines a list of ID numbers from which the MP-vars are automatically
@@ -1516,7 +1516,7 @@ no\_cache
          no\_cache
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -1545,7 +1545,7 @@ noPageTitle
          noPageTitle
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          0
@@ -1572,7 +1572,7 @@ pageRendererTemplateFile
          pageRendererTemplateFile
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          :file:`EXT:core/Resources/Private/Templates/PageRenderer.html`
@@ -1620,7 +1620,7 @@ pageTitleFirst
          pageTitleFirst
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -1696,7 +1696,7 @@ pageTitleSeparator
          pageTitleSeparator
 
    Data type
-         :t3-data-type:`string` / :ref:`stdwrap`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Default
          : *(colon with following space)*
@@ -1782,7 +1782,7 @@ removeDefaultCss
          removeDefaultCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          Remove CSS generated by :ref:`\_CSS\_DEFAULT\_STYLE
@@ -1804,7 +1804,7 @@ removeDefaultJS
          removeDefaultJS
 
    Data type
-         :t3-data-type:`boolean` / :t3-data-type:`string`
+         :ref:`data-type-boolean` / :ref:`data-type-string`
 
    Default
          external
@@ -1838,7 +1838,7 @@ sendCacheHeaders
          sendCacheHeaders
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, TYPO3 will output cache-control headers to the client based
@@ -1901,7 +1901,7 @@ showWebsiteTitle
          showWebsiteTitle
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          1
@@ -1959,7 +1959,7 @@ spamProtectEmailAddresses\_atSubst
          spamProtectEmailAddresses\_atSubst
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          (at)
@@ -1980,7 +1980,7 @@ spamProtectEmailAddresses\_lastDotSubst
          spamProtectEmailAddresses\_lastDotSubst
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          . *(just a simple dot)*
@@ -2034,7 +2034,7 @@ typolinkLinkAccessRestrictedPages
          typolinkLinkAccessRestrictedPages
 
    Data type
-         :t3-data-type:`integer` (page id) / keyword "NONE"
+         :ref:`data-type-integer` (page id) / keyword "NONE"
 
    Description
          If set, typolinks pointing to access restricted pages will still link
@@ -2082,7 +2082,7 @@ typolinkLinkAccessRestrictedPages\_addParams
          typolinkLinkAccessRestrictedPages\_addParams
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          See :ref:`setup-config-typolinklinkaccessrestrictedpages` above.
@@ -2100,7 +2100,7 @@ xmlprologue
          xmlprologue
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          If empty (not set) then the default XML 1.0 prologue is set, when the

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -150,29 +150,29 @@ Properties
    Property                       Data Type                             :ref:`stdwrap`         Default
    ============================== ===================================== ====================== ========================
    `1,2,3,4...`_                  :ref:`cObject <data-type-cobject>`
-   `bodyTag`_                     :t3-data-type:`tag`                                          <body>
-   `bodyTagAdd`_                  :t3-data-type:`string`
+   `bodyTag`_                     :ref:`data-type-tag`                                         <body>
+   `bodyTagAdd`_                  :ref:`data-type-string`
    `bodyTagCObject`_              :ref:`cObject <data-type-cobject>`
    `config`_                      :ref:`->CONFIG <config>`
    `cssInline.[array]`_           :ref:`cObject <data-type-cobject>`
    `footerData.[array]`_          :ref:`cObject <data-type-cobject>`
    `headerData.[array]`_          :ref:`cObject <data-type-cobject>`
-   `headTag`_                     :t3-data-type:`tag` / :ref:`stdwrap`                         <head>
-   `includeCSS.[array]`_          :t3-data-type:`resource`
-   `includeCSSLibs.[array]`_      :t3-data-type:`resource`
-   `includeJS.[array]`_           :t3-data-type:`resource`
-   `includeJSFooter.[array]`_     :t3-data-type:`resource`
-   `includeJSFooterlibs.[array]`_ :t3-data-type:`resource`
-   `includeJSLibs.[array]`_       :t3-data-type:`resource`
+   `headTag`_                     :ref:`data-type-tag` / :ref:`stdwrap`                        <head>
+   `includeCSS.[array]`_          :ref:`data-type-resource`
+   `includeCSSLibs.[array]`_      :ref:`data-type-resource`
+   `includeJS.[array]`_           :ref:`data-type-resource`
+   `includeJSFooter.[array]`_     :ref:`data-type-resource`
+   `includeJSFooterlibs.[array]`_ :ref:`data-type-resource`
+   `includeJSLibs.[array]`_       :ref:`data-type-resource`
    `inlineLanguageLabelFiles`_    (array of strings)
    `inlineSettings`_              (array of strings)
    `jsFooterInline.[array]`_      :ref:`cObject <data-type-cobject>`
    `jsInline.[array]`_            :ref:`cObject <data-type-cobject>`
    `meta`_                        (array of strings)
-   `shortcutIcon`_                :t3-data-type:`resource`
+   `shortcutIcon`_                :ref:`data-type-resource`
    `stdWrap`_                     :ref:`stdwrap`
-   `typeNum`_                     :t3-data-type:`integer`                                      0
-   `wrap`_                        :t3-data-type:`wrap`
+   `typeNum`_                     :ref:`data-type-integer`                                      0
+   `wrap`_                        :ref:`data-type-wrap`
    ============================== ===================================== ====================== ========================
 
 .. ### BEGIN~OF~TABLE ###
@@ -230,7 +230,7 @@ bodyTag
          bodyTag
 
    Data type
-         :t3-data-type:`tag`
+         :ref:`data-type-tag`
 
    Default
          <body>
@@ -259,7 +259,7 @@ bodyTagAdd
          bodyTagAdd
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          This content is added inside of the opening :html:`<body>` tag right
@@ -452,7 +452,7 @@ headTag
          headTag
 
    Data type
-         :t3-data-type:`tag` / :ref:`stdwrap`
+         :ref:`data-type-tag` / :ref:`stdwrap`
 
    Default
          <head>
@@ -474,14 +474,14 @@ includeCSS.[array]
          includeCSS.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Inserts a stylesheet (just like the :typoscript:`stylesheet` property), but allows
          setting up more than a single stylesheet, because you can enter files
          in an array.
 
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted.
 
          Each file has *optional properties*:
@@ -558,12 +558,12 @@ includeCSSLibs.[array]
          includeCSSLibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Adds CSS library files to head of page.
 
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted. This means that remote files cannot be referenced
          (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
 
@@ -627,13 +627,13 @@ includeJS.[array]
          includeJS.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Inserts one or more (Java)Scripts in :html:`<script>` tags.
          With :ref:`setup-config-movejsfromheadertofooter` set to TRUE all files
          will be moved to the footer.
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted. This means that remote files cannot be referenced
          (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
 
@@ -726,7 +726,7 @@ includeJSFooter.[array]
          includeJSFooter.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Add JS files to footer (after possible files set in :ref:`includeJSFooterlibs <setup-page-includejsfooterlibs-array>`)
@@ -749,7 +749,7 @@ includeJSFooterlibs.[array]
          includeJSFooterlibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Add JS library files to footer.
@@ -774,7 +774,7 @@ includeJSLibs.[array]
          includeJSLibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Adds JS library files to head of page.
@@ -1069,7 +1069,7 @@ shortcutIcon
       shortcutIcon
 
    Data type
-      :t3-data-type:`resource`
+      :ref:`data-type-resource`
 
    Description
       Favicon of the page. Create a reference to an icon here!
@@ -1119,7 +1119,7 @@ typeNum
          typeNum
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          0
@@ -1144,7 +1144,7 @@ wrap
          wrap
 
    Data type
-         :t3-data-type:`wrap`
+         :ref:`data-type-wrap`
 
    Description
          Wraps the content of the cObject array.

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -57,7 +57,7 @@ userFunc
          \_CSS\_DEFAULT\_STYLE
 
    Data type
-         :t3-data-type:`string` / :ref:`stdwrap`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Use this to have some default CSS styles inserted in the header
@@ -107,7 +107,7 @@ ignoreFlexFormSettingsIfEmpty
         ignoreFlexFormSettingsIfEmpty
 
     Data type
-        :t3-data-type:`string`
+        :ref:`data-type-string`
 
     Description
         Define :ref:`FlexForm <t3coreapi:flexforms>` settings that will be
@@ -164,7 +164,7 @@ persistence.enableAutomaticCacheClearing
       persistence.enableAutomaticCacheClearing
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       true
@@ -196,7 +196,7 @@ persistence.storagePid
       persistence.storagePid
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       true
@@ -345,7 +345,7 @@ mvc.callDefaultActionIfActionCantBeResolved
       mvc.callDefaultActionIfActionCantBeResolved
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       false
@@ -376,7 +376,7 @@ mvc.throwPageNotFoundExceptionIfActionCantBeResolved
       mvc.callDefaultActionIfActionCantBeResolved
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       false
@@ -411,7 +411,7 @@ Format
       format
 
    Data type
-      :t3-data-type:`string`
+      :ref:`data-type-string`
 
    Default
       html
@@ -445,7 +445,7 @@ Format
         \_LOCAL\_LANG.[lang-key].[label-key]
 
     Data type
-        :t3-data-type:`string`
+        :ref:`data-type-string`
 
     Description
         Can be used to override the default language labels for Extbase plugins.

--- a/Documentation/UsingSetting/Constants.rst
+++ b/Documentation/UsingSetting/Constants.rst
@@ -25,7 +25,7 @@ programming languages.
 
 **Reserved name**
 
-The object or property "file" is always interpreted as data type :t3-data-type:`resource`. That means it refers to a file, which has to be uploaded
+The object or property "file" is always interpreted as data type :ref:`data-type-resource`. That means it refers to a file, which has to be uploaded
 in the TYPO3 CMS installation.
 
 **Multi-line values: The ( ) signs**
@@ -57,7 +57,7 @@ expected location.
    }
 
 The objects in the highlighted lines contain the reserved word "file" and the
-properties are always of data type ":t3-data-type:`resource`".
+properties are always of data type ":ref:`data-type-resource`".
 
 
 .. index:: Constants; Usage


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally, index is added for missing data types.

Releases: main, 12.4, 11.5