### PR TITLE
[TASK] Replace "t3-cobj-case" with "confval"

### DIFF
--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -26,94 +26,112 @@ be used as it has a special meaning: If the value of the "key"
 property is *not* found in the array of cObjects, then the cObject
 from the "default" property will be used.
 
-.. contents::
-   :local:
+..  contents::
+    :local:
 
 Properties
 ==========
 
+..  _cobj-case-array-of-cObjects:
+
 (array of cObjects)
 -------------------
 
-..  t3-cobj-case:: array of cObjects
+..  confval:: array of cObjects
 
     :Data type: :ref:`cObject <data-type-cobject>`
 
     Array of cObjects. Use this to define cObjects for the different
-    values of :t3-cobj-case:`key`. If :t3-cobj-case:`key` has a certain value,
+    values of :ref:`cobj-case-key`. If :ref:`cobj-case-key` has a certain value,
     the according cObject will be rendered. The cObjects can have any name, but not
     the names of the other properties of the cObject CASE.
+
+..  _cobj-case-cache:
 
 cache
 -----
 
-..  t3-cobj-case:: cache
+..  confval:: cache
 
     :Data type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
+
+..  _cobj-case-default:
+
 default
 -------
 
-..  t3-cobj-case:: default
+..  confval:: default
 
     :Data type: :ref:`cObject <data-type-cobject>`
 
-     Use this to define the rendering for *those* values of :t3-cobj-case:`key` that
-     do *not* match any of the values of the :t3-cobj-case:`array of cObjects`. If no
+     Use this to define the rendering for *those* values of :ref:`cobj-case-key` that
+     do *not* match any of the values of the :ref:`cobj-case-array-of-cObjects`. If no
      default cObject is defined, an empty string will be returned for
      the default case.
+
+
+..  _cobj-case-if:
 
 if
 --
 
-..  t3-cobj-case:: if
+..  confval:: if
 
     :Data type: :ref:`->if <if>`
 
     If :ref:`if <if>` returns false, nothing is returned.
 
+
+..  _cobj-case-key:
+
 key
 ---
 
-..  t3-cobj-case:: key
+..  confval:: key
 
-    :Data type: string /:ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: default
 
     The key, which determines, which cObject will be rendered. Its
     value is expected to match the name of one of the cObjects from
     the array of cObjects; this cObject is then rendered. If no name
-    of a cObject is matched, the cObject from the property :t3-cobj-case:`default`
+    of a cObject is matched, the cObject from the property :ref:`cobj-case-default`
     is rendered.
 
     This property defines the source of the value that will be matched against
-    the values of the :t3-cobj-case:`array of cObjects`. It will generally not be a
+    the values of the :ref:`cobj-case-array-of-cObjects`. It will generally not be a
     simple string, but use its :ref:`stdWrap` properties to retrieve a
     dynamic value from some specific source, typically a field of the
     current record. See the :ref:`example below <cobj-case-examples>`.
 
 
+..  _cobj-case-setCurrent:
+
 setCurrent
 ----------
 
-..  t3-cobj-case:: setCurrent
+..  confval:: setCurrent
 
-    :Data type: string /:ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
-    Sets the "current"-value.
+    Sets the "current" value.
+
+
+..  _cobj-case-stdWrap:
 
 stdWrap
 -------
 
-
-..  t3-cobj-case:: stdWrap
+..  confval:: stdWrap
 
     :Data type: :ref:`stdWrap <stdwrap>`
 
     :ref:`stdWrap` around any object that was rendered no matter what the
-    :t3-cobj-case:`key` value is.
+    :ref:`cobj-case-key` value is.
+
 
 ..  _cobj-case-examples:
 
@@ -122,10 +140,10 @@ Example:
 
 If in this example the field :sql:`header` turns out not to be set ("false"), an
 empty string is returned. Otherwise TYPO3 chooses between two different
-renderings of some content depending on whether the :t3-cobj-case:`key` field
-`layout` is "1" or not (:t3-cobj-case:`default`).
+renderings of some content depending on whether the :ref:`cobj-case-key` field
+:typoscript:`layout` is "1" or not (:ref:`cobj-case-default`).
 
-The result is in either case wrapped with "\|<br>".
+The result is in either case wrapped with :typoscript:`|<br>`.
 
 ..  code-block:: typoscript
     :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -78,7 +78,7 @@ stdWrap
 
     :Data type: :ref:`->stdWrap <stdwrap>`
 
-    Executed on all rendered cObjects after property :t3-cobj-coa:`wrap`.
+    Executed on all rendered cObjects after property :ref:`cobj-coa-wrap`.
 
 
 ..  _cobj-coa-wrap:
@@ -90,7 +90,7 @@ wrap
 
     :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
 
-     Wraps all rendered cObjects. Executed before property :t3-cobj-coa:`stdWrap`.
+     Wraps all rendered cObjects. Executed before property :ref:`cobj-coa-stdWrap`.
 
 
 .. _cobj-cobj-array-examples:

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -25,7 +25,6 @@ use_opensearch       =
 
 [sphinx_object_types_to_add]
 
-t3-cobj-case = t3-cobj-case // t3-cobj-case // Content object CASE
 t3-cobj-content = t3-cobj-content // t3-cobj-content // Content object CONTENT
 t3-cobj-extbaseplugin = t3-cobj-extbaseplugin // t3-cobj-extbaseplugin // Content object EXTBASEPLUGIN
 t3-cobj-files = t3-cobj-files // t3-cobj-files // Content object FILES


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- Named anchors are added
- Data types (like string) are linked
- Fix wrong references in COA chapter which were missed in a previous change

Releases: main, 12.4, 11.5