### PR TITLE
[TASK] Replace "t3-data-processor-flex" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
@@ -11,23 +11,29 @@ data within an XML structure inside a single database column. The data processor
 :php:`\TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor` converts the
 FlexForm data of a given field into a Fluid-readable array.
 
-Options
-========
 
-..  t3-data-processor-flex:: fieldname
+Options
+=======
+
+..  _FlexFormProcessor-fieldname:
+
+..  confval:: fieldname
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: 'pi_flexform'
 
     Field name of the column the FlexForm data is stored in.
 
-..  t3-data-processor-flex:: references
+
+..  _FlexFormProcessor-references:
+
+..  confval:: references
 
     ..  versionadded:: 13.0
 
     :Required: false
-    :type: array
+    :Data type: array
 
     Associative array of FlexForm fields (key) and the according database field
     (value).
@@ -39,13 +45,17 @@ Options
 
     See :ref:`FlexFormProcessor-resolving-fal`.
 
-..  t3-data-processor-flex:: as
+
+..  _FlexFormProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: 'flexFormData'
 
-    Name for the variable in the Fluid template..
+    Name for the variable in the Fluid template.
+
 
 Examples
 ========

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-flex = t3-data-processor-flex // t3-data-processor-flex // Data processor FlexFormProcessor
 t3-data-processor-gallery = t3-data-processor-gallery // t3-data-processor-gallery // Data processor GalleryProcessor
 t3-data-processor-lang = t3-data-processor-lang // t3-data-processor-lang // Data processor LanguageMenuProcessor
 t3-data-processor-menu = t3-data-processor-menu // t3-data-processor-menu // Data processor MenuProcessor


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string) are linked

Releases: main, 12.4, 11.5