### PR TITLE
[TASK] #100405 - Deprecate property TypoScriptFrontendController->type

### DIFF
--- a/Documentation/AppendixA/Index.rst
+++ b/Documentation/AppendixA/Index.rst
@@ -158,11 +158,25 @@ writing: :php:`TypoScriptFrontendController->id`.
    Variable
          type
 
+         .. versionchanged:: 12.4
+            The property has been marked as deprecated and will be removed with
+            v13.0.
+
    PHP-Type
          integer
 
    Description
          The type
+
+   Migration
+         When using this property in PHP code via :php:`$GLOBALS['TSFE']->type`,
+         it is recommended to move to the
+         :ref:`PSR-7 request <t3coreapi:typo3-request>` via
+         :php:`$request->getAttribute('routing')->getPageType()`, which is the
+         property of the :php:`PageArguments` object, as a result of the
+         :php:`GET` parameter :php:`type`, or
+         :php:`$GLOBALS['TSFE']->getPageArguments()->getPageType()`, if the
+         request object is not available.
 
 
 .. container:: table-row


### PR DESCRIPTION
Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/444
Releases: main, 12.4