### PR TITLE
[TASK] Replace "t3-cobj-load-register" with "confval"

### DIFF
--- a/Documentation/ContentObjects/LoadRegister/Index.rst
+++ b/Documentation/ContentObjects/LoadRegister/Index.rst
@@ -30,13 +30,14 @@ Properties
 (array of field names)
 ----------------------
 
-..  t3-cobj-load-register:: array of field names
+..  confval:: array of field names
 
-    :Data type: string /:ref:`stdWrap <stdwrap>`
+    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     **Example:**
 
-    This sets "contentWidth", "label" and "head".
+    This sets :typoscript:`contentWidth`, :typoscript:`label` and
+    :typoscript:`head`.
 
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -25,7 +25,6 @@ use_opensearch       =
 
 [sphinx_object_types_to_add]
 
-t3-cobj-load-register = t3-cobj-load-register // t3-cobj-load-register // Content object LOAD_REGISTER
 t3-cobj-records = t3-cobj-records // t3-cobj-records // Content object RECORDS
 t3-cobj-svg = t3-cobj-svg // t3-cobj-svg // Content object SVG
 t3-cobj-user = t3-cobj-user // t3-cobj-user // Content object USER


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- Data type (string) are linked
- Field names in the text are marked as TypoScript

Releases: main, 12.4, 11.5