### PR TITLE
[BUGFIX] #102891 - Use traverse for request.getParsedBody()

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -929,7 +929,7 @@ request.getParsedBody()
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-        [request && request.getParsedBody()['foo'] == 1]
+        [request && traverse(request.getParsedBody(), 'foo') == 1]
 
 
 ..  index:: Conditions; request.getHeaders()


### PR DESCRIPTION
Related: https://forge.typo3.org/issues/102891
Releases: main, 12.4, 11.5