### PR TITLE
Removed unnecessary new line

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -384,7 +384,6 @@ templateName
     This name is used together with the set format to find the template in the
     given templateRootPaths. Use this property to define a content object, which
     should be used as template file. It is an alternative to :typoscript:`.file`. If
-
     `.templateName` is set, it takes precedence.
 
     **Example 1:**


### PR DESCRIPTION
This removes a blank line which caused a wrong output in the documentation. Without this blank line the text should not go into a new block.