### PR TITLE
[TASK] Add ddev directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ ehthumbs.db
 composer.lock
 nbproject
 Thumbs.db
+/.ddev/
+!/.ddev/config.yaml


### PR DESCRIPTION
Most recent versions of ddev seem to not create their own gitignore anymore

releases: main, 12.4, 11.5