### PR TITLE
Update Index.rst

### DIFF
--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -612,7 +612,8 @@ includeJS.[array]
         It is automatically set to `anonymous` for external JavaScript files if an
         :typoscript:`.integrity` is set.
 
-    `defer` Allows to set the HTML5 attribute :html:`defer`.
+    `defer`
+        Allows to set the HTML5 attribute :html:`defer`.
 
     `disableCompression`
         If :typoscript:`config.compressJs` is enabled,


### PR DESCRIPTION
Use the same Markup syntax for "defer" property in `includeJS` paragraph as for other option flags. Previously it was easily overlooked, because the "defer" option was not printed bold and its description was not in a newline below the bold text.