### PR TITLE
[TASK] Replace "t3-data-processor-site" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteProcessor.rst
@@ -12,10 +12,12 @@ The :php:`SiteProcessor` fetches data from the :ref:`site configuration
 Options
 =======
 
-..  t3-data-processor-site:: as
+..  _SiteProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: "site"
 
     The variable name to be used in the Fluid template.

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-site = t3-data-processor-site // t3-data-processor-site // Data processor SiteProcessor
 t3-data-processor-split = t3-data-processor-split // t3-data-processor-split // Data processor SplitProcessor
 
 t3-tlo-config = t3-tlo-config // t3-tlo-config // Top level object 'config'


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string) are linked

Releases: main, 12.4, 11.5