### PR TITLE
[BUGFIX] Correct reference to TYPO3_CONF_VARS['SYS'] chapter in TYPO3 Explained

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -803,7 +803,7 @@ feature()
     :Data type: String
 
     Provides access to the current state of
-    :ref:`feature toggles <typo3ConfVars_sys_features>`.
+    :ref:`feature toggles <t3coreapi:typo3ConfVars_sys_features>`.
 
     Example:
 


### PR DESCRIPTION
Sphinx is here lax and looks, if there is a reference of that name in all of the intersphinxes. But guides is more picky and throws a warning. Therefore, the reference is now prefixed with the correct manual.

Releases: main, 12.4, 11.5