### PR TITLE
[TASK] Replace "t3-cobj-img-resource" with "confval"

### DIFF
--- a/Documentation/ContentObjects/ImgResource/Index.rst
+++ b/Documentation/ContentObjects/ImgResource/Index.rst
@@ -1,34 +1,39 @@
-.. include:: /Includes.rst.txt
-.. index:: Content objects; IMAGE_RESOURCE
-.. _cobj-img-resource:
+..  include:: /Includes.rst.txt
+..  index:: Content objects; IMAGE_RESOURCE
+..  _cobj-img-resource:
 
 =============
 IMG\_RESOURCE
 =============
 
 Objects of type IMG_RESOURCE returns a reference to an image, possibly
-wrapped with :t3-cobj-img-resource:`stdWrap`. Can
-for example be used for putting background images in tables or
+wrapped with :ref:`cobj-img-resource-stdWrap`. It can be used, for example,
+for putting background images in tables or
 table rows or to import an image in your own include scripts.
 Depending on your use case you might prefer using the cObject
 :ref:`IMAGE <cobj-image>`, which creates a complete :html:`img` tag.
 
-.. contents::
-   :local:
+..  contents::
+    :local:
 
 Properties
 ==========
 
+..  _cobj-img-resource-file:
+
 file
 ----
 
-..  t3-cobj-img-resource:: file
+..  confval:: file
 
-    :Data type: imgResource
+    :Data type: :ref:`->imgResource <imgresource>`
+
+
+..  _cobj-img-resource-stdWrap:
 
 stdWrap
 -------
 
-..  t3-cobj-img-resource:: stdWrap
+..  confval:: stdWrap
 
     :Data type: :ref:`->stdWrap <stdwrap>`

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -25,7 +25,6 @@ use_opensearch       =
 
 [sphinx_object_types_to_add]
 
-t3-cobj-img-resource = t3-cobj-img-resource // t3-cobj-img-resource // Content object IMG_RESOURCE
 t3-cobj-load-register = t3-cobj-load-register // t3-cobj-load-register // Content object LOAD_REGISTER
 t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- Anchors added where missing
- Data types (imgResource) are linked

Releases: main, 12.4, 11.5