### PR TITLE
[TASK] Restrict depth of TOC in data chapter

### DIFF
--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -53,6 +53,7 @@ Properties
 
 ..  contents::
     :local:
+    :depth: 2
 
 ..  _data-type-gettext-applicationcontext:
 


### PR DESCRIPTION
This removes the "Example:" headings from the TOC for better readability of the data keys. This also shortens the menu.

Releases: main, 12.4, 11.5