### PR TITLE
[TASK] Replace "t3-data-processor-sitelang" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteLanguageProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteLanguageProcessor.rst
@@ -14,10 +14,12 @@ The :php:`SiteLanguageProcessor` fetches language-related data from the
 Options
 =======
 
-..  t3-data-processor-sitelang:: as
+..  _SiteLanguageProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: "site"
 
     The variable name to be used in the Fluid template.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-sitelang = t3-data-processor-sitelang // t3-data-processor-sitelang // Data processor SiteLanguageProcessor
 t3-data-processor-site = t3-data-processor-site // t3-data-processor-site // Data processor SiteProcessor
 t3-data-processor-split = t3-data-processor-split // t3-data-processor-split // Data processor SplitProcessor
 


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string) are linked

Releases: main, 12.4