### PR TITLE
[TASK] Replace "t3-data-processor-db" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -16,38 +16,46 @@ array of records.
 Options:
 ========
 
-..  t3-data-processor-db:: if
+..  _DatabaseQueryProcessor-if:
+
+..  confval:: if
 
     :Required: false
-    :type: :ref:`if` condition
+    :Data type: :ref:`if` condition
     :default: ''
 
     Only if the condition is met the data processor is executed.
 
-..  t3-data-processor-db:: table
+
+..  _DatabaseQueryProcessor-table:
+
+..  confval:: table
 
     :Required: true
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: ''
 
     Name of the table from which the records should be fetched.
 
-..  t3-data-processor-db:: as
+..  _DatabaseQueryProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: 'records'
 
     The variable's name to be used in the Fluid template.
 
-..  t3-data-processor-db:: dataProcessing
+..  _DatabaseQueryProcessor-dataProcessing:
+
+..  confval:: dataProcessing
 
     :Required: false
-    :type: array of :ref:`dataProcessing`
-    :default: ''
+    :Data type: array of :ref:`dataProcessing`
+    :default: []
 
     Array of data processors to be applied to all fetched records.
-
 
 ..  note::
     All other options will be interpreted as in the TypoScript function
@@ -99,4 +107,6 @@ and the data of the images in :php:`files`.
 
 ..  figure:: /Images/ManualScreenshots/FrontendOutput/DataProcessing/DatabaseProcessor.png
     :class: with-shadow
-    :alt: haiku record data dump and output
+    :alt: Haiku record data dump and output
+
+    Haiku record data dump and output

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-db = t3-data-processor-db // t3-data-processor-db // Data processor DatabaseQueryProcessor
 t3-data-processor-files = t3-data-processor-files // t3-data-processor-files // Data processor FilesProcessor
 t3-data-processor-flex = t3-data-processor-flex // t3-data-processor-flex // Data processor FlexFormProcessor
 t3-data-processor-gallery = t3-data-processor-gallery // t3-data-processor-gallery // Data processor GalleryProcessor


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string and integer) are linked

Releases: main, 12.4, 11.5