### PR TITLE
[Backport 11.5] [TASK] Replace "t3-data-type" with "confval" (#929)

### DIFF
--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -242,7 +242,7 @@ Expanded form:
     // STEP 6: Return 'totalResult'
 
 
-See also: :ref:`if`, :ref:`select`, :t3-data-type:`wrap`, :ref:`stdWrap`,
+See also: :ref:`if`, :ref:`select`, :ref:`data-type-wrap`, :ref:`stdWrap`,
 :ref:`data-type-cobject`
 
 

--- a/Documentation/ContentObjects/Hmenu/Categories.rst
+++ b/Documentation/ContentObjects/Hmenu/Categories.rst
@@ -66,7 +66,7 @@ special.relation
          special.relation
 
    Data type
-         :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
    Default
          special.categories
@@ -88,7 +88,7 @@ special.sorting
          special.sorting
 
    Data type
-         :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+         :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
    Description
          Which field from the "pages" table should be used for sorting.

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -109,7 +109,7 @@ layoutKey
 
 ..  t3-cobj-image:: layoutKey
 
-    :Data type: :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: default
 
     Defines the render layout for the IMAGE. The render layout is the HTML Code for the IMAGE itself.
@@ -205,7 +205,7 @@ layout.layoutKey.element
 
 ..  t3-cobj-image:: layout.layoutKey.element
 
-    :Data type: :t3-data-type:`string`
+    :Data type: :ref:`data-type-string`
 
     The outer element definition for the HTML rendering of the image.
     Possible markers are mainly all parameters which can be defined in the
@@ -487,7 +487,7 @@ linkWrap
 
 ..  t3-cobj-image:: linkWrap
 
-    :Data type: :t3-data-type:`wrap` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     (before ".wrap")
 

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -45,7 +45,7 @@ src
 
 ..  t3-cobj-svg:: src
 
-    :Data type: :t3-data-type:`resource` /:ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-resource` /:ref:`stdWrap <stdwrap>`
 
     SVG file resource, can also be referenced via :file:`EXT:` prefix to
     point to files of extensions.

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -44,7 +44,7 @@ userFunc
 
 ..  t3-cobj-user:: userFunc
 
-    :Data type: :t3-data-type:`function name`
+    :Data type: :ref:`data-type-function-name`
 
     The name of the function, which should be called. If you specify the
     name with a '->' in it, then it is interpreted as a call to a method in

--- a/Documentation/DataTypes/Index.rst
+++ b/Documentation/DataTypes/Index.rst
@@ -1,7 +1,7 @@
-.. include:: /Includes.rst.txt
-.. index:: Simple data types
-.. _data-types:
-.. _data-types-reference:
+..  include:: /Includes.rst.txt
+..  index:: Simple data types
+..  _data-types:
+..  _data-types-reference:
 
 =================
 Simple data types
@@ -19,23 +19,30 @@ RGB-values have to be provided.
 The following is a list of available data types, their usage, purpose and
 examples.
 
-.. contents::
-   :local:
+..  contents::
+    :local:
+
+..  index:: Simple data types; align
+..  _data-type-align:
 
 align
 =====
 
-..  t3-data-type:: align
+..  confval:: align
 
     :Default: :typoscript:`left`
     :Allowed values: :typoscript:`left`, :typoscript:`center`, :typoscript:`right`
 
     Decides about alignment.
 
+
+..  index:: Simple data types; boolean
+..  _data-type-boolean:
+
 boolean
 =======
 
-..  t3-data-type:: boolean
+..  confval:: boolean
 
     Possible values for boolean variables are `1` and `0`
     meaning TRUE and FALSE.
@@ -55,10 +62,14 @@ boolean
        dummy.enable = 1   # true,  preferred notation
        dummy.enable =     # false, because the value is empty
 
+
+..  index:: Simple data types; case
+..  _data-type-case:
+
 case
 ====
 
-..  t3-data-type:: case
+..  confval:: case
 
 
     Do a case conversion.
@@ -90,15 +101,19 @@ case
 
     Result:
 
-    ..  code-block:: html
+    ..  code-block:: text
         :caption: Example Output
 
         HELLO WORLD!
 
+
+..  index:: Simple data types; date-conf
+..  _data-type-date-conf:
+
 date-conf
 =========
 
-..  t3-data-type:: date-conf
+..  confval:: date-conf
 
     Used to format a date, see PHP function :php:`date()`. See the
     documentation of `allowed date time formats in
@@ -111,19 +126,27 @@ date-conf
 
         page.10.date-conf = d-m-y
 
+
+..  index:: Simple data types; degree
+..  _data-type-degree:
+
 degree
 ======
 
-..  t3-data-type:: degree
+..  confval:: degree
 
     `-90` to `90`, integers
 
     Example: `45`
 
+
+..  index:: Simple data types; dir
+..  _data-type-dir:
+
 dir
 ===
 
-..  t3-data-type:: dir
+..  confval:: dir
 
     ..  rubric:: Syntax
 
@@ -146,10 +169,14 @@ dir
 
         page.10.dir = fileadmin/files/ | pdf,gif,jpg | name | r | true
 
+
+..  index:: Simple data types; function name
+..  _data-type-function-name:
+
 function name
 =============
 
-..  t3-data-type:: function name
+..  confval:: function name
 
     Indicates a function or method in a class to call. See more information at
     the :ref:`USER cObject <cobj-user>`.
@@ -161,7 +188,7 @@ function name
     TypoScript configuration and :php:`$content`, some content to be processed and
     returned.
 
-    ..  Which entry in TYPO3_CONF_VARS enables the user-prefix to be changed? This
+    ..  todo: Which entry in TYPO3_CONF_VARS enables the user-prefix to be changed? This
         should be mentioned. Looks like this entry has gone and this info no
         longer valid.
 
@@ -171,27 +198,31 @@ function name
     instead. See the document "Inside TYPO3" for more information on extending
     classes in TYPO3!
 
-    .. Where is this feature mentioned? We should add a reference here.
+    ..  todo: Where is this feature mentioned? We should add a reference here.
 
     ..  rubric:: Examples
 
     Method in namespaced class. This is the preferred version:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         Your\NameSpace\YourClass->reverseString
 
     Single Function:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         user_reverseString
 
     Method in class without namespace:
 
-    ..  code-block:: php
+    ..  code-block:: text
 
         user_yourClass->reverseString
+
+
+..  index:: Simple data types; getText
+..  _data-type-getText:
 
 getText
 =======
@@ -199,10 +230,14 @@ getText
 The getText data type is some kind of tool box allowing to retrieve
 values from a variety of sources. Read more: :ref:`data-type-gettext`
 
+
+..  index:: Simple data types; GraphicColor
+..  _data-type-GraphicColor:
+
 GraphicColor
 ============
 
-..  t3-data-type:: GraphicColor
+..  confval:: GraphicColor
 
     ..  rubric:: Syntax:
 
@@ -228,10 +263,14 @@ GraphicColor
     *   :typoscript:`red : *0.8` ("red" is darkened by factor 0.8)
     *   :typoscript:`#ffeecc : +16` ("ffeecc" is going to #fffedc because 16 is added)
 
+
+..  index:: Simple data types; imageExtension
+..  _data-type-imageExtension:
+
 imageExtension
 ==============
 
-..  t3-data-type:: imageExtension
+..  confval:: imageExtension
 
     Image extensions can be anything among the allowed types defined in the
     global variable :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.
@@ -246,19 +285,23 @@ imageExtension
 
     web *(gif or jpg ..)*
 
+
+..  index:: Simple data types; imgResource
+..  _data-type-imgResource:
+
 imgResource
 ===========
 
-..  t3-data-type:: imgResource
+..  confval:: imgResource
 
-    #.  A :t3-data-type:`resource` plus imgResource properties.
+    #.  A :confval:`resource` plus imgResource properties.
 
         Filetypes can be anything among the allowed types defined in the
         configuration variable
         :php:`$GLOBALS['TYPO3_CONF_VARS']['GFX']['imagefile_ext']`.  Standard is
         pdf, gif, jpg, jpeg, tif, bmp, ai, pcx, tga, png.
 
-    #.  A GIFBUILDER object. See the object reference for :ref:`gifbuilder` below.
+    #.  A GIFBUILDER object. See the object reference for :ref:`gifbuilder`.
 
     ..  rubric:: Examples
 
@@ -284,10 +327,14 @@ imgResource
             # GIFBUILDER properties here...
         }
 
+
+..  index:: Simple data types; integer
+..  _data-type-integer:
+
 integer
 =======
 
-..  t3-data-type:: integer
+..  confval:: integer
 
     ..  rubric:: Examples
 
@@ -295,12 +342,16 @@ integer
 
 
     This data type is sometimes used generally though another type would have
-    been more appropriate, like :t3-data-type:`pixels`.
+    been more appropriate, like :ref:`pixels <data-type-pixels>`.
+
+
+..  index:: Simple data types; path
+..  _data-type-path:
 
 path
 ====
 
-..  t3-data-type:: path
+..  confval:: path
 
 
     Path relative to the root directory from which we operate.
@@ -313,11 +364,14 @@ path
 
         page.10.settings.somePath = fileadmin/stuff/
 
+
+..  index:: Simple data types; pixels
+..  _data-type-pixels:
+
 pixels
 ======
 
-..  t3-data-type:: pixels
-
+..  confval:: pixels
 
     pixel-distance
 
@@ -328,22 +382,30 @@ pixels
 
         page.10.someWidth = 345
 
+
+..  index:: Simple data types; positive integer
+..  _data-type-positive-integer:
+
 positive integer
 ================
 
-..  t3-data-type:: positive integer
+..  confval:: positive integer
 
 
-    Positive :t3-data-type:`integer`.
+    Positive :confval:`integer`.
 
     ..  rubric:: Examples
 
     42, 8, 9
 
+
+..  index:: Simple data types; resource
+..  _data-type-resource:
+
 resource
 ========
 
-..  t3-data-type:: resource
+..  confval:: resource
 
     If the value contains a "/", it is expected to be a reference (absolute or
     relative) to a file in the file system. There is no support for wildcard
@@ -358,20 +420,24 @@ resource
 
        page.10.settings.someFile = fileadmin/picture.gif
 
-.. index:: Simple data types; strftime-conf
-.. _data-type-strftime-conf:
+..  index:: Simple data types; strftime-conf
+..  _data-type-strftime-conf:
 
 strftime-conf
 =============
 
-..  t3-data-type:: strftime-conf
+..  confval:: strftime-conf
 
     See function `strftime on php.net <https://www.php.net/manual/en/function.strftime>`__.
+
+
+..  index:: Simple data types; string
+..  _data-type-string:
 
 string
 ======
 
-..  t3-data-type:: string
+..  confval:: string
 
 
     Sometimes used generally though another type would have been more
@@ -381,10 +447,14 @@ string
 
     The quick brown fox jumps over the lazy dog.
 
+
+..  index:: Simple data types; tag
+..  _data-type-tag:
+
 tag
 ===
 
-..  t3-data-type:: tag
+..  confval:: tag
 
     An HTML tag.
 
@@ -395,14 +465,14 @@ tag
 
         page.10.settings.bodyTag = <body lang="de">
 
-.. index:: Simple data types; tag-params
-.. _data-type-tag-params:
+
+..  index:: Simple data types; tag-params
+..  _data-type-tag-params:
 
 tag-params
 ==========
 
-..  t3-data-type:: tag-params
-
+..  confval:: tag-params
 
     Parameters for a tag.
 
@@ -416,13 +486,13 @@ tag-params
         page.10.settings.someParams = border="0" framespacing="0"
 
 
-.. index:: Simple data types; target
-.. _data-type-target:
+..  index:: Simple data types; target
+..  _data-type-target:
 
 target
 ======
 
-..  t3-data-type:: target
+..  confval:: target
 
     ..  rubric:: Examples
 
@@ -434,13 +504,14 @@ target
     This is normally the same value as the name of the root-level object
     that defines the frame.
 
-.. index:: Simple data types; wrap
-.. _data-type-wrap:
+
+..  index:: Simple data types; wrap
+..  _data-type-wrap:
 
 wrap
 ====
 
-..  t3-data-type:: wrap
+..  confval:: wrap
 
     :Syntax: <...> \| </...>
 

--- a/Documentation/Functions/Cache.rst
+++ b/Documentation/Functions/Cache.rst
@@ -38,7 +38,7 @@ key
    key
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    The cache identifier that is used to store the rendered content into
@@ -94,7 +94,7 @@ tags
    tags
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Can hold a comma-separated list of tags. These tags will be attached

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -140,7 +140,7 @@ date
    date
 
 :aspect:`Description:`
-   Can be used with a colon and :t3-data-type:`date-conf`.
+   Can be used with a colon and :ref:`data-type-date-conf`.
 
 :aspect:`Default:`
    :typoscript:`d/m Y`

--- a/Documentation/Functions/Encapslines.rst
+++ b/Documentation/Functions/Encapslines.rst
@@ -79,7 +79,7 @@ remapTag.[*tagname*]
    remapTag.[*tagname*]
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Enter a new tag name here if you wish the tag name of any encapsulation
@@ -154,7 +154,7 @@ removeWrapping
    removeWrapping
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, then all existing wrapping will be removed.
@@ -261,7 +261,7 @@ defaultAlign
    defaultAlign
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    If set, this value is set as the default "align" value of the wrapping

--- a/Documentation/Functions/Htmlparser.rst
+++ b/Documentation/Functions/Htmlparser.rst
@@ -40,7 +40,7 @@ stripEmptyTags
    stripEmptyTags
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    Passes the content to PHPs :php:`strip_tags()`.
@@ -56,7 +56,7 @@ stripEmptyTags.keepTags
    stripEmptyTags.keepTags
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Comma separated list of tags to keep when applying :php:`strip_tags()`.
@@ -72,7 +72,7 @@ tags.[tagname]
    tags.[tagname]
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`htmlparser-tags`
+   :ref:`data-type-boolean` / :ref:`htmlparser-tags`
 
 :aspect:`Description`
    Either set this property to `0` or `1` to allow or deny the tag. If you
@@ -178,7 +178,7 @@ keepNonMatchedTags
    keepNonMatchedTags
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / "protect"
+   :ref:`data-type-boolean` / "protect"
 
 :aspect:`Description`
    If set (:typoscript:`1`), then all tags are kept regardless of tags present as

--- a/Documentation/Functions/HtmlparserTags.rst
+++ b/Documentation/Functions/HtmlparserTags.rst
@@ -24,7 +24,7 @@ overrideAttribs
    overrideAttribs
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    If set, this string is preset as the attributes of the tag.
@@ -67,7 +67,7 @@ fixAttrib.[attribute].set
    fixAttrib.[attribute].set
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Force the attribute value to this value.
@@ -83,7 +83,7 @@ fixAttrib.[attribute].unset
    fixAttrib.[attribute].unset
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the attribute is unset.
@@ -99,7 +99,7 @@ fixAttrib.[attribute].default
    fixAttrib.[attribute].default
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    If no attribute exists by this name, this value is set as default
@@ -116,7 +116,7 @@ fixAttrib.[attribute].always
    fixAttrib.[attribute].always
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the attribute is always processed. Normally an attribute is
@@ -132,7 +132,7 @@ fixAttrib.[attribute].always
    fixAttrib.[attribute].lower
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If any of these keys are set, the value is passed through the
@@ -182,7 +182,7 @@ fixAttrib.[attribute].removeIfFalse
    fixAttrib.[attribute].removeIfFalse
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :typoscript:`blank` string
+   :ref:`data-type-boolean` / :typoscript:`blank` string
 
 :aspect:`Description`
    If set, then the attribute is removed if it is false (= :typoscript:`0`).
@@ -200,7 +200,7 @@ fixAttrib.[attribute].removeIfEquals
    fixAttrib.[attribute].removeIfEquals
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    If the attribute value matches the value set here, then it is removed.
@@ -216,7 +216,7 @@ fixAttrib.[attribute].casesensitiveComp
    fixAttrib.[attribute].casesensitiveComp
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the comparison in :ref:`htmlparser-tags-fixattrib-attribute-removeifequals`
@@ -264,7 +264,7 @@ fixAttrib.[attribute].prefixRelPathWith
    fixAttrib.[attribute].prefixRelPathWith
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :Data type: :ref:`data-type-string`
 
 :aspect:`Description`
    If the value of the attribute seems to be a relative URL (no scheme
@@ -288,7 +288,7 @@ fixAttrib.[attribute].userFunc
    fixAttrib.[attribute].userFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    User function for processing of the attribute. The return value
@@ -329,7 +329,7 @@ protect
    protect
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the tag :html:`<>` is converted to :html:`&lt;` and :html:`&gt;`
@@ -345,7 +345,7 @@ remap
    remap
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    If set, the tagname is remapped to this tagname
@@ -361,7 +361,7 @@ rmTagIfNoAttrib
    rmTagIfNoAttrib
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, then the tag is removed if no attributes happened to be there.

--- a/Documentation/Functions/If.rst
+++ b/Documentation/Functions/If.rst
@@ -71,7 +71,7 @@ directReturn
    directReturn
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If this property exists, no other conditions will be checked. Instead
@@ -112,7 +112,7 @@ isFalse
    isFalse
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    If the content is "false", which is empty or zero.
@@ -221,7 +221,7 @@ isPositive
    isPositive
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
+   :ref:`data-type-integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
 
 :aspect:`Description`
    Returns true, if the content is positive.
@@ -237,7 +237,7 @@ isTrue
    isTrue
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    If the content is "true", which is not empty string and not zero.
@@ -253,7 +253,7 @@ negate
    negate
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    This property is checked after all other properties. If set, it

--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -24,7 +24,7 @@ enable
     imageLinkWrap.enable
 
 :aspect:`Data type`
-    :t3-data-type:`boolean` / :ref:`stdwrap`
+    :ref:`data-type-boolean
 
 :aspect:`Default`
     0
@@ -52,7 +52,7 @@ width
     imageLinkWrap.width
 
 :aspect:`Data type`
-    :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
@@ -70,7 +70,7 @@ height
     imageLinkWrap.height
 
 :aspect:`Data type`
-    :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
@@ -123,7 +123,7 @@ sample
     imageLinkWrap.sample
 
 :aspect:`Data type`
-    :t3-data-type:`positive integer` / :ref:`stdwrap`
+    :ref:`data-type-positive-integer` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
@@ -145,7 +145,7 @@ title
     imageLinkWrap.title
 
 :aspect:`Data type`
-    :t3-data-type:`string` / :ref:`stdwrap`
+    :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
     Specifies the html-page-title of the preview window.
@@ -159,7 +159,7 @@ bodyTag
     imageLinkWrap.bodyTag
 
 :aspect:`Data type`
-    :t3-data-type:`tag` / :ref:`stdwrap`
+    :ref:`data-type-tag` / :ref:`stdwrap`
 
 :aspect:`Description`
     This is the `<body>`-tag of the preview window.
@@ -185,7 +185,7 @@ wrap
     imageLinkWrap.bodyTag
 
 :aspect:`Data type`
-    :t3-data-type:`wrap`
+    :ref:`data-type-wrap`
 
 :aspect:`Description`
     This wrap is placed around the `<img>`-tag in the preview window.
@@ -198,7 +198,7 @@ target
     imageLinkWrap.target
 
 :aspect:`Data type`
-    :t3-data-type:`target` / :ref:`stdwrap`
+    :ref:`data-type-target` / :ref:`stdwrap`
 
 :aspect:`Default`
     :typoscript:`thePicture`
@@ -231,7 +231,7 @@ JSwindow
     imageLinkWrap.JSwindow
 
 :aspect:`Data type`
-    :t3-data-type:`boolean` / :ref:`stdwrap`
+    :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
@@ -256,7 +256,7 @@ JSwindow.expand
 
 :aspect:`Description`
     :typoscript:`x` and :typoscript:`x` are of data type
-    :t3-data-type:`integer`. The values are added to the width and height
+    :ref:`data-type-integer`. The values are added to the width and height
     of the preview image when calculating the width and height of the
     preview window.
 
@@ -268,16 +268,16 @@ JSwindow.newWindow
     imageLinkWrap.JSwindow.expand
 
 :aspect:`Data type`
-    :t3-data-type:`boolean` / :ref:`stdwrap`
+    :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
 
 :aspect:`Description`
-    If the :ref:`Doctype <setup-config-doctype>` allows the :t3-data-type:`target`
+    If the :ref:`Doctype <setup-config-doctype>` allows the :ref:`data-type-target`
     attribute then the image will be opened in a window with the name given
     by `target`. If that windows is kept open and the next image with the
-    same :t3-data-type:`target` attribute is to be shown then it will appear
+    same :ref:`data-type-target` attribute is to be shown then it will appear
     in the same preview window.
     If :typoscript:`JSwindow.newWindow` is set to True,
     then a unique hash value is used as `target` value for each image.
@@ -291,7 +291,7 @@ JSwindow.altUrl
     imageLinkWrap.JSwindow.altUrl
 
 :aspect:`Data type`
-    :t3-data-type:`string` / :ref:`stdwrap`
+    :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
     If this returns anything then it is used as URL of the preview window.
@@ -305,7 +305,7 @@ JSwindow.altUrl\_noDefaultParams
     imageLinkWrap.JSwindow.altUrl_noDefaultParams
 
 :aspect:`Data type`
-    :t3-data-type:`boolean` / :ref:`stdwrap`
+    :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Default`
     0
@@ -338,7 +338,7 @@ directImageLink
     imageLinkWrap.directImageLink
 
 :aspect:`Data type`
-    :t3-data-type:`boolean` / :ref:`stdwrap`
+    :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Default`
     0

--- a/Documentation/Functions/Imgresource.rst
+++ b/Documentation/Functions/Imgresource.rst
@@ -30,7 +30,7 @@ ext
    ext
 
 :aspect:`Data type`
-   :t3-data-type:`imageExtension` / :ref:`stdwrap`
+   :ref:`data-type-imageExtension` / :ref:`stdwrap`
 
 :aspect:`Default`
    web
@@ -53,7 +53,7 @@ width
    width
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    If both the width and the height are set and one of the numbers is
@@ -117,7 +117,7 @@ height
    height
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    See :ref:`imgresource-width`
@@ -133,7 +133,7 @@ params
    params
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    GraphicsMagick/ImageMagick command-line:
@@ -150,7 +150,7 @@ sample
    sample
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, `-sample` is used to scale images instead of `-geometry`. Sample
@@ -169,7 +169,7 @@ noScale
    noScale
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    If set, the image itself will never be scaled. Only width and height
@@ -210,7 +210,7 @@ crop
    crop
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    It is possible to define an area that should be taken (cropped) from the image.
@@ -245,7 +245,7 @@ cropVariant
    cropVariant
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Since it's possible to define certain :ref:`crop variants <t3coreapi:cropvariants>`
@@ -275,7 +275,7 @@ frame
    frame
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Chooses the frame in a PDF or GIF file.
@@ -293,7 +293,7 @@ import
    import
 
 :aspect:`Data type`
-   :t3-data-type:`path` / :ref:`stdwrap`
+   :ref:`data-type-path` / :ref:`stdwrap`
 
 :aspect:`Description`
    *value* should be set to the path of the file
@@ -324,7 +324,7 @@ treatIdAsReference
    treatIdAsReference
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    If set, given UIDs are interpreted as UIDs to sys_file_reference
@@ -343,7 +343,7 @@ maxW
    maxW
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    Maximum width
@@ -357,7 +357,7 @@ maxH
    maxH
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    Maximum height
@@ -371,7 +371,7 @@ minW
    minW
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    Minimum width (overrules maxW/maxH)
@@ -385,7 +385,7 @@ minH
    minH
 
 :aspect:`Data type`
-   :t3-data-type:`pixels` / :ref:`stdwrap`
+   :ref:`data-type-pixels` / :ref:`stdwrap`
 
 :aspect:`Description`
    Minimum height (overrules maxW/maxH)
@@ -401,7 +401,7 @@ stripProfile
       stripProfile
 
 :aspect:`Data type`
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
 :aspect:`Description`
       If set, the GraphicsMagick/ImageMagick-command will use a
@@ -437,7 +437,7 @@ m.mask
    m.mask
 
 :aspect:`Data type`
-   :t3-data-type:`imgResource`
+   :ref:`data-type-imgResource`
 
 :aspect:`Description`
    The mask with which the image is masked onto :typoscript:`m.bgImg`. Both :typoscript:`m.mask`
@@ -452,7 +452,7 @@ m.bgImg
    m.bgImg
 
 :aspect:`Data type`
-   :t3-data-type:`imgResource`
+   :ref:`data-type-imgResource`
 
 :aspect:`Description`
    **Note:** Both :typoscript:`m.mask` and :typoscript:`m.bgImg` must be valid images.
@@ -464,7 +464,7 @@ m.bottomImg
    m.bottomImg
 
 :aspect:`Data type`
-   :t3-data-type:`imgResource`
+   :ref:`data-type-imgResource`
 
 :aspect:`Description`
    An image masked by :typoscript:`m.bottomImg_mask` onto :typoscript:`m.bgImg` before the
@@ -485,7 +485,7 @@ m.bottomImg\_mask
    m.bottomImg\_mask
 
 :aspect:`Data type`
-   :t3-data-type:`imgResource`
+   :ref:`data-type-imgResource`
 
 :aspect:`Description`
    (optional)

--- a/Documentation/Functions/Index.rst
+++ b/Documentation/Functions/Index.rst
@@ -22,7 +22,7 @@ Example:
             value
 
       Data type
-            :t3-data-type:`string` /:ref:`stdWrap <stdwrap>`
+            :ref:`data-type-string` /:ref:`stdWrap <stdwrap>`
 
 
 ..  toctree::

--- a/Documentation/Functions/Makelinks.rst
+++ b/Documentation/Functions/Makelinks.rst
@@ -51,7 +51,7 @@ http.extTarget
    http.extTarget
 
 :aspect:`Data type`
-   :t3-data-type:`target`
+   :ref:`data-type-target`
 
 :aspect:`Description`
    The target of the link.
@@ -68,7 +68,7 @@ http.wrap
    http.wrap
 
 :aspect:`Data type`
-   :t3-data-type:`wrap` / :ref:`stdwrap`
+   :ref:`data-type-wrap` / :ref:`stdwrap`
 
 :aspect:`Description`
    Wrap around the link.
@@ -82,7 +82,7 @@ http.ATagBeforeWrap
    http.ATagBeforeWrap
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the link is first wrapped with :typoscript:`http.wrap` and then the
@@ -126,7 +126,7 @@ http.ATagParams
    http.ATagParams
 
 :aspect:`Data type`
-   :t3-data-type:`tag-params` / :ref:`stdwrap`
+   :ref:`data-type-tag-params` / :ref:`stdwrap`
 
 :aspect:`Description`
    Additional parameters
@@ -159,7 +159,7 @@ mailto.wrap
    mailto.wrap
 
 :aspect:`Data type`
-   :t3-data-type:`wrap` / :ref:`stdwrap`
+   :ref:`data-type-wrap` / :ref:`stdwrap`
 
 :aspect:`Description`
    Wrap around the link.
@@ -173,7 +173,7 @@ mailto.ATagBeforeWrap
    mailto.ATagBeforeWrap
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the link is first wrapped with mailto :typoscript:`wrap` and then the
@@ -191,7 +191,7 @@ mailto.ATagParams
    mailto.ATagParams
 
 :aspect:`Data type`
-   :t3-data-type:`tag-params` / :ref:`stdwrap`
+   :ref:`data-type-tag-params` / :ref:`stdwrap`
 
 :aspect:`Description`
    Additional parameters

--- a/Documentation/Functions/Numberformat.rst
+++ b/Documentation/Functions/Numberformat.rst
@@ -35,7 +35,7 @@ decimals
    decimals
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Number of decimals the formatted number will have.
@@ -55,7 +55,7 @@ dec\_point
    dec\_point
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap <stdwrap>`
+   :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
 :aspect:`Description`
    Character that divides the decimals from the rest of the number.
@@ -72,7 +72,7 @@ thousands\_sep
    thousands\_sep
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Character that divides the thousands of the number.

--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -40,11 +40,11 @@ externalBlocks
 
    **.[tagname]** {
 
-   * **callRecursive:** :t3-data-type:`boolean`. If set, the content of the block is
+   * **callRecursive:** :ref:`data-type-boolean`. If set, the content of the block is
      directed into parseFunc again. Otherwise the content is passed
      through with no other processing than :ref:`stdwrap` (see below).
 
-   * **callRecursive.dontWrapSelf:** :t3-data-type:`boolean`. If set, the tags of the
+   * **callRecursive.dontWrapSelf:** :ref:`data-type-boolean`. If set, the tags of the
      block is *not* wrapped around the content returned from parseFunc.
 
    * **callRecursive.alternativeWrap:** Alternative wrapping instead of
@@ -55,15 +55,15 @@ externalBlocks
    * **stdWrap:** :ref:`stdwrap` processing of the whole block (regardless of
      whether callRecursive was set.)
 
-   * **stripNLprev:** :t3-data-type:`boolean`. Strips off last line break of the previous
+   * **stripNLprev:** :ref:`data-type-boolean`. Strips off last line break of the previous
      outside block.
 
-   * **stripNLnext:** :t3-data-type:`boolean`. Strips off first line break of the next
+   * **stripNLnext:** :ref:`data-type-boolean`. Strips off first line break of the next
      outside block.
 
-   * **stripNL:** :t3-data-type:`boolean`. Does both of the above.
+   * **stripNL:** :ref:`data-type-boolean`. Does both of the above.
 
-   * **HTMLtableCells:** :t3-data-type:`boolean`. If set, then the content is expected
+   * **HTMLtableCells:** :ref:`data-type-boolean`. If set, then the content is expected
      to be a table and every table-cell is traversed.
 
    Below, "default" means all cells and "1", "2", "3", ... overrides
@@ -71,7 +71,7 @@ externalBlocks
 
    * **HTMLtableCells.[default/1/2/3/...]** {
 
-     * **callRecursive:** :t3-data-type:`boolean`. The content is parsed through current
+     * **callRecursive:** :ref:`data-type-boolean`. The content is parsed through current
        parseFunc.
 
      * **stdWrap:** :ref:`stdwrap` processing of the content in the cell.
@@ -79,7 +79,7 @@ externalBlocks
      * **tagStdWrap:** -> The :html:`<TD>` tag is processed by :ref:`stdwrap`.
 
 
-   * **HTMLtableCells.addChr10BetweenParagraphs:** :t3-data-type:`boolean`. If set, then
+   * **HTMLtableCells.addChr10BetweenParagraphs:** :ref:`data-type-boolean`. If set, then
      all appearances of :html:`</P><P>` will have a :php:`chr(10)` inserted between them.
 
 
@@ -128,7 +128,7 @@ constants
    constants
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    You can define constants in the :ref:`top-level object "constants"
@@ -205,7 +205,7 @@ userFunc
    userFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    This passes the non-tag content to a function of your own choice.
@@ -243,7 +243,7 @@ nonTypoTagUserFunc
    nonTypoTagUserFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    Like :ref:`parsefunc-userFunc`.
@@ -293,7 +293,7 @@ makelinks
    makelinks
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`makelinks`
+   :ref:`data-type-boolean` / :ref:`makelinks`
 
 :aspect:`Description`
    Convert web addresses prefixed with `http://` and mail addresses

--- a/Documentation/Functions/Replacement.rst
+++ b/Documentation/Functions/Replacement.rst
@@ -29,7 +29,7 @@ search
    search
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Defines the string that shall be replaced.
@@ -43,7 +43,7 @@ replace
    replace
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Defines the string to be used for the replacement.
@@ -57,7 +57,7 @@ useRegExp
    useRegExp
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    Defines that the search and replace strings are considered as PCRE
@@ -85,7 +85,7 @@ useOptionSplitReplace
    useOptionSplitReplace
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    This property allows to use :ref:`objects-optionsplit` for the replace

--- a/Documentation/Functions/Round.rst
+++ b/Documentation/Functions/Round.rst
@@ -31,7 +31,7 @@ roundType
    roundType
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Round method which should be used.
@@ -59,7 +59,7 @@ decimals
    decimals
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Number of decimals the rounded value will have. Only used with the
@@ -78,7 +78,7 @@ round
    round
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    Set round = 1 to enable rounding.

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -149,7 +149,7 @@ recursive
    recursive
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdWrap`
+   :ref:`data-type-integer` / :ref:`stdWrap`
 
 :aspect:`Description`
    Number of recursive levels for the pidInList.
@@ -209,7 +209,7 @@ max
    max
 
 :aspect:`Data type`
-   :t3-data-type:`integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+   :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
 :aspect:`Description`
    Max records
@@ -226,7 +226,7 @@ begin
       begin
 
 :aspect:`Data type`
-      :t3-data-type:`integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+      :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
 :aspect:`Description`
       Begin with record number *value*.
@@ -273,7 +273,7 @@ languageField
    languageField
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    This defaults to whatever is defined in TCA "ctrl"-section in the
@@ -294,7 +294,7 @@ includeRecordsWithoutDefaultTranslation
    includeRecordsWithoutDefaultTranslation
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    If content language overlay is activated and the option :typoscript:`languageField` is not disabled,
@@ -314,7 +314,7 @@ selectFields
    selectFields
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    List of fields to select, or :php:`count(*)`.
@@ -339,7 +339,7 @@ join, leftjoin, rightjoin
    join, leftjoin, rightjoin
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
    Enter the JOIN clause without :sql:`JOIN`, :sql:`LEFT OUTER JOIN` and :sql:`RIGHT OUTER JOIN`
    respectively.
@@ -388,7 +388,7 @@ markers
    <markername>.value (value)
       Sets the value directly.
 
-   <markername>.commaSeparatedList (:t3-data-type:`boolean`)
+   <markername>.commaSeparatedList (:ref:`data-type-boolean`)
       If set, the value is interpreted as a comma-separated list of values.
       Each value in the list is individually escaped and quoted.
 
@@ -506,7 +506,7 @@ See also:
 
 *   :ref:`cobj-content`: for more complete examples with :typoscript:`select`
     and rendering the output with :typoscript:`renderObj`
-*   :t3-data-type:`wrap`: enclosing results within text, used in some of the
+*   :ref:`data-type-wrap`: enclosing results within text, used in some of the
     examples above
 *   :ref:`stdWrap`: for more functionality, can be used in some of the properties,
     such as :typoscript:`pidInList`, :typoscript:`selectFields` etc.

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -30,7 +30,7 @@ token
    token
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    String or character (token) used to split the value.
@@ -44,7 +44,7 @@ max
    max
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Maximum number of splits.
@@ -58,7 +58,7 @@ min
    min
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Minimum number of splits.
@@ -72,7 +72,7 @@ returnKey
    returnKey
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    Instead of parsing the split result, return the element of the
@@ -88,7 +88,7 @@ returnCount
    returnCount
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    Counts all elements resulting from the split, returns their number

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -38,7 +38,7 @@ setContentToCurrent
    setContentToCurrent
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Sets the current value to the incoming content of the function.
@@ -54,7 +54,7 @@ addPageCacheTags
    addPageCacheTags
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Comma-separated list of cache tags, which should be added to the page
@@ -88,7 +88,7 @@ setCurrent
    setCurrent
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Sets the "current"-value. This is normally set from some outside
@@ -186,7 +186,7 @@ current
    current
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Sets the content to the "current"-value (see :ref:`->split <split>`)
@@ -233,7 +233,7 @@ preUserFunc
    preUserFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    Calls the provided PHP function. If you specify the name with a '->'
@@ -263,7 +263,7 @@ override
    override
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    if "override" returns something else than "" or zero (trimmed), the
@@ -296,7 +296,7 @@ ifNull
    ifNull
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    If the content is null (:php:`NULL` type in PHP), the content is overridden
@@ -329,7 +329,7 @@ ifEmpty
    ifEmpty
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    If the trimmed content is empty at this point, the content is loaded
@@ -346,7 +346,7 @@ ifBlank
    ifBlank
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Same as :typoscript:`ifEmpty` but the check is done against ''. Zeros are not
@@ -363,7 +363,7 @@ listNum
    listNum
 
 :aspect:`Data type`
-   :t3-data-type:`integer` :ref:`+calc <objects-calc>` +"last" +"rand" / :ref:`stdWrap`
+   :ref:`data-type-integer` :ref:`+calc <objects-calc>` +"last" +"rand" / :ref:`stdWrap`
 
 :aspect:`Description`
    Explodes the content with "," (comma) and the content is set to the
@@ -423,7 +423,7 @@ trim
    trim
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    If set, the PHP-function :php:`trim()` will be used to remove whitespaces
@@ -473,7 +473,7 @@ required
    required
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    This flag requires the content to be set to some value after any
@@ -532,7 +532,7 @@ csConv
    csConv
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Convert the charset of the string from the charset given as value to
@@ -633,7 +633,7 @@ HTMLparser
    HTMLparser
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`htmlparser` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`htmlparser` / :ref:`stdWrap`
 
 :aspect:`Description`
    This object allows you to parse the HTML-content and perform all kinds of
@@ -686,7 +686,7 @@ prioriCalc
    prioriCalc
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Calculation of the value using operators -+\*/%^ plus respects
@@ -726,7 +726,7 @@ char
    char
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdWrap`
+   :ref:`data-type-integer` / :ref:`stdWrap`
 
 :aspect:`Description`
    Content is set to :php:`chr(*value*)`. This returns a one-character
@@ -750,7 +750,7 @@ intval
    intval
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    PHP function :php:`intval()` returns an integer:
@@ -770,7 +770,7 @@ hash
    hash
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Returns a hashed value of the current content. Set to one of the
@@ -833,7 +833,7 @@ date
    date
 
 :aspect:`Data type`
-   :t3-data-type:`date-conf` / :ref:`stdWrap`
+   :ref:`data-type-date-conf` / :ref:`stdWrap`
 
 :aspect:`Description`
    The content should be data-type "UNIX-time". Returns the content
@@ -874,7 +874,7 @@ strtotime
    strtotime
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Allows conversion of formatted dates to timestamp, e.g. to perform date calculations.
@@ -913,7 +913,7 @@ strftime
    strftime
 
 :aspect:`Data type`
-   :t3-data-type:`strftime-conf` / :ref:`stdWrap`
+   :ref:`data-type-strftime-conf` / :ref:`stdWrap`
 
 :aspect:`Description`
    Very similar to "date", but using a different format. See the PHP manual (`strftime <https://www.php.net/strftime>`_) for the
@@ -945,7 +945,7 @@ age
    age
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` or :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-boolean` or :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    If enabled with a "1" (number, integer) the content is seen as a date
@@ -990,7 +990,7 @@ case
    case
 
 :aspect:`Data type`
-   :t3-data-type:`case` / :ref:`stdWrap`
+   :ref:`data-type-case` / :ref:`stdWrap`
 
 :aspect:`Description`
    Converts case
@@ -1008,7 +1008,7 @@ bytes
    bytes
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Default`
    iec, 1024
@@ -1199,7 +1199,7 @@ cropHTML
    cropHTML
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Crops the content to a certain length. In contrast to :typoscript:`stdWrap.crop` it
@@ -1221,7 +1221,7 @@ stripHtml
    stripHtml
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Strips all HTML tags.
@@ -1237,7 +1237,7 @@ crop
    crop
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Crops the content to a certain length.
@@ -1286,7 +1286,7 @@ rawUrlEncode
    rawUrlEncode
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Passes the content through the PHP function `rawurlencode() <https://www.php.net/rawurlencode>`_.
@@ -1302,7 +1302,7 @@ htmlSpecialChars
    htmlSpecialChars
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Passes the content through the PHP function `htmlspecialchars() <https://www.php.net/htmlspecialchars>`_.
@@ -1321,7 +1321,7 @@ encodeForJavaScriptValue
    encodeForJavaScriptValue
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Encodes content to be used safely inside strings in JavaScript.
@@ -1354,7 +1354,7 @@ doubleBrTag
    doubleBrTag
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    All double-line-breaks are substituted with this value.
@@ -1370,7 +1370,7 @@ br
    br
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Pass the value through the PHP function `nl2br() <https://www.php.net/nl2br>`_. This
@@ -1387,7 +1387,7 @@ brTag
    brTag
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    All ASCII codes of "10" (line feed, LF) are substituted with the
@@ -1421,7 +1421,7 @@ keywords
    keywords
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Splits the content by characters "," ";" and php:`chr(10)` (return), trims
@@ -1502,7 +1502,7 @@ wrapAlign
    wrapAlign
 
 :aspect:`Data type`
-   :t3-data-type:`align` / :ref:`stdWrap`
+   :ref:`data-type-align` / :ref:`stdWrap`
 
 :aspect:`Description`
    Wraps content with :typoscript:`<div style=text-align:[*value*];"> | </div>`
@@ -1752,7 +1752,7 @@ insertData
    insertData
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    If set, then the content string is parsed like :typoscript:`dataWrap` above.
@@ -1788,7 +1788,7 @@ postUserFunc
    postUserFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    Calls the provided PHP function. If you specify the name with a '->'
@@ -1898,7 +1898,7 @@ postUserFuncInt
    postUserFuncInt
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    Calls the provided PHP function. If you specify the name with a '->'
@@ -1927,7 +1927,7 @@ prefixComment
    prefixComment
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdWrap`
+   :ref:`data-type-string` / :ref:`stdWrap`
 
 :aspect:`Description`
    Prefixes content with an HTML comment with the second part of input
@@ -1981,7 +1981,7 @@ editPanel
    editPanel
 
 :aspect:`Data type`
-   :ref:`boolean <data-type-bool>` / :ref:`cobj-editpanel`
+   :ref:`data-type-boolean` / :ref:`cobj-editpanel`
 
 :aspect:`Description`
    See :ref:`Migration from the build-in EDITPANEL<cobj-editpanel_migration>`.
@@ -2002,7 +2002,7 @@ htmlSanitize
    htmlSanitize
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / array with key "build"
+   :ref:`data-type-boolean` / array with key "build"
 
 :aspect:`Description`
    The property controls the sanitization and removal of XSS from markup. It
@@ -2073,7 +2073,7 @@ debug
    debug
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Prints content with :php:`HTMLSpecialChars()` and :html:`<pre></pre>`:
@@ -2095,7 +2095,7 @@ debugFunc
    debugFunc
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Prints the content directly to browser with the :php:`debug()` function.
@@ -2117,7 +2117,7 @@ debugData
    debugData
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdWrap`
+   :ref:`data-type-boolean` / :ref:`stdWrap`
 
 :aspect:`Description`
    Prints the current data-array, :php:`$cObj->data`, directly to browser. This

--- a/Documentation/Functions/Strpad.rst
+++ b/Documentation/Functions/Strpad.rst
@@ -28,7 +28,7 @@ length
    length
 
 :aspect:`Data type`
-   :t3-data-type:`integer` / :ref:`stdwrap`
+   :ref:`data-type-integer` / :ref:`stdwrap`
 
 :aspect:`Description`
    The length of the output string. If the value is negative, less
@@ -47,7 +47,7 @@ padWith
    padWith
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    The character(s) to pad with. The value of :ref:`strpad-padWith` may be

--- a/Documentation/Functions/Tags.rst
+++ b/Documentation/Functions/Tags.rst
@@ -56,10 +56,10 @@ Properties
 
    **Special properties for each content object:**
 
-   **[cObject].stripNL:** :t3-data-type:`boolean` option, which tells :typoscript:`parseFunc` that
+   **[cObject].stripNL:** :ref:`data-type-boolean` option, which tells :typoscript:`parseFunc` that
    newlines before and after the content of the tag should be stripped.
 
-   **[cObject].breakoutTypoTagContent:** :t3-data-type:`boolean` option, which tells
+   **[cObject].breakoutTypoTagContent:** :ref:`data-type-boolean` option, which tells
    :ref:`parseFunc` that this block of content is breaking up the nonTypoTag
    content and that the content after this must be re-wrapped.
 

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -118,7 +118,7 @@ no\_cache
    no\_cache
 
 :aspect:`Data type`
-   :t3-data-type:`boolean` / :ref:`stdwrap`
+   :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
    Adds ``&no_cache=1`` to the link
@@ -134,7 +134,7 @@ additionalParams
    additionalParams
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    This is parameters that are added to the end of the URL. This must be
@@ -170,7 +170,7 @@ addQueryString
    addQueryString
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    Add the current query string to the start of the link.
@@ -227,7 +227,7 @@ ATagBeforeWrap
    ATagBeforeWrap
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, the link is first wrapped with :typoscript:`wrap` and then the
@@ -247,7 +247,7 @@ parameter
    parameter
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    This is the main data that is used for creating the link. It can be
@@ -387,7 +387,7 @@ forceAbsoluteUrl
    forceAbsoluteUrl
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    Forces links to internal pages to be absolute, thus having a proper
@@ -422,7 +422,7 @@ title
    title
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    Sets the title parameter of the A-tag.
@@ -438,7 +438,7 @@ JSwindow\_params
    JSwindow\_params
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    Preset values for opening the window. This example lists almost all
@@ -460,7 +460,7 @@ returnLast
    returnLast
 
 :aspect:`Data type`
-   :t3-data-type:`string`
+   :ref:`data-type-string`
 
 :aspect:`Description`
    If set to "url", then it will return the URL of the link
@@ -498,7 +498,7 @@ section
    section
 
 :aspect:`Data type`
-   :t3-data-type:`string` / :ref:`stdwrap`
+   :ref:`data-type-string` / :ref:`stdwrap`
 
 :aspect:`Description`
    If this value is present, it's prepended with a "#" and placed after
@@ -540,7 +540,7 @@ linkAccessRestrictedPages
    linkAccessRestrictedPages
 
 :aspect:`Data type`
-   :t3-data-type:`boolean`
+   :ref:`data-type-boolean`
 
 :aspect:`Description`
    If set, typolinks pointing to access restricted pages will still link
@@ -557,7 +557,7 @@ userFunc
    userFunc
 
 :aspect:`Data type`
-   :t3-data-type:`function name`
+   :ref:`data-type-function-name`
 
 :aspect:`Description`
    This passes the link-data compiled by the typolink function to a user-

--- a/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
@@ -90,7 +90,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the box.

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -70,7 +70,7 @@ backColor
 
 ..  confval:: backColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: The original background color
 
     Background color.

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -40,7 +40,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the ellipse.

--- a/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
@@ -38,7 +38,7 @@ highColor
 
 ..  confval:: highColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Upper border color.
 
@@ -63,7 +63,7 @@ lowColor
 
 ..  confval:: lowColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Lower border color.
 

--- a/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
@@ -70,7 +70,7 @@ file
 
 ..  confval:: file
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     The image file.
 
@@ -82,7 +82,7 @@ mask
 
 ..  confval:: mask
 
-    :Data type: :t3-data-type:`imgResource`
+    :Data type: :ref:`data-type-imgResource`
 
     Optional mask image for the image file.
 

--- a/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
@@ -29,7 +29,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Color of the outline.
 

--- a/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
@@ -35,7 +35,7 @@ color
 
 ..  confval:: color
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     The color of the shadow.
 

--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -42,7 +42,7 @@ angle
 
 ..  confval:: angle
 
-    :Data type: :t3-data-type:`degree`
+    :Data type: :ref:`data-type-degree`
     :Default: 0
     :Range: -90 to 90
 
@@ -131,7 +131,7 @@ fontColor
 
 ..  confval:: fontColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     The font color.

--- a/Documentation/Gifbuilder/Properties.rst
+++ b/Documentation/Gifbuilder/Properties.rst
@@ -31,7 +31,7 @@ backColor
 
 ..  confval:: backColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: white
 
     Background color of the image.
@@ -251,7 +251,7 @@ transparentColor
 
 ..  confval:: transparentColor
 
-    :Data type: :t3-data-type:`GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Specify a color that should be transparent.
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -39,8 +39,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-type = t3-data-type // t3-data-type // Data type
-
 t3-data-processor-csv = t3-data-processor-csv // t3-data-processor-csv // Data processor CommaSeparatedValueProcessor
 t3-data-processor-db = t3-data-processor-db // t3-data-processor-db // Data processor DatabaseQueryProcessor
 t3-data-processor-files = t3-data-processor-files // t3-data-processor-files // Data processor FilesProcessor

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -52,7 +52,7 @@ absRefPrefix
 
 .. t3-tlo-config:: absRefPrefix
 
-   :Data type: :t3-data-type:`string`
+   :Data type: :ref:`data-type-string`
    :Special value: "auto"
 
    If set the string is prepended to all relative links that TYPO3 generates.
@@ -185,7 +185,7 @@ admPanel
          admPanel
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, the :ref:`Admin Panel <ext_adminpanel:introduction>` displays at the
@@ -228,7 +228,7 @@ baseURL
          baseURL
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          This writes the :html:`<base>` tag in the header of the document. Set this to
@@ -333,7 +333,7 @@ cache\_clearAtMidnight
          cache\_clearAtMidnight
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          false
@@ -357,7 +357,7 @@ cache\_period
          cache\_period
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          86400 *(= 24 hours)*
@@ -383,7 +383,7 @@ compressCss
          compressCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -429,7 +429,7 @@ compressJs
          compressJs
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -478,7 +478,7 @@ concatenateCss
          concatenateCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -521,7 +521,7 @@ concatenateJs
          concatenateJs
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -635,7 +635,7 @@ debug
          debug
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set then debug information in the TypoScript code is sent.
@@ -656,7 +656,7 @@ disableAllHeaderCode
          disableAllHeaderCode
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          false
@@ -707,7 +707,7 @@ disableBodyTag
          disableBodyTag
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0 (false)
@@ -736,7 +736,7 @@ disableCanonical
          disableCanonical
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          When the system extension SEO is installed, canonical tags are generated
@@ -779,7 +779,7 @@ disableHrefLang
          disableHrefLang
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          When the system extension SEO is installed, hreflang tags are generated
@@ -841,7 +841,7 @@ disablePrefixComment
          disablePrefixComment
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, the stdWrap property :ref:`stdwrap-prefixcomment` will be disabled, thus
@@ -862,7 +862,7 @@ disablePreviewNotification
          disablePreviewNotification
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -883,7 +883,7 @@ disableLanguageHeader
          disableLanguageHeader
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -909,7 +909,7 @@ doctype
          doctype
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          If set, then a document type declaration (and an XML prologue) will be
@@ -957,7 +957,7 @@ enableContentLengthHeader
          enableContentLengthHeader
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          1
@@ -1024,7 +1024,7 @@ forceTypeValue
          forceTypeValue
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Description
          Force the `&type` value of all TYPO3 generated links to a specific value
@@ -1048,7 +1048,7 @@ headerComment
          headerComment
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          The content is added before the "TYPO3 Content Management Framework"
@@ -1126,7 +1126,7 @@ htmlTag\_setParams
          htmlTag\_setParams
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Sets the attributes for the :html:`<html>` tag on the page. If you set
@@ -1183,7 +1183,7 @@ index\_descrLgd
          index\_descrLgd
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          200
@@ -1206,7 +1206,7 @@ index\_enable
          index\_enable
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          Enables cached pages to be indexed.
@@ -1227,7 +1227,7 @@ index\_externals
          index\_externals
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, external media linked to on the pages is indexed as well.
@@ -1248,7 +1248,7 @@ index\_metatags
          index\_metatags
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          true
@@ -1271,7 +1271,7 @@ inlineStyle2TempFile
          inlineStyle2TempFile
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          1
@@ -1383,7 +1383,7 @@ message\_preview
          message\_preview
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Alternative message in HTML that appears when the preview function is
@@ -1403,7 +1403,7 @@ message\_preview\_workspace
          message\_preview\_workspace
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Alternative message in HTML that appears when the preview function is
@@ -1466,7 +1466,7 @@ moveJsFromHeaderToFooter
          moveJsFromHeaderToFooter
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, all JavaScript (includes and inline) will be moved to the
@@ -1487,7 +1487,7 @@ MP\_defaults
          MP\_defaults
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          Allows you to set a list of page id numbers which will always have a
@@ -1520,7 +1520,7 @@ MP\_disableTypolinkClosestMPvalue
          MP\_disableTypolinkClosestMPvalue
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, the typolink function will not try to find the closest MP
@@ -1540,7 +1540,7 @@ MP\_mapRootPoints
       MP\_mapRootPoints
 
    Data type
-      list of PIDs / :t3-data-type:`string`
+      list of PIDs / :ref:`data-type-string`
 
    Description
       Defines a list of ID numbers from which the MP-vars are automatically
@@ -1610,7 +1610,7 @@ no\_cache
          no\_cache
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -1639,7 +1639,7 @@ noPageTitle
          noPageTitle
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          0
@@ -1666,7 +1666,7 @@ pageRendererTemplateFile
          pageRendererTemplateFile
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          :file:`EXT:core/Resources/Private/Templates/PageRenderer.html`
@@ -1714,7 +1714,7 @@ pageTitleFirst
          pageTitleFirst
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          0
@@ -1790,7 +1790,7 @@ pageTitleSeparator
          pageTitleSeparator
 
    Data type
-         :t3-data-type:`string` / :ref:`stdwrap`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Default
          : *(colon with following space)*
@@ -1853,7 +1853,7 @@ removeDefaultCss
          removeDefaultCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          Remove CSS generated by :ref:`\_CSS\_DEFAULT\_STYLE
@@ -1875,7 +1875,7 @@ removeDefaultJS
          removeDefaultJS
 
    Data type
-         :t3-data-type:`boolean` / :t3-data-type:`string`
+         :ref:`data-type-boolean` / :ref:`data-type-string`
 
    Default
          external
@@ -1909,7 +1909,7 @@ removePageCss
          removePageCss
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          Remove CSS generated by :ref:`\_CSS\_PAGE\_STYLE
@@ -1933,7 +1933,7 @@ sendCacheHeaders
          sendCacheHeaders
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If set, TYPO3 will output cache-control headers to the client based
@@ -1995,7 +1995,7 @@ sendCacheHeaders\_onlyWhenLoginDeniedInBranch
          sendCacheHeaders\_onlyWhenLoginDeniedInBranch
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Description
          If this is set, then cache-control headers allowing client caching is
@@ -2052,7 +2052,7 @@ spamProtectEmailAddresses
          setting it to >= 2 means a "z" is converted to "\|" which is a special
          character in TYPO3 tables syntax – and that might confuse columns in
          tables.)
-         
+
          It is required to enable the default JavaScript and not disable it. (see :ref:`removeDefaultJS <setup-config-removedefaultjs>`)
 
 
@@ -2068,7 +2068,7 @@ spamProtectEmailAddresses\_atSubst
          spamProtectEmailAddresses\_atSubst
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          (at)
@@ -2089,7 +2089,7 @@ spamProtectEmailAddresses\_lastDotSubst
          spamProtectEmailAddresses\_lastDotSubst
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          . *(just a simple dot)*
@@ -2202,7 +2202,7 @@ typolinkLinkAccessRestrictedPages
          typolinkLinkAccessRestrictedPages
 
    Data type
-         :t3-data-type:`integer` (page id) / keyword "NONE"
+         :ref:`data-type-integer` (page id) / keyword "NONE"
 
    Description
          If set, typolinks pointing to access restricted pages will still link
@@ -2242,7 +2242,7 @@ typolinkLinkAccessRestrictedPages\_addParams
          typolinkLinkAccessRestrictedPages\_addParams
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          See :ref:`setup-config-typolinklinkaccessrestrictedpages` above.
@@ -2261,7 +2261,7 @@ xhtmlDoctype
          xhtmlDoctype
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Default
          (same as config.doctype if set to a keyword)
@@ -2307,7 +2307,7 @@ xmlprologue
          xmlprologue
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          If empty (not set) then the default XML 1.0 prologue is set, when the

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -150,30 +150,30 @@ Properties
    Property                       Data Type                             :ref:`stdwrap`         Default
    ============================== ===================================== ====================== ========================
    `1,2,3,4...`_                  :ref:`cObject <data-type-cobject>`
-   `bodyTag`_                     :t3-data-type:`tag`                                          <body>
-   `bodyTagAdd`_                  :t3-data-type:`string`
+   `bodyTag`_                     :ref:`data-type-tag`                                         <body>
+   `bodyTagAdd`_                  :ref:`data-type-string`
    `bodyTagCObject`_              :ref:`cObject <data-type-cobject>`
    `config`_                      :ref:`->CONFIG <config>`
-   `css\_inlinestyle`_            :t3-data-type:`string`
+   `css\_inlinestyle`_            :ref:`data-type-string`
    `cssInline.[array]`_           :ref:`cObject <data-type-cobject>`
    `footerData.[array]`_          :ref:`cObject <data-type-cobject>`
    `headerData.[array]`_          :ref:`cObject <data-type-cobject>`
-   `headTag`_                     :t3-data-type:`tag` / :ref:`stdwrap`                         <head>
-   `includeCSS.[array]`_          :t3-data-type:`resource`
-   `includeCSSLibs.[array]`_      :t3-data-type:`resource`
-   `includeJS.[array]`_           :t3-data-type:`resource`
-   `includeJSFooter.[array]`_     :t3-data-type:`resource`
-   `includeJSFooterlibs.[array]`_ :t3-data-type:`resource`
-   `includeJSLibs.[array]`_       :t3-data-type:`resource`
+   `headTag`_                     :ref:`data-type-tag` / :ref:`stdwrap`                        <head>
+   `includeCSS.[array]`_          :ref:`data-type-resource`
+   `includeCSSLibs.[array]`_      :ref:`data-type-resource`
+   `includeJS.[array]`_           :ref:`data-type-resource`
+   `includeJSFooter.[array]`_     :ref:`data-type-resource`
+   `includeJSFooterlibs.[array]`_ :ref:`data-type-resource`
+   `includeJSLibs.[array]`_       :ref:`data-type-resource`
    `inlineLanguageLabelFiles`_    (array of strings)
    `inlineSettings`_              (array of strings)
    `jsFooterInline.[array]`_      :ref:`cObject <data-type-cobject>`
    `jsInline.[array]`_            :ref:`cObject <data-type-cobject>`
    `meta`_                        (array of strings)
-   `shortcutIcon`_                :t3-data-type:`resource`
+   `shortcutIcon`_                :ref:`data-type-resource`
    `stdWrap`_                     :ref:`stdwrap`
-   `typeNum`_                     :t3-data-type:`integer`                                      0
-   `wrap`_                        :t3-data-type:`wrap`
+   `typeNum`_                     :ref:`data-type-integer`                                      0
+   `wrap`_                        :ref:`data-type-wrap`
    ============================== ===================================== ====================== ========================
 
 .. ### BEGIN~OF~TABLE ###
@@ -231,7 +231,7 @@ bodyTag
          bodyTag
 
    Data type
-         :t3-data-type:`tag`
+         :ref:`data-type-tag`
 
    Default
          <body>
@@ -260,7 +260,7 @@ bodyTagAdd
          bodyTagAdd
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          This content is added inside of the opening :html:`<body>` tag right
@@ -340,7 +340,7 @@ CSS\_inlineStyle
          CSS\_inlineStyle
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          This value is just passed on as CSS.
@@ -475,7 +475,7 @@ headTag
          headTag
 
    Data type
-         :t3-data-type:`tag` / :ref:`stdwrap`
+         :ref:`data-type-tag` / :ref:`stdwrap`
 
    Default
          <head>
@@ -497,14 +497,14 @@ includeCSS.[array]
          includeCSS.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Inserts a stylesheet (just like the :typoscript:`stylesheet` property), but allows
          setting up more than a single stylesheet, because you can enter files
          in an array.
 
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted.
 
          Each file has *optional properties*:
@@ -583,12 +583,12 @@ includeCSSLibs.[array]
          includeCSSLibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Adds CSS library files to head of page.
 
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted. This means that remote files cannot be referenced
          (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
 
@@ -654,13 +654,13 @@ includeJS.[array]
          includeJS.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Inserts one or more (Java)Scripts in <script> tags.
          With :ref:`setup-config-movejsfromheadertofooter` set to TRUE all files
          will be moved to the footer.
-         The file definition must be a valid :t3-data-type:`resource` data type,
+         The file definition must be a valid :ref:`data-type-resource` data type,
          otherwise nothing is inserted. This means that remote files cannot be referenced
          (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
 
@@ -737,7 +737,7 @@ includeJSFooter.[array]
          includeJSFooter.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Add JS files to footer (after possible files set in :ref:`includeJSFooterlibs <setup-page-includejsfooterlibs-array>`)
@@ -760,7 +760,7 @@ includeJSFooterlibs.[array]
          includeJSFooterlibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Add JS library files to footer.
@@ -785,7 +785,7 @@ includeJSLibs.[array]
          includeJSLibs.[array]
 
    Data type
-         :t3-data-type:`resource`
+         :ref:`data-type-resource`
 
    Description
          Adds JS library files to head of page.
@@ -1080,7 +1080,7 @@ shortcutIcon
       shortcutIcon
 
    Data type
-      :t3-data-type:`resource`
+      :ref:`data-type-resource`
 
    Description
       Favicon of the page. Create a reference to an icon here!
@@ -1129,7 +1129,7 @@ typeNum
          typeNum
 
    Data type
-         :t3-data-type:`integer`
+         :ref:`data-type-integer`
 
    Default
          0
@@ -1154,7 +1154,7 @@ wrap
          wrap
 
    Data type
-         :t3-data-type:`wrap`
+         :ref:`data-type-wrap`
 
    Description
          Wraps the content of the cObject array.

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -57,7 +57,7 @@ userFunc
          \_CSS\_DEFAULT\_STYLE
 
    Data type
-         :t3-data-type:`string` / :ref:`stdwrap`
+         :ref:`data-type-string` / :ref:`stdwrap`
 
    Description
          Use this to have some default CSS styles inserted in the header
@@ -93,7 +93,7 @@ userFunc
          \_CSS\_PAGE\_STYLE
 
    Data type
-         :t3-data-type:`string`
+         :ref:`data-type-string`
 
    Description
          `_CSS_PAGE_STYLE` is included only on the affected pages. Depending
@@ -195,7 +195,7 @@ features.skipDefaultArguments
          features.skipDefaultArguments
 
    Data type
-         :t3-data-type:`boolean`
+         :ref:`data-type-boolean`
 
    Default
          false
@@ -225,7 +225,7 @@ features.ignoreAllEnableFieldsInBe
       features.ignoreAllEnableFieldsInBe
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       false
@@ -263,7 +263,7 @@ persistence.enableAutomaticCacheClearing
       persistence.enableAutomaticCacheClearing
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       true
@@ -295,7 +295,7 @@ persistence.storagePid
       persistence.storagePid
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       true
@@ -444,7 +444,7 @@ mvc.callDefaultActionIfActionCantBeResolved
       mvc.callDefaultActionIfActionCantBeResolved
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       false
@@ -475,7 +475,7 @@ mvc.throwPageNotFoundExceptionIfActionCantBeResolved
       mvc.callDefaultActionIfActionCantBeResolved
 
    Data type
-      :t3-data-type:`boolean`
+      :ref:`data-type-boolean`
 
    Default
       false
@@ -510,7 +510,7 @@ Format
       format
 
    Data type
-      :t3-data-type:`string`
+      :ref:`data-type-string`
 
    Default
       html

--- a/Documentation/UsingSetting/Constants.rst
+++ b/Documentation/UsingSetting/Constants.rst
@@ -32,7 +32,7 @@ programming languages.
 
 **Reserved name**
 
-The object or property "file" is always interpreted as data type :t3-data-type:`resource`. That means it refers to a file, which has to be uploaded
+The object or property "file" is always interpreted as data type :ref:`data-type-resource`. That means it refers to a file, which has to be uploaded
 in the TYPO3 CMS installation.
 
 **Multi-line values: The ( ) signs**
@@ -64,7 +64,7 @@ expected location.
    }
 
 The objects in the highlighted lines contain the reserved word "file" and the
-properties are always of data type ":t3-data-type:`resource`".
+properties are always of data type ":ref:`data-type-resource`".
 
 
 .. index:: Constants; Usage


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally, index is added for missing data types.

Releases: main, 12.4, 11.5