### PR TITLE
[BUGFIX] Correct outdated reference to typolink/forceAbsoluteUrl

### DIFF
--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -935,7 +935,7 @@ forceAbsoluteUrls
 ..  note::
     Setting this option will override any setting in :ref:`config.absRefPrefix
     <setup-config-absrefprefix>` and any typolink
-    :t3-function-typolink:`forceAbsoluteUrl` options.
+    :ref:`typolink-forceAbsoluteUrl` options.
 
 
 ..  index:: config; forceTypeValue


### PR DESCRIPTION
Releases: main, 12.4