### PR TITLE
[TASK] #102621 - TSFE->getPageArguments() marked as internal

### DIFF
--- a/Documentation/AppendixA/Index.rst
+++ b/Documentation/AppendixA/Index.rst
@@ -168,11 +168,7 @@ writing: :php:`TypoScriptFrontendController->id`.
          When using this property in PHP code via :php:`$GLOBALS['TSFE']->type`,
          it is recommended to move to the
          :ref:`PSR-7 request <t3coreapi:typo3-request>` via
-         :php:`$request->getAttribute('routing')->getPageType()`, which is the
-         property of the :php:`PageArguments` object, as a result of the
-         :php:`GET` parameter :php:`type`, or
-         :php:`$GLOBALS['TSFE']->getPageArguments()->getPageType()`, if the
-         request object is not available.
+         :php:`$request->getAttribute('routing')->getPageType()`.
 
 
 .. container:: table-row


### PR DESCRIPTION
The usage of `TSFE->getPageArguments()` is not recommended anymore as this method has been marked as internal for v13.0. Additionally, remove the internal knowledge, the migration of the request attribute should be enough for the average user.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/752
Releases: main