### PR TITLE
[BUGFIX] Correct more references

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
@@ -39,7 +39,7 @@ Options
     (value).
 
     Each FlexForm field, which should be resolved, needs a reference definition
-    to the :ref:`foreign_match_fields <columns-inline-properties-foreign-match-fields>`.
+    to the :ref:`foreign_match_fields <t3tca:columns-inline-properties-foreign-match-fields>`.
     This reference is used in the :ref:`FilesProcessor <FilesProcessor>` to
     resolve the correct :ref:`FAL <t3coreapi:fal>` resource.
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -13,7 +13,7 @@ defined with TypoScript - often it is used in
 combination with the Fluid templating engine.
 
 This document is a **reference**, used to lookup TypoScript templating
-:ref:`basic data types <data-types>`, :ref:`object types <cobjects>`,
+:ref:`basic data types <data-types>`, :ref:`object types <cobject>`,
 :ref:`functions <functions>` and :ref:`conditions <conditions>`. This
 reference is not intended to give you a full introduction into the topic
 TypoScript.

--- a/Documentation/TopLevelObjects/Module.rst
+++ b/Documentation/TopLevelObjects/Module.rst
@@ -16,7 +16,7 @@ for all backend modules of that extension.
 Even though we are in the backend context here we use TypoScript setup. The
 settings should be done globally and not changed on a per-page basis.
 Therefore they are usually done in the file
-:ref:`EXT:my_extension/ext_typoscript_setup.typoscript <ext_typoscript_setup_typoscript>`.
+:ref:`EXT:my_extension/ext_typoscript_setup.typoscript <t3coreapi:ext_typoscript_setup_typoscript>`.
 
 
 Options for simple backend modules


### PR DESCRIPTION
Sphinx is here lax and looks, if there is a reference of that name in all of the intersphinxes. But guides is more picky and throws a warning. Therefore, the reference is now prefixed with the correct manual.

Releases: main, 12.4, 11.5