### PR TITLE
[TASK] Replace "t3-data-processor-lang" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/LanguageMenuProcessor.rst
@@ -21,17 +21,22 @@ assigned to the :typoscript:`FLUIDTEMPLATE` as a variable.
 Options:
 ========
 
-..  t3-data-processor-lang:: if
+..  _LanguageMenuProcessor-if:
+
+..  confval:: if
 
     :Required: false
-    :type: :ref:`if` condition
+    :Data type: :ref:`if` condition
 
     Only if the condition is met the data processor is executed.
 
-..  t3-data-processor-lang:: languages
+
+..  _LanguageMenuProcessor-languages:
+
+..  confval:: languages
 
     :Required: true
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: "auto"
     :Example: "0,1,2"
 
@@ -40,20 +45,25 @@ Options:
     <t3coreapi:sitehandling>`.
 
 
-..  t3-data-processor-lang:: addQueryString.exclude
+..  _LanguageMenuProcessor-addQueryString-exclude:
+
+..  confval:: addQueryString.exclude
 
     :Required: true
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: ""
     :Example: "gclid,contrast"
 
     A list of comma-separated parameter names to be excluded from the language
     menu URLs.
 
-..  t3-data-processor-lang:: as
+
+..  _LanguageMenuProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: defaults to the fieldName
 
     The variable name to be used in the Fluid template.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-lang = t3-data-processor-lang // t3-data-processor-lang // Data processor LanguageMenuProcessor
 t3-data-processor-menu = t3-data-processor-menu // t3-data-processor-menu // Data processor MenuProcessor
 t3-data-processor-sitelang = t3-data-processor-sitelang // t3-data-processor-sitelang // Data processor SiteLanguageProcessor
 t3-data-processor-site = t3-data-processor-site // t3-data-processor-site // Data processor SiteProcessor


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string) are linked

Releases: main, 12.4, 11.5