### PR TITLE
[Backport 11.5] [BUGFIX] Remove noopener as superfluous (#1113)

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -303,7 +303,7 @@ parameter
    contain spaces must be enclosed in double quotes. Each of these values
    are described in more detail below.
 
-   Link targets that are external or contain `_blank` will be added :html:`rel="noopener noreferrer"` automatically.
+   Link targets that are external or contain `_blank` will be added :html:`rel="noreferrer"` automatically.
 
 :aspect:`Resource reference`
    1. The link


### PR DESCRIPTION
Initially this feature added `rel="noopener noreferrer`. However `noreferrer` also implies the property `noopener`. Therefore, the later was removed.

Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/867
Releases: main, 12.4, 11.5