### PR TITLE
[BUGFIX] Correct more references (#1107)

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -13,7 +13,7 @@ defined with TypoScript - often it is used in
 combination with the Fluid templating engine.
 
 This document is a **reference**, used to lookup TypoScript templating
-:ref:`basic data types <data-types>`, :ref:`object types <cobjects>`,
+:ref:`basic data types <data-types>`, :ref:`object types <cobject>`,
 :ref:`functions <functions>` and :ref:`conditions <conditions>`. This
 reference is not intended to give you a full introduction into the topic
 TypoScript.
@@ -48,8 +48,6 @@ Please read the following for an introduction:
 * :ref:`TypoScript Syntax <t3coreapi:typoscript-syntax-start>`
   chapter in "TYPO3 Explained" for an introduction to the TypoScript
   syntax
-* :ref:`t3start:Templating` in the "Getting Started Tutorial" for an
-  introduction into templating in general.
 * :doc:`t3ts45:Index` for an introduction to TypoScript Templating
 * The chapter :ref:`using-and-setting` describes how to use, set
   and extend TypoScript.

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -193,7 +193,7 @@ admPanel
 
          **Note:** In addition, the panel must be enabled for the user as well,
          using the TSconfig for the user. See the :ref:`TSconfig
-         reference <t3tsconfig:useradmpanel>` for more information.
+         reference <ext_adminpanel:typoscript-config-admpanel>` for more information.
 
 
 

--- a/Documentation/TopLevelObjects/Module.rst
+++ b/Documentation/TopLevelObjects/Module.rst
@@ -16,7 +16,7 @@ for all backend modules of that extension.
 Even though we are in the backend context here we use TypoScript setup. The
 settings should be done globally and not changed on a per-page basis.
 Therefore they are usually done in the file
-:ref:`EXT:my_extension/ext_typoscript_setup.typoscript <ext_typoscript_setup_typoscript>`.
+:ref:`EXT:my_extension/ext_typoscript_setup.typoscript <t3coreapi:ext_typoscript_setup_typoscript>`.
 
 
 Options for simple backend modules


### PR DESCRIPTION
Sphinx is here lax and looks, if there is a reference of that name in all of the intersphinxes. But guides is more picky and throws a warning. Therefore, the reference is now prefixed with the correct manual.

Additionally, the reference to "t3start:Templating" has been removed as this reference is not available anymore and also not used in newer versions of this manual.

Releases: main, 12.4, 11.5