### PR TITLE
[BUGFIX] Remove some rendering warnings

### DIFF
--- a/Documentation/ContentObjects/Hmenu/Rootline.rst
+++ b/Documentation/ContentObjects/Hmenu/Rootline.rst
@@ -94,7 +94,7 @@ Properties
 
          Here the links to pages on level 3 will have :html:`target="page"`, while
          all other levels will have :html:`target="_top"` as defined for the
-         :ref:`TMENU <tmenu>` property :t3-menu-tmenu:`target`.
+         :ref:`TMENU <tmenu>` property :ref:`target <tmenu-target>`.
 
          .. code-block:: typoscript
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript

--- a/Documentation/Functions/Replacement.rst
+++ b/Documentation/Functions/Replacement.rst
@@ -88,7 +88,7 @@ useOptionSplitReplace
    :ref:`data-type-boolean` / :ref:`stdwrap`
 
 :aspect:`Description`
-   This property allows to use :ref:`objects-optionsplit` for the replace
+   This property allows to use :ref:`optionsplit` for the replace
    property. That way the replace property can be different depending on the
    occurrence of the string (first/middle/last part, ...). This works for
    both normal and regular expression replacements. For examples see below.
@@ -128,7 +128,7 @@ This returns: "There are an animal, an animal and an animal around the
 block! Yeah!".
 
 
-The following examples demonstrate the use of :ref:`objects-optionsplit`:
+The following examples demonstrate the use of :ref:`optionsplit`:
 
 
 .. code-block:: typoscript

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -115,7 +115,7 @@ cObjNum
    cObjNum
 
 :aspect:`Data type`
-   *cObjNum* + :ref:`objects-optionsplit` / :ref:`stdwrap`
+   *cObjNum* + :ref:`optionsplit` / :ref:`stdwrap`
 
 :aspect:`Description`
    This is a pointer the array of this object ("1,2,3,4"), that should
@@ -164,7 +164,7 @@ wrap
    wrap
 
 :aspect:`Data type`
-   wrap + :ref:`objects-optionsplit` / :ref:`stdwrap`
+   wrap + :ref:`optionsplit` / :ref:`stdwrap`
 
 :aspect:`Description`
    Defines a wrap for each item.

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -1568,7 +1568,7 @@ noTrimWrap
    Can be set to define an alternative special character. :typoscript:`stdWrap` is
    available. Default is "\|" - the vertical line. This sub-property is
    useful in cases when the default special character would be recognized
-   by :ref:`objects-optionsplit` (which takes precedence over :typoscript:`noTrimWrap`).
+   by :ref:`optionsplit` (which takes precedence over :typoscript:`noTrimWrap`).
 
 :aspect:`Example`
    .. code-block:: typoscript
@@ -1588,7 +1588,7 @@ noTrimWrap
          noTrimWrap.splitChar = ^
       }
 
-   :ref:`objects-optionsplit` will use the "\|\|" to have two subparts in
+   :ref:`optionsplit` will use the "\|\|" to have two subparts in
    the first part. In each subpart :typoscript:`noTrimWrap` will then use the "^" as
    special character.
 

--- a/Documentation/MenuObjects/Tmenu/Index.rst
+++ b/Documentation/MenuObjects/Tmenu/Index.rst
@@ -410,6 +410,8 @@ Basically this shows that
    pages and thereby have no children.
 
 
+.. _tmenu-target:
+
 target
 ------
 

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -40,7 +40,6 @@ t3-tlo-config = t3-tlo-config // t3-tlo-config // Top level object 'config'
 t3coreapi      = https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/
 # t3docteam      = https://docs.typo3.org/m/typo3/team-t3docteam/main/en-us/
 # t3editors      = https://docs.typo3.org/m/typo3/tutorial-editors/main/en-us/
-t3extbasebook  = https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/
 # t3extexample   = https://docs.typo3.org/m/typo3/guide-example-extension-manual/main/en-us/
 t3home         = https://docs.typo3.org/
 # t3install      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
