### PR TITLE
[TASK] Avoid 'types' TLO

### DIFF
--- a/Documentation/TopLevelObjects/Index.rst
+++ b/Documentation/TopLevelObjects/Index.rst
@@ -35,7 +35,6 @@ example `config` or `plugin`.
    :ref:`tt_* <tlo-tt>`
    :ref:`resources <tlo-resources>`      readonly
    :ref:`sitetitle <tlo-sitetitle>`      readonly
-   :ref:`types <tlo-types>`              readonly
    ===================================== =========================
 
 

--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -88,27 +88,4 @@ sitetitle
          SiteTitle (internal)
 
 
-
-.. index:: Top-level objects; types
-.. _top-level-objects-types:
-.. _tlo-types:
-
-=====
-types
-=====
-
-.. container:: table-row
-
-   Property
-         types
-
-   Data type
-         readonly
-
-   Description
-         Types (internal)
-
-         :typoscript:`type=99` reserved for plaintext display
-
-
 .. ###### END~OF~TABLE ######


### PR DESCRIPTION
This one is declared 'internal' in the docs
already and may be removed in v13. There is
no point in documenting this core internal
structure. The 'plaintext' hint is wrong.