### PR TITLE
[TASK] Replace "t3-data-processor-split" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SplitProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SplitProcessor.rst
@@ -13,66 +13,85 @@ Whitespaces are automatically trimmed.
 Options
 =======
 
-..  t3-data-processor-split:: if
+..  _splitProcessor-if:
+
+..  confval:: if
 
     :Required: false
-    :type: :ref:`if` condition
+    :Data type: :ref:`if` condition
     :default: ''
 
     Only if the condition is met the data processor is executed.
 
-..  t3-data-processor-split:: fieldName
+
+..  _splitProcessor-fieldName:
+
+..  confval:: fieldName
 
     :Required: true
-    :type: string, :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: ''
 
     Name of the field to be used.
 
-..  t3-data-processor-split:: as
+
+..  _splitProcessor-as:
+
+..  confval:: as
 
     :Required: false
-    :type: string
+    :Data type: :ref:`data-type-string`
     :default: defaults to the fieldName
 
     The variable name to be used in the Fluid template.
 
-..  t3-data-processor-split:: delimiter
+
+..  _splitProcessor-delimiter:
+
+..  confval:: delimiter
 
     :Required: false
-    :type: string(1), :ref:`stdWrap`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
     :default: Line Feed
     :Example: ","
 
     The field delimiter, a character separating the values.
 
-..  t3-data-processor-split:: filterIntegers
+
+..  _splitProcessor-filterIntegers:
+
+..  confval:: filterIntegers
 
     :Required: false
-    :type: bool, :ref:`stdWrap`
-    :default: false
-    :Example: true
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :default: 0
+    :Example: 1
 
-    If set to `true`, all values are being cast to int.
+    If set to `1`, all values are being cast to int.
 
 
-..  t3-data-processor-split:: filterUnique
+..  _splitProcessor-filterUnique:
 
-    :Required: false
-    :type: bool, :ref:`stdWrap`
-    :default: false
-    :Example: true
-
-    All duplicates will be removed.
-
-..  t3-data-processor-split:: removeEmptyEntries
+..  confval:: filterUnique
 
     :Required: false
-    :type: bool, :ref:`stdWrap`
-    :default: false
-    :Example: true
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :default: 0
+    :Example: 1
 
-    All empty values will be removed.
+    If set to `1`, all duplicates will be removed.
+
+
+..  _splitProcessor-removeEmptyEntries:
+
+..  confval:: removeEmptyEntries
+
+    :Required: false
+    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :default: 0
+    :Example: 1
+
+    If set to `1`, all empty values will be removed.
 
 
 Example: Splitting a URL

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,8 +40,6 @@ t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER
 
-t3-data-processor-split = t3-data-processor-split // t3-data-processor-split // Data processor SplitProcessor
-
 t3-tlo-config = t3-tlo-config // t3-tlo-config // Top level object 'config'
 
 t3-function-cache = t3-function-cache // t3-function-cache // Function cache


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- "Data type" is used instead of "type" to streamline with other sections
- Named anchors are added
- Data types (like string, bool) are linked
- Boolean types are corrected, "0" or "1" is necessary instead of "false" or "true"

Releases: main, 12.4, 11.5