### PR TITLE
[TASK] Replace "t3-data-processor-csv" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/CommaSeparatedValueProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/CommaSeparatedValueProcessor.rst
@@ -16,53 +16,70 @@ and enclosure into account, before it is passed to the view.
 Options:
 ========
 
-..  t3-data-processor-csv:: if
+..  _CommaSeparatedValueProcessor-if:
+
+..  confval:: if
 
     :Required: false
-    :type: :ref:`if` condition
-    :default: ""
+    :Data type: :ref:`if` condition
+    :default: ''
 
-    If the condition is met the data processor is processed.
+    If the condition is met, the data processor is processed.
 
-..  t3-data-processor-csv:: fieldName
+
+..  _CommaSeparatedValueProcessor-fieldName:
+
+..  confval:: fieldName
 
     :Required: true
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: ''
 
     Name of the field in the processed ContentObjectRenderer.
 
-..  t3-data-processor-csv:: as
+
+..  _CommaSeparatedValueProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: defaults to the fieldName
 
     The variable's name to be used in the Fluid template.
 
-..  t3-data-processor-csv:: maximumColumns
+
+..  _CommaSeparatedValueProcessor-maximumColumns:
+
+..  confval:: maximumColumns
 
     :Required: false
-    :type: int, :ref:`stdWrap`
-    :default: 0
+    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :default: :typoscript:`0`
 
     Maximal number of columns to be transformed. Surplus columns will be
-    silently dropped. When set to `0` (default) all columns will be
+    silently dropped. When set to :typoscript:`0` (default) all columns will be
     transformed.
 
-..  t3-data-processor-csv:: fieldDelimiter
+
+..  _CommaSeparatedValueProcessor-fieldDelimiter:
+
+..  confval:: fieldDelimiter
 
     :Required:  false
-    :type: string(1), :ref:`stdWrap`
-    :default: ','
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :default: :typoscript:`,`
 
     The field delimiter, a character separating the values.
 
-..  t3-data-processor-csv:: fieldEnclosure
+
+..  _CommaSeparatedValueProcessor-fieldEnclosure:
+
+..  confval:: fieldEnclosure
 
     :Required:  false
-    :type: string(1), :ref:`stdWrap`
-    :default: '"'
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :default: :typoscript:`"`
 
     The field enclosure, a character surrounding the values.
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-csv = t3-data-processor-csv // t3-data-processor-csv // Data processor CommaSeparatedValueProcessor
 t3-data-processor-db = t3-data-processor-db // t3-data-processor-db // Data processor DatabaseQueryProcessor
 t3-data-processor-files = t3-data-processor-files // t3-data-processor-files // Data processor FilesProcessor
 t3-data-processor-flex = t3-data-processor-flex // t3-data-processor-flex // Data processor FlexFormProcessor


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors have been added
- Data types (like string and integer) are linked
- The length of strings ("string(1)") is removed as there is no enforcement in the code

Releases: main, 12.4, 11.5