### PR TITLE
[TASK] Replace "t3-function-numberformat" with "confval"

### DIFF
--- a/Documentation/Functions/Numberformat.rst
+++ b/Documentation/Functions/Numberformat.rst
@@ -26,10 +26,12 @@ for that function. Consult the PHP manual, if unsure.
 Properties
 ==========
 
+..  _numberformat-decimals:
+
 decimals
 --------
 
-..  t3-function-numberformat:: decimals
+..  confval:: decimals
 
     :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
@@ -39,20 +41,26 @@ decimals
 
     Your input will in that case be rounded up or down to the next integer.
 
+
+..  _numberformat-dec-point:
+
 dec\_point
 ----------
 
-..  t3-function-numberformat:: dec_point
+..  confval:: dec_point
 
     :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: .
 
     Character that divides the decimals from the rest of the number.
 
+
+..  _numberformat-thousands-sep:
+
 thousands\_sep
 --------------
 
-..  t3-function-numberformat:: thousands_sep
+..  confval:: thousands_sep
 
     :Data type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: ,
@@ -60,7 +68,7 @@ thousands\_sep
     Character that divides the thousands of the number.
     Set an empty value to have no thousands separator.
 
-.. _numberformat-examples:
+..  _numberformat-examples:
 
 Examples
 ========

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -25,7 +25,6 @@ use_opensearch       =
 
 [sphinx_object_types_to_add]
 
-t3-function-numberformat = t3-function-numberformat // t3-function-numberformat // Function numberformat
 t3-function-numrows = t3-function-numrows // t3-function-numrows // Function numRows
 t3-function-parsefunc = t3-function-parsefunc // t3-function-parsefunc // Function parseFunc
 t3-function-replacement = t3-function-replacement // t3-function-replacement // Function replacement


### PR DESCRIPTION
This is a preparation for switching to PHP-based documentation rendering.

Additionally:
- Anchors are added

Releases: main, 12.4