### PR TITLE
[BUGFIX] Correct example about parseFunc.short

### DIFF
--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -136,7 +136,7 @@ short
 
         page.10 = TEXT
         page.10.value = Learn more about ###T3###, look here: ###T3web###
-        page.10.userFunc.short {
+        page.10.parseFunc.short {
               T3 = TYPO3 CMS
               T3web = <a href="https://typo3.org">typo3.org</a>
         }


### PR DESCRIPTION
Releases: main, 12.4, 11.5