@@ -52,7 +51,7 @@ t3tca          = https://docs.typo3.org/m/typo3/reference-tca/11.5/en-us/
 t3tsconfig     = https://docs.typo3.org/m/typo3/reference-tsconfig/11.5/en-us/
 # t3tsref        = https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/
 t3ts45         = https://docs.typo3.org/m/typo3/tutorial-typoscript-in-45-minutes/11.5/en-us/
-# t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/
+t3viewhelper   = https://docs.typo3.org/other/typo3/view-helper-reference/11.5/en-us/
 # t3upgrade      = https://docs.typo3.org/m/typo3/guide-installation/main/en-us/
 
 # TYPO3 system extensions

--- a/Documentation/Setup/Page/Examples.rst
+++ b/Documentation/Setup/Page/Examples.rst
@@ -96,6 +96,4 @@ header with `Content-type:application/json` has to be set:
       }
    }
 
-The built-in :php:`JsonView` can be used to create the content
-via Extbase. See :ref:`Using built-in JsonView
-<t3extbasebook:using-built-in-jsonview>`
+The built-in :php:`JsonView` can be used to create the content via Extbase.

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -1085,6 +1085,7 @@ shortcutIcon
       and next to the title of the page in the tab.
 
       Example:
+
       .. code-block:: typoscript
          :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -270,8 +270,7 @@ persistence.enableAutomaticCacheClearing
 
    Description
       **Only for Extbase plugins**.
-      Enables the automatic cache clearing when changing data sets (see also
-      :ref:`t3coreapi:extbase_caching_of_actions_and_records`).
+      Enables the automatic cache clearing when changing data sets.
 
 
    Example

--- a/Documentation/UsingSetting/Debugging.rst
+++ b/Documentation/UsingSetting/Debugging.rst
@@ -77,4 +77,4 @@ TypoScript itself offers a number of debug functions:
 - :ref:`TMENU <tmenu>` comes with the property
   :ref:`debugItemConf <menu-common-properties>`.
   If set to :typoscript:`1`, it outputs the configuration arrays for each menu item.
-  Useful to debug :ref:`optionSplit <objects-optionsplit>` things and such.
+  Useful to debug :ref:`optionSplit <optionsplit>` things and such.


### PR DESCRIPTION
WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://docs.typo3.org/m/typo3/book-extbasefluid/11.5/en-us/objects.inv

./Documentation/ContentObjects/Hmenu/Rootline.rst:95: ERROR: Unknown interpreted text role "t3-menu-tmenu".

./Documentation/ContentObjects/Fluidtemplate/Index.rst:33: WARNING: undefined label: t3viewhelper:cobject_data
./Documentation/ContentObjects/Fluidtemplate/Index.rst:46: WARNING: undefined label: t3viewhelper:typo3fluid-fluid-debug
./Documentation/ContentObjects/Fluidtemplate/Index.rst:114: WARNING: undefined label: t3viewhelper:typo3-fluid-translate
./Documentation/ContentObjects/Fluidtemplate/Index.rst:114: WARNING: undefined label: t3viewhelper:typo3-fluid-uri-resource

./Documentation/Functions/Replacement.rst:91: WARNING: undefined label: objects-optionsplit
./Documentation/Functions/Replacement.rst:131: WARNING: undefined label: objects-optionsplit
./Documentation/Functions/Split.rst:118: WARNING: undefined label: objects-optionsplit
./Documentation/Functions/Split.rst:167: WARNING: undefined label: objects-optionsplit
./Documentation/Functions/Stdwrap.rst:1568: WARNING: undefined label: objects-optionsplit
./Documentation/Functions/Stdwrap.rst:1591: WARNING: undefined label: objects-optionsplit

./Documentation/Setup/Page/Index.rst:1089: ERROR: Unexpected indentation.

./Documentation/Setup/Page/Examples.rst:99: WARNING: undefined label: t3extbasebook:using-built-in-jsonview
./Documentation/TopLevelObjects/Plugin.rst:272: WARNING: undefined label: t3coreapi:extbase_caching_of_actions_and_records

Releases: 11.5