### PR TITLE
[Backport 11.5] [TASK] Adjust indentation on "CONFIG & config" chapter (#1025)

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -1,11 +1,11 @@
-.. include:: /Includes.rst.txt
-.. index::
-   config
-   Top-level objects; config
-.. _config:
-.. _config-object-type:
-.. _config-datatype:
-.. _top-level-objects-config:
+..  include:: /Includes.rst.txt
+..  index::
+    config
+    Top-level objects; config
+..  _config:
+..  _config-object-type:
+..  _config-datatype:
+..  _top-level-objects-config:
 
 ===============
 CONFIG & config
@@ -27,13 +27,13 @@ files by writing :php:`$GLOBALS['TSFE']->config['config']`.
 This typoscript "top level object" `config` provides access to the internal
 array. This means, that configuration settings can be made easily. For example:
 
-.. code-block::
+..  code-block::
 
-   # TypoScript
-   config.debug = 1
+    # TypoScript
+    config.debug = 1
 
-   # will produce, in php
-   $GLOBALS['TSFE']->config['config']['debug'] // with value 1
+    # will produce, in php
+    $GLOBALS['TSFE']->config['config']['debug'] // with value 1
 
 .. index:: config; Properties
 
@@ -42,139 +42,139 @@ Known properties of 'config'
 
 
 
-.. ### BEGIN~OF~TABLE ###
+..  ### BEGIN~OF~TABLE ###
 
 
-.. _setup-config-absrefprefix:
+..  _setup-config-absrefprefix:
 
 absRefPrefix
 ============
 
-.. t3-tlo-config:: absRefPrefix
+..  t3-tlo-config:: absRefPrefix
 
-   :Data type: :ref:`data-type-string`
-   :Special value: "auto"
+    :Data type: :ref:`data-type-string`
+    :Special value: "auto"
 
-   If set, the string is prepended to all relative links that TYPO3 generates.
+    If set, the string is prepended to all relative links that TYPO3 generates.
 
-   `config.absRefPrefix = auto` lets TYPO3 autodetect
-   the site root based on path prefixes and not based on host name variables
-   from the server, making this value safe for multi-domain environments.
+    :typoscript:`config.absRefPrefix = auto` lets TYPO3 autodetect
+    the site root based on path prefixes and not based on host name variables
+    from the server, making this value safe for multi-domain environments.
 
-   Using an URI in :typoscript:`absRefPrefix` will require additional conditions
-   if you use different domains for your deployment stages in CI environments.
+    Using an URI in :typoscript:`absRefPrefix` will require additional conditions
+    if you use different domains for your deployment stages in CI environments.
 
-   If you're working on a server where you have different domain
-   names or different path segments leading to the same page (e.g. for internal
-   and external access), you may do yourself a favor and set `absRefPrefix` to
-   the URL and path of your site, e.g. :samp:`https://example.org/`. If you do not,
-   you risk to render pages to cache from the internal network and thereby
-   prefix image-references and links with a wrong path or a path not accessible
-   from outside.
+    If you are working on a server where you have different domain names or
+    different path segments leading to the same page (e.g. for internal and
+    external access), you may do yourself a favor and set :typoscript:`absRefPrefix` to
+    the URL and path of your site, e.g. :samp:`https://example.org/`. If you do not,
+    you risk to render pages to cache from the internal network and thereby
+    prefix image references and links with a wrong path or a path not accessible
+    from outside.
 
-   .. rubric:: Examples
+    ..  rubric:: Examples
 
-   1. Prefixing all links with a "/" results in absolute link paths:
+    #.  Prefixing all links with a "/" results in absolute link paths:
 
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-         config.absRefPrefix = /
+            config.absRefPrefix = /
 
-   2. Prefixing all links with the path to a subdirectory:
+    #.  Prefixing all links with the path to a subdirectory:
 
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-         config.absRefPrefix = /some-subsite/
+            config.absRefPrefix = /some-subsite/
 
-   3. Prefixing all links with a URI scheme:
+    #.  Prefixing all links with a URI scheme:
 
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-         config.absRefPrefix = https://example.org/
+            config.absRefPrefix = https://example.org/
 
 
-.. _setup-config-additionalheaders:
+..  _setup-config-additionalheaders:
 
 additionalHeaders
 =================
 
-.. t3-tlo-config:: additionalHeaders
+..  t3-tlo-config:: additionalHeaders
 
-   :Data type: numerically indexed array of "HTTP header entries".
+    :Data type: numerically indexed array of "HTTP header entries".
 
-   By means of `config.additionalHeaders` as series of additional HTTP headers
-   can be configured. An entry has the following structure:
+    By means of :typoscript:`config.additionalHeaders` as series of additional HTTP headers
+    can be configured. An entry has the following structure:
 
-   `10.header = the header string`
-      This value is required.
+    :typoscript:`10.header = the header string`
+        This value is required.
 
-   `10.replace = 0 | 1`
-      Optional, boolean, default is `1`.
-      If true, the header will replace an existing one that has the same name.
+    :typoscript:`10.replace = 0 | 1`
+        Optional, boolean, default is `1`.
+        If true, the header will replace an existing one that has the same name.
 
-   `10.httpResponseCode = 201`
-      Optional, integer, a http status code that the page should return.
+    :typoscript:`10.httpResponseCode = 201`
+        Optional, integer, a http status code that the page should return.
 
-   By default TYPO3 sends a "Content-Type" header with the defined
-   encoding. It then sends cache headers, if configured via
-   :ref:`setup-config-sendcacheheaders`.
-   Then additional headers are send, plus finally a "Content-Length"
-   header, if enabled via :ref:`setup-config-enablecontentlengthheader`.
+    By default TYPO3 sends a "Content-Type" header with the defined
+    encoding. It then sends cache headers, if configured via
+    :ref:`setup-config-sendcacheheaders`.
+    Then additional headers are send, plus finally a "Content-Length"
+    header, if enabled via :ref:`setup-config-enablecontentlengthheader`.
 
-   .. rubric:: Examples
+    ..  rubric:: Examples
 
-   1. General usage
+    #.  General usage
 
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-         config.additionalHeaders {
-             10 {
-                 # The header string
-                 header = foo
+            config.additionalHeaders {
+              10 {
+                # The header string
+                header = foo
 
-                 # Do not replace previous headers with the same name.
-                 replace = 0
+                # Do not replace previous headers with the same name.
+                replace = 0
 
-                 # Force a 401 HTTP response code
-                 httpResponseCode = 401
-             }
-             # Always set cache headers to private, overwriting the default TYPO3 Cache-control header
-             20.header = Cache-control: Private
-         }
-
-   2. General usage, same usage, alternate notation
-
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-         config.additionalHeaders.10.header = foo
-         config.additionalHeaders.10.replace = 0
-         config.additionalHeaders.10.httpResponseCode = 401
-         config.additionalHeaders.20.header = Cache-control: Private
-
-
-   3. Set content type for a page returning json
-
-      .. code-block:: typoscript
-         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-         json = PAGE
-         json {
-            typeNum = 1617455215
-            10 =< tt_content.list.20.tx_myextension_myjsonplugin
-            config {
-               disableAllHeaderCode = 1
-               additionalHeaders.10.header = Content-type:application/json
+                # Force a 401 HTTP response code
+                httpResponseCode = 401
+              }
+              # Always set cache headers to private, overwriting the default TYPO3 Cache-control header
+              20.header = Cache-control: Private
             }
-         }
+
+    #.  General usage, same usage, alternate notation
+
+        .. code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+            config.additionalHeaders.10.header = foo
+            config.additionalHeaders.10.replace = 0
+            config.additionalHeaders.10.httpResponseCode = 401
+            config.additionalHeaders.20.header = Cache-control: Private
 
 
-.. index:: config; admPanel
-.. _setup-config-admpanel:
+    #.  Set content type for a page returning JSON
+
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+            json = PAGE
+            json {
+              typeNum = 1617455215
+              10 =< tt_content.list.20.tx_myextension_myjsonplugin
+              config {
+                disableAllHeaderCode = 1
+                additionalHeaders.10.header = Content-type:application/json
+              }
+            }
+
+
+..  index:: config; admPanel
+..  _setup-config-admpanel:
 
 admPanel
 ========
@@ -197,8 +197,9 @@ admPanel
 
 
 
-.. index:: config; ATagParams
-.. _setup-config-atagparams:
+
+..  index:: config; ATagParams
+..  _setup-config-atagparams:
 
 ATagParams
 ==========
@@ -216,8 +217,8 @@ ATagParams
 
 
 
-.. index:: config; baseURL
-.. _setup-config-baseurl:
+..  index:: config; baseURL
+..  _setup-config-baseurl:
 
 baseURL
 =======
@@ -246,8 +247,8 @@ baseURL
             config.baseURL = https://example.org/sub_dir/
 
 
-.. index:: config; cache
-.. _setup-config-cache:
+..  index:: config; cache
+..  _setup-config-cache:
 
 cache
 =====
@@ -321,8 +322,8 @@ cache
             config.cache.all = fe_users:current
 
 
-.. index:: config; cache_clearAtMidnight
-.. _setup-config-cache-clearatmidnight:
+..  index:: config; cache_clearAtMidnight
+..  _setup-config-cache-clearatmidnight:
 
 cache\_clearAtMidnight
 ======================
@@ -345,8 +346,8 @@ cache\_clearAtMidnight
 
 
 
-.. index:: config; cache_period
-.. _setup-config-cache-period:
+..  index:: config; cache_period
+..  _setup-config-cache-period:
 
 cache\_period
 =============
@@ -371,8 +372,8 @@ cache\_period
 
 
 
-.. index:: config; compressCss
-.. _setup-config-compresscss:
+..  index:: config; compressCss
+..  _setup-config-compresscss:
 
 compressCss
 ===========
@@ -417,8 +418,8 @@ compressCss
             config.compressCss = 1
 
 
-.. index:: config; compressJs
-.. _setup-config-compressjs:
+..  index:: config; compressJs
+..  _setup-config-compressjs:
 
 compressJs
 ==========
@@ -466,8 +467,8 @@ compressJs
             config.compressJs = 1
 
 
-.. index:: config; concatenateCss
-.. _setup-config-concatenatecss:
+..  index:: config; concatenateCss
+..  _setup-config-concatenatecss:
 
 concatenateCss
 ==============
@@ -509,8 +510,8 @@ concatenateCss
 
 
 
-.. index:: config; concatenateJs
-.. _setup-config-concatenatejs:
+..  index:: config; concatenateJs
+..  _setup-config-concatenatejs:
 
 concatenateJs
 =============
@@ -561,8 +562,8 @@ concatenateJs
 
 
 
-.. index:: config; contentObjectExceptionHandler
-.. _setup-config-contentObjectExceptionHandler:
+..  index:: config; contentObjectExceptionHandler
+..  _setup-config-contentObjectExceptionHandler:
 
 contentObjectExceptionHandler
 =============================
@@ -623,8 +624,8 @@ contentObjectExceptionHandler
             tt_content.login.20.exceptionHandler.ignoreCodes.10 = 1414512813
 
 
-.. index:: config; debug
-.. _setup-config-debug:
+..  index:: config; debug
+..  _setup-config-debug:
 
 debug
 =====
@@ -644,8 +645,8 @@ debug
 
 
 
-.. index:: config; disableAllHeaderCode
-.. _setup-config-disableallheadercode:
+..  index:: config; disableAllHeaderCode
+..  _setup-config-disableallheadercode:
 
 disableAllHeaderCode
 ====================
@@ -695,8 +696,8 @@ disableAllHeaderCode
 
 
 
-.. index:: config; disableBodyTag
-.. _setup-config-disablebodytag:
+..  index:: config; disableBodyTag
+..  _setup-config-disablebodytag:
 
 disableBodyTag
 ==============
@@ -724,8 +725,8 @@ disableBodyTag
 
 
 
-.. index:: config; disableCanonical
-.. _setup-config-disableCanonical:
+..  index:: config; disableCanonical
+..  _setup-config-disableCanonical:
 
 disableCanonical
 ================
@@ -746,8 +747,8 @@ disableCanonical
 
 
 
-.. index:: config; disableCharsetHeader
-.. _setup-config-disablecharsetheader:
+..  index:: config; disableCharsetHeader
+..  _setup-config-disablecharsetheader:
 
 disableCharsetHeader
 ====================
@@ -766,8 +767,8 @@ disableCharsetHeader
 
 
 
-.. index:: config; disableHrefLang
-.. _setup-config-disableHrefLang:
+..  index:: config; disableHrefLang
+..  _setup-config-disableHrefLang:
 
 disableHrefLang
 ===============
@@ -786,9 +787,8 @@ disableHrefLang
          the rendering of those tags will be skipped.
 
 
-
-.. index:: config; disableImgBorderAttr
-.. _setup-config-disableimgborderattr:
+..  index:: config; disableImgBorderAttr
+..  _setup-config-disableimgborderattr:
 
 disableImgBorderAttr
 ====================
@@ -808,8 +808,8 @@ disableImgBorderAttr
 
 
 
-.. index:: config; disablePageExternalUrl
-.. _setup-config-disablepageexternalurl:
+..  index:: config; disablePageExternalUrl
+..  _setup-config-disablepageexternalurl:
 
 disablePageExternalUrl
 ======================
@@ -849,8 +849,8 @@ disablePrefixComment
 
 
 
-.. index:: config; disablePreviewNotification
-.. _setup-config-disablepreviewnotification:
+..  index:: config; disablePreviewNotification
+..  _setup-config-disablepreviewnotification:
 
 disablePreviewNotification
 ==========================
@@ -870,8 +870,8 @@ disablePreviewNotification
          Disables the "preview" notification box completely.
 
 
-.. index:: config; disableLanguageHeader
-.. _disableLanguageHeader:
+..  index:: config; disableLanguageHeader
+..  _disableLanguageHeader:
 
 disableLanguageHeader
 =====================
@@ -896,8 +896,8 @@ disableLanguageHeader
          If :typoscript:`config.disableLanguageHeader` is set, this header will not be sent.
 
 
-.. index:: config; doctype
-.. _setup-config-doctype:
+..  index:: config; doctype
+..  _setup-config-doctype:
 
 doctype
 =======
@@ -944,8 +944,8 @@ doctype
 
             <!DOCTYPE html>
 
-.. index:: config; enableContentLengthHeader
-.. _setup-config-enablecontentlengthheader:
+..  index:: config; enableContentLengthHeader
+..  _setup-config-enablecontentlengthheader:
 
 enableContentLengthHeader
 =========================
@@ -970,8 +970,8 @@ enableContentLengthHeader
          document in some browsers.
 
 
-.. index:: config; extTarget
-.. _setup-config-exttarget:
+..  index:: config; extTarget
+..  _setup-config-exttarget:
 
 extTarget
 =========
@@ -992,8 +992,8 @@ extTarget
 
 
 
-.. index:: config; fileTarget
-.. _setup-config-filetarget:
+..  index:: config; fileTarget
+..  _setup-config-filetarget:
 
 fileTarget
 ==========
@@ -1011,8 +1011,8 @@ fileTarget
 
 
 
-.. index:: config; forceTypeValue
-.. _setup-config-forcetypevalue:
+..  index:: config; forceTypeValue
+..  _setup-config-forcetypevalue:
 
 forceTypeValue
 ==============
@@ -1035,8 +1035,8 @@ forceTypeValue
 
 
 
-.. index:: config; headerComment
-.. _setup-config-headercomment:
+..  index:: config; headerComment
+..  _setup-config-headercomment:
 
 headerComment
 =============
@@ -1056,8 +1056,8 @@ headerComment
 
 
 
-.. index:: config; htmlTag.attributes
-.. _setup-config-htmltag-attributes:
+..  index:: config; htmlTag.attributes
+..  _setup-config-htmltag-attributes:
 
 htmlTag.attributes
 ==================
@@ -1104,17 +1104,17 @@ htmlTag.attributes
             <html lang="fr" amp>
 
 
-.. warning::
+..  warning::
     If you are using :typoscript:`htmlTag.attributes` the property :ref:`setup-config-htmltag-setparams` will not have any effect.
 
-.. note::
+..  note::
     Please note that the `lang` attribute in these examples are auto-generated by
     :ref:`site handling<t3coreapi:sitehandling>`, depending on the value added there.
 
 
-.. index:: config; htmlTag_setParams
-.. _setup-config-htmltag-dir:
-.. _setup-config-htmltag-setparams:
+..  index:: config; htmlTag_setParams
+..  _setup-config-htmltag-dir:
+..  _setup-config-htmltag-setparams:
 
 htmlTag\_setParams
 ==================
@@ -1150,8 +1150,8 @@ htmlTag\_setParams
     `htmlTag_setParams` for language related configuration in TypoScript.
 
 
-.. index:: config; htmlTag_stdWrap
-.. _setup-config-htmltag-stdwrap:
+..  index:: config; htmlTag_stdWrap
+..  _setup-config-htmltag-stdwrap:
 
 htmlTag\_stdWrap
 ================
@@ -1170,8 +1170,8 @@ htmlTag\_stdWrap
 
 
 
-.. index:: config; index_descrLgd
-.. _setup-config-index-descrlgd:
+..  index:: config; index_descrLgd
+..  _setup-config-index-descrlgd:
 
 index\_descrLgd
 ===============
@@ -1193,8 +1193,8 @@ index\_descrLgd
 
 
 
-.. index:: config; index_enable
-.. _setup-config-index-enable:
+..  index:: config; index_enable
+..  _setup-config-index-enable:
 
 index\_enable
 =============
@@ -1214,8 +1214,8 @@ index\_enable
 
 
 
-.. index:: config; index_externals
-.. _setup-config-index-externals:
+..  index:: config; index_externals
+..  _setup-config-index-externals:
 
 index\_externals
 ================
@@ -1235,8 +1235,8 @@ index\_externals
 
 
 
-.. index:: config; index_metatags
-.. _setup-config-index-metatags:
+..  index:: config; index_metatags
+..  _setup-config-index-metatags:
 
 index\_metatags
 ===============
@@ -1258,8 +1258,8 @@ index\_metatags
 
 
 
-.. index:: config; inlineStyle2TempFile
-.. _setup-config-inlinestyle2tempfile:
+..  index:: config; inlineStyle2TempFile
+..  _setup-config-inlinestyle2tempfile:
 
 inlineStyle2TempFile
 ====================
@@ -1290,8 +1290,8 @@ inlineStyle2TempFile
 
 
 
-.. index:: config; intTarget
-.. _setup-config-inttarget:
+..  index:: config; intTarget
+..  _setup-config-inttarget:
 
 intTarget
 =========
@@ -1308,8 +1308,8 @@ intTarget
          Default internal target. Used by typolink if no target is set
 
 
-.. index:: config; linkVars
-.. _setup-config-linkvars:
+..  index:: config; linkVars
+..  _setup-config-linkvars:
 
 linkVars
 ========
@@ -1370,8 +1370,8 @@ linkVars
          `tracking[blue]` will not be kept.
 
 
-.. index:: config; message_preview
-.. _setup-config-message-preview:
+..  index:: config; message_preview
+..  _setup-config-message-preview:
 
 message\_preview
 ================
@@ -1390,8 +1390,8 @@ message\_preview
 
 
 
-.. index:: config; message_preview_workspace
-.. _setup-config-message-preview-workspace:
+..  index:: config; message_preview_workspace
+..  _setup-config-message-preview-workspace:
 
 message\_preview\_workspace
 ===========================
@@ -1417,7 +1417,7 @@ message\_preview\_workspace
             config.message_preview_workspace = <div class="previewbox">Displaying workspace number %2$s named "%1$s"!</div>
 
 
-.. _setup-config-metacharset:
+..  _setup-config-metacharset:
 
 metaCharset
 ===========
@@ -1453,8 +1453,8 @@ metaCharset
 
 
 
-.. index:: config; moveJsFromHeaderToFooter
-.. _setup-config-movejsfromheadertofooter:
+..  index:: config; moveJsFromHeaderToFooter
+..  _setup-config-movejsfromheadertofooter:
 
 moveJsFromHeaderToFooter
 ========================
@@ -1474,8 +1474,8 @@ moveJsFromHeaderToFooter
 
 
 
-.. index:: config; MP_defaults
-.. _setup-config-mp-defaults:
+..  index:: config; MP_defaults
+..  _setup-config-mp-defaults:
 
 MP\_defaults
 ============
@@ -1507,8 +1507,8 @@ MP\_defaults
 
 
 
-.. index:: config; MP_disableTypolinkClosestMPvalue
-.. _setup-config-mp-disabletypolinkclosestmpvalue:
+..  index:: config; MP_disableTypolinkClosestMPvalue
+..  _setup-config-mp-disabletypolinkclosestmpvalue:
 
 MP\_disableTypolinkClosestMPvalue
 =================================
@@ -1527,8 +1527,8 @@ MP\_disableTypolinkClosestMPvalue
 
 
 
-.. index:: config; MP_mapRootPoints
-.. _setup-config-mp-maprootpoints:
+..  index:: config; MP_mapRootPoints
+..  _setup-config-mp-maprootpoints:
 
 MP\_mapRootPoints
 =================
@@ -1561,8 +1561,8 @@ MP\_mapRootPoints
 
 
 
-.. index:: config; namespaces
-.. _setup-config-namespaces:
+..  index:: config; namespaces
+..  _setup-config-namespaces:
 
 namespaces
 ==========
@@ -1597,8 +1597,8 @@ namespaces
 
 
 
-.. index:: config; no_cache
-.. _setup-config-no-cache:
+..  index:: config; no_cache
+..  _setup-config-no-cache:
 
 no\_cache
 =========
@@ -1626,8 +1626,8 @@ no\_cache
 
 
 
-.. index:: config; noPageTitle
-.. _setup-config-nopagetitle:
+..  index:: config; noPageTitle
+..  _setup-config-nopagetitle:
 
 noPageTitle
 ===========
@@ -1653,8 +1653,8 @@ noPageTitle
          manually already.
 
 
-.. index:: config; pageRendererTemplateFile
-.. _setup-config-pagerenderertemplatefile:
+..  index:: config; pageRendererTemplateFile
+..  _setup-config-pagerenderertemplatefile:
 
 pageRendererTemplateFile
 ========================
@@ -1681,8 +1681,8 @@ pageRendererTemplateFile
             pageRendererTemplateFile = fileadmin/test_pagerender.html
 
 
-.. index:: config; pageTitle
-.. _setup-config-pagetitle:
+..  index:: config; pageTitle
+..  _setup-config-pagetitle:
 
 pageTitle
 =========
@@ -1701,8 +1701,8 @@ pageTitle
 
 
 
-.. index:: config; pageTitleFirst
-.. _setup-config-pagetitlefirst:
+..  index:: config; pageTitleFirst
+..  _setup-config-pagetitlefirst:
 
 pageTitleFirst
 ==============
@@ -1728,8 +1728,8 @@ pageTitleFirst
 
 
 
-.. index:: config; pageTitleProviders
-.. _setup-config-pagetitleproviders:
+..  index:: config; pageTitleProviders
+..  _setup-config-pagetitleproviders:
 
 pageTitleProviders
 ==================
@@ -1777,8 +1777,8 @@ pageTitleProviders
 
 
 
-.. index:: config; pageTitleSeparator
-.. _setup-config-pagetitleseparator:
+..  index:: config; pageTitleSeparator
+..  _setup-config-pagetitleseparator:
 
 pageTitleSeparator
 ==================
@@ -1840,8 +1840,8 @@ pageTitleSeparator
             }
 
 
-.. index:: config; removeDefaultCss
-.. _setup-config-removedefaultcss:
+..  index:: config; removeDefaultCss
+..  _setup-config-removedefaultcss:
 
 removeDefaultCss
 ================
@@ -1862,8 +1862,8 @@ removeDefaultCss
 
 
 
-.. index:: config; removeDefaultJS
-.. _setup-config-removedefaultjs:
+..  index:: config; removeDefaultJS
+..  _setup-config-removedefaultjs:
 
 removeDefaultJS
 ===============
@@ -1896,8 +1896,8 @@ removeDefaultJS
             config.removeDefaultJS = 1
 
 
-.. index:: config; removePageCss
-.. _setup-config-removepagecss:
+..  index:: config; removePageCss
+..  _setup-config-removepagecss:
 
 removePageCss
 =============
@@ -1920,8 +1920,8 @@ removePageCss
 
 
 
-.. index:: config; sendCacheHeaders
-.. _setup-config-sendcacheheaders:
+..  index:: config; sendCacheHeaders
+..  _setup-config-sendcacheheaders:
 
 sendCacheHeaders
 ================
@@ -1982,8 +1982,8 @@ sendCacheHeaders
 
 
 
-.. index:: config; endCacheHeaders_onlyWhenLoginDeniedInBranch
-.. _setup-config-sendcacheheaders-onlywhenlogindeniedinbranch:
+..  index:: config; endCacheHeaders_onlyWhenLoginDeniedInBranch
+..  _setup-config-sendcacheheaders-onlywhenlogindeniedinbranch:
 
 sendCacheHeaders\_onlyWhenLoginDeniedInBranch
 =============================================
@@ -2023,8 +2023,8 @@ sendCacheHeaders\_onlyWhenLoginDeniedInBranch
 
 
 
-.. index:: config; spamProtectEmailAddresses
-.. _setup-config-spamprotectemailaddresses:
+..  index:: config; spamProtectEmailAddresses
+..  _setup-config-spamprotectemailaddresses:
 
 spamProtectEmailAddresses
 =========================
@@ -2055,8 +2055,8 @@ spamProtectEmailAddresses
          It is required to enable the default JavaScript and not disable it. (see :ref:`removeDefaultJS <setup-config-removedefaultjs>`)
 
 
-.. index:: config; spamProtectEmailAddresses_atSubst
-.. _setup-config-spamprotectemailaddresses-atsubst:
+..  index:: config; spamProtectEmailAddresses_atSubst
+..  _setup-config-spamprotectemailaddresses-atsubst:
 
 spamProtectEmailAddresses\_atSubst
 ==================================
@@ -2076,8 +2076,8 @@ spamProtectEmailAddresses\_atSubst
          Substitute label for the at-sign (@).
 
 
-.. index:: config; spamProtectEmailAddresses_lastDotSubst
-.. _setup-config-spamprotectemailaddresses-lastdotsubst:
+..  index:: config; spamProtectEmailAddresses_lastDotSubst
+..  _setup-config-spamprotectemailaddresses-lastdotsubst:
 
 spamProtectEmailAddresses\_lastDotSubst
 =======================================
@@ -2101,8 +2101,8 @@ spamProtectEmailAddresses\_lastDotSubst
 
 
 
-.. index:: config; sword_noMixedCase
-.. _setup-config-sword-nomixedcase:
+..  index:: config; sword_noMixedCase
+..  _setup-config-sword-nomixedcase:
 
 sword\_noMixedCase
 ==================
@@ -2159,8 +2159,8 @@ sword\_standAlone
 
 
 
-.. index:: config; Extension configuration
-.. _setup-config-tx-extension-key-with-no-underscores:
+..  index:: config; Extension configuration
+..  _setup-config-tx-extension-key-with-no-underscores:
 
 tx\_[extension key with no underscores]\_[\*]
 =============================================
@@ -2189,8 +2189,8 @@ tx\_[extension key with no underscores]\_[\*]
 
 
 
-.. index:: config; typolinkLinkAccessRestrictedPages
-.. _setup-config-typolinklinkaccessrestrictedpages:
+..  index:: config; typolinkLinkAccessRestrictedPages
+..  _setup-config-typolinklinkaccessrestrictedpages:
 
 typolinkLinkAccessRestrictedPages
 =================================
@@ -2229,8 +2229,8 @@ typolinkLinkAccessRestrictedPages
 
 
 
-.. index:: config; typolinkLinkAccessRestrictedPages_addParams
-.. _setup-config-typolinklinkaccessrestrictedpages-addparams:
+..  index:: config; typolinkLinkAccessRestrictedPages_addParams
+..  _setup-config-typolinklinkaccessrestrictedpages-addparams:
 
 typolinkLinkAccessRestrictedPages\_addParams
 ============================================
@@ -2248,8 +2248,8 @@ typolinkLinkAccessRestrictedPages\_addParams
 
 
 
-.. index:: config; xhtmlDoctype
-.. _setup-config-xhtmldoctype:
+..  index:: config; xhtmlDoctype
+..  _setup-config-xhtmldoctype:
 
 xhtmlDoctype
 ============
@@ -2294,8 +2294,8 @@ xhtmlDoctype
 
 
 
-.. index:: config; xmlprologue
-.. _setup-config-xmlprologue:
+..  index:: config; xmlprologue
+..  _setup-config-xmlprologue:
 
 xmlprologue
 ===========


### PR DESCRIPTION
The indentation of the "container" directives are not adjusted for now. In a follow-up they are converted to a "confval".

Releases: main, 12.4, 11.5