### PR TITLE
[BUGFIX] Correct reference to backend layout chapter in TYPO3 Explained

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -147,7 +147,7 @@ tree.pagelayout
 
     :Data type: Integer / String
 
-    Check for the defined :ref:`backend layout <be-layout>` of a page, including
+    Check for the defined :ref:`backend layout <t3coreapi:be-layout>` of a page, including
     the inheritance of the field `Backend Layout (subpages of this page)`.
 
     Example:


### PR DESCRIPTION
Sphinx is in this case lax and looks, if there is a reference of that name in all of the intersphinxes. But guides is more strict and throws a warning. Therefore, the reference is now prefixed with the correct manual.

Releases: main, 12.4, 11.5