### PR TITLE
[TASK] unify confvals

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -45,8 +45,7 @@ applicationContext
 
 ..  confval:: applicationContext
     :name: condition-applicationContext
-
-    :Data type: String
+    :type: String
 
     The current application context as a string.
     See :ref:`t3coreapi:bootstrapping-context`.
@@ -75,8 +74,7 @@ page
 
 ..  confval:: page
     :name: condition-page
-
-    :Data type: Array
+    :type: Array
 
     All data of the current page record as array.
 
@@ -127,8 +125,7 @@ tree
 
 ..  confval:: tree
     :name: condition-tree
-
-    :Data type: Object
+    :type: Object
 
     Object with tree information.
 
@@ -145,8 +142,7 @@ tree.level
 
 ..  confval:: tree.level
     :name: condition-tree-level
-
-    :Data type: Integer
+    :type: Integer
 
     The current tree level.
 
@@ -169,8 +165,7 @@ tree.pagelayout
 
 ..  confval:: tree.pagelayout
     :name: condition-tree-pagelayout
-
-    :Data type: Integer / String
+    :type: Integer / String
 
     Check for the defined :ref:`backend layout <t3coreapi:be-layout>` of a page, including
     the inheritance of the field `Backend Layout (subpages of this page)`.
@@ -200,8 +195,7 @@ tree.rootLine
 
 ..  confval:: tree.rootLine
     :name: condition-tree-rootLine
-
-    :Data type: Array
+    :type: Array
 
     Array of arrays with UID and PID.
 
@@ -225,8 +219,7 @@ tree.rootLineIds
 
 ..  confval:: tree.rootLineIds
     :name: condition-tree-rootLineIds
-
-    :Data type: Array
+    :type: Array
 
     An array with UIDs of the root line.
 
@@ -251,8 +244,7 @@ tree.rootLineParentIds
 
 ..  confval:: tree.rootLineParentIds
     :name: condition-tree-rootLineParentIds
-
-    :Data type: Array
+    :type: Array
 
     An array with parent UIDs of the root line.
 
@@ -275,8 +267,7 @@ backend
 
 ..  confval:: backend
     :name: condition-backend
-
-    :Data type: Object
+    :type: Object
 
     Object with backend information.
 
@@ -289,8 +280,7 @@ backend.user
 
 ..  confval:: backend.user
     :name: condition-backend-user
-
-    :Data type: Object
+    :type: Object
 
     Object with current backend user information.
 
@@ -305,8 +295,7 @@ backend.user.isAdmin
 
 ..  confval:: backend.user.isAdmin
     :name: condition-backend-user-isAdmin
-
-    :Data type: Boolean
+    :type: Boolean
 
     True, if the current backend user is administrator.
 
@@ -329,8 +318,7 @@ backend.user.isLoggedIn
 
 ..  confval:: backend.user.isLoggedIn
     :name: condition-backend-user-isLoggedIn
-
-    :Data type: Boolean
+    :type: Boolean
 
     True, if the current backend user is logged in.
 
@@ -353,8 +341,7 @@ backend.user.userId
 
 ..  confval:: backend.user.userId
     :name: condition-backend-user-userId
-
-    :Data type: Integer
+    :type: Integer
 
     UID of the the current backend user.
 
@@ -378,8 +365,7 @@ backend.user.userGroupIds
 
 ..  confval:: backend.user.userGroupIds
     :name: condition-backend-user-userGroupIds
-
-    :Data type: Array
+    :type: Array
     :Context: Frontend, backend
 
     Array of user group IDs assigned to the current backend user.
@@ -402,8 +388,7 @@ backend.user.userGroupList
 
 ..  confval:: backend.user.userGroupList
     :name: condition-backend-user-userGroupList
-
-    :Data type: String
+    :type: String
 
     Comma-separated list of group UIDs.
 
@@ -425,8 +410,7 @@ frontend
 
 ..  confval:: frontend
     :name: condition-frontend
-
-    :Data type: Object
+    :type: Object
 
     Object with frontend information.
 
@@ -439,8 +423,7 @@ frontend.user
 
 ..  confval:: frontend.user
     :name: condition-frontend-user
-
-    :Data type: Object
+    :type: Object
 
     Object with current frontend user information.
 
@@ -453,8 +436,7 @@ frontend.user.isLoggedIn
 
 ..  confval:: frontend.user.isLoggedIn
     :name: condition-frontend-user-isLoggedIn
-
-    :Data type: Boolean
+    :type: Boolean
 
     True, if the current frontend user is logged in.
 
@@ -476,8 +458,7 @@ frontend.user.userId
 
 ..  confval:: frontend.user.userId
     :name: condition-frontend-user-userId
-
-    :Data type: Integer
+    :type: Integer
 
     The UID of the current frontend user.
 
@@ -499,8 +480,7 @@ frontend.user.userGroupIds
 
 ..  confval:: frontend.user.userGroupIds
     :name: condition-frontend-user-userGroupIds
-
-    :Data type: Array
+    :type: Array
     :Context: Frontend
 
     Array of user group IDs of the current frontend user.
@@ -523,8 +503,7 @@ frontend.user.userGroupList
 
 ..  confval:: frontend.user.userGroupList
     :name: condition-frontend-user-userGroupList
-
-    :Data type: String
+    :type: String
 
     Comma-separated list of group UIDs.
 
@@ -546,8 +525,7 @@ workspace
 
 ..  confval:: workspace
     :name: condition-workspace
-
-    :Data type: Object
+    :type: Object
 
     Object with :ref:`workspace <t3coreapi:workspaces>` information.
 
@@ -560,8 +538,7 @@ workspace.workspaceId
 
 ..  confval:: workspace.workspaceId
     :name: condition-workspace-workspaceId
-
-    :Data type: Integer
+    :type: Integer
 
     UID of the current workspace.
 
@@ -584,8 +561,7 @@ workspace.isLive
 
 ..  confval:: workspace.isLive
     :name: condition-workspace-isLive
-
-    :Data type: Boolean
+    :type: Boolean
 
     True, if the current workspace is the live workspace.
 
@@ -607,8 +583,7 @@ workspace.isOffline
 
 ..  confval:: workspace.isOffline
     :name: condition-workspace-isOffline
-
-    :Data type: Boolean
+    :type: Boolean
 
     True, if the current workspace is offline.
 
@@ -630,8 +605,7 @@ typo3
 
 ..  confval:: typo3
     :name: condition-typo3
-
-    :Data type: Object
+    :type: Object
 
     Object with TYPO3-related information.
 
@@ -644,8 +618,7 @@ typo3.version
 
 ..  confval:: typo3.version
     :name: condition-typo3-version
-
-    :Data type: String
+    :type: String
 
     TYPO3_version (for example, 12.4.5)
 
@@ -667,8 +640,7 @@ typo3.branch
 
 ..  confval:: typo3.branch
     :name: condition-typo3-branch
-
-    :Data type: String
+    :type: String
 
     TYPO3 branch (for example, 12.4)
 
@@ -690,8 +662,7 @@ typo3.devIpMask
 
 ..  confval:: typo3.devIpMask
     :name: condition-typo3-devIpMask
-
-    :Data type: String
+    :type: String
 
     :ref:`$GLOBALS['TYPO3_CONF_VARS']['SYS']['devIPmask'] <t3coreapi:typo3ConfVars_sys_devIPmask>`
 
@@ -715,7 +686,7 @@ date()
     :name: condition-date
 
     :Parameter: String
-    :Data type: String | Integer
+    :type: String | Integer
 
     Get the current date in the given format. See the PHP `date function`_
     as a reference for the possible usage.
@@ -758,7 +729,7 @@ like()
     :name: condition-like
 
     :Parameter: String, String
-    :Data type: Boolean
+    :type: Boolean
 
     This function has two parameters: The first parameter is the string to
     search in, the second parameter is the search string.
@@ -794,7 +765,7 @@ traverse()
     :name: condition-traverse
 
     :Parameter: Array, String
-    :Data type: Mixed
+    :type: Mixed
 
     This function gets a value from an array with arbitrary depth and suppresses
     a PHP warning when sub-arrays do not exist. It has two parameters: The first
@@ -831,7 +802,7 @@ compatVersion()
     :name: condition-compatVersion
 
     :Parameter: String
-    :Data type: Boolean
+    :type: Boolean
 
     Compares against the current TYPO3 branch.
 
@@ -859,8 +830,7 @@ getTSFE()
 
 ..  confval:: getTSFE()
     :name: condition-getTSFE
-
-    :Data type: Object
+    :type: Object
 
     Provides access to :ref:`TypoScriptFrontendController <t3coreapi:tsfe>`
     :php:`$GLOBALS['TSFE']`. This function can directly access methods of
@@ -892,8 +862,7 @@ getenv()
 
 ..  confval:: getenv()
     :name: condition-getenv
-
-    :Data type: String
+    :type: String
 
     PHP function `getenv <https://www.php.net/manual/en/function.getenv.php>`_.
 
@@ -915,8 +884,7 @@ feature()
 
 ..  confval:: feature()
     :name: condition-feature
-
-    :Data type: String
+    :type: String
 
     Provides access to the current state of
     :ref:`feature toggles <t3coreapi:typo3ConfVars_sys_features>`.
@@ -947,7 +915,7 @@ ip()
     :name: condition-ip
 
     :Parameter: String
-    :Data type: Boolean
+    :type: Boolean
 
     Value or constraint, wildcard or regular expression possible; special value:
     "devIP" (matches the :ref:`devIPmask <t3coreapi:typo3ConfVars_sys_devIPmask>`).
@@ -980,8 +948,7 @@ request()
 
 ..  confval:: request()
     :name: condition-request
-
-    :Data type: Mixed
+    :type: Mixed
 
     Allows to fetch information from current request.
 
@@ -1003,8 +970,7 @@ request.getQueryParams()
 
 ..  confval:: request.getQueryParams()
     :name: condition-request-getQueryParams
-
-    :Data type: Array
+    :type: Array
 
     Allows to access GET parameters from current request.
 
@@ -1042,8 +1008,7 @@ request.getParsedBody()
 
 ..  confval:: request.getParsedBody()
     :name: condition-request-getParsedBody
-
-    :Data type: Array
+    :type: Array
 
     Provide all values contained in the request body, for example, in case of
     submitted form via POST, the submitted values.
@@ -1066,8 +1031,7 @@ request.getHeaders()
 
 ..  confval:: request.getHeaders()
     :name: condition-request-getHeaders
-
-    :Data type: Array
+    :type: Array
 
     Provide all values from request headers.
 
@@ -1093,8 +1057,7 @@ request.getCookieParams()
 
 ..  confval:: request.getCookieParams()
     :name: condition-request-getCookieParams
-
-    :Data type: Array
+    :type: Array
 
     Provides available cookies.
 
@@ -1116,8 +1079,7 @@ request.getNormalizedParams()
 
 ..  confval:: request.getNormalizedParams()
     :name: condition-request-getNormalizedParams
-
-    :Data type: Array
+    :type: Array
 
     Provides access to the :php:`\TYPO3\CMS\Core\Http\NormalizedParams` object.
     Have a look at the
@@ -1147,8 +1109,7 @@ request.getPageArguments()
 
 ..  confval:: request.getPageArguments()
     :name: condition-request-getPageArguments
-
-    :Data type: Object
+    :type: Object
 
     Get the current :php:`\TYPO3\CMS\Core\Routing\PageArguments` object with
     the resolved route parts from enhancers.
@@ -1177,7 +1138,7 @@ session()
     :name: condition-session
 
     :Parameter: String
-    :Data type: Mixed
+    :type: Mixed
 
     Allows to access values of the current session. Available values depend on
     values written to the session, for example, by extensions. Use
@@ -1204,7 +1165,7 @@ site()
     :name: condition-site
 
     :Parameter: String
-    :Data type: Mixed
+    :type: Mixed
 
     Get a value from the :ref:`site configuration <t3coreapi:sitehandling>`, or
     null, if no site was found or the property does not exists.
@@ -1279,7 +1240,7 @@ siteLanguage()
     :name: condition-siteLanguage
 
     :Parameter: String
-    :Data type: Mixed
+    :type: Mixed
 
     Get a value from the
     :ref:`site language configuration <t3coreapi:sitehandling-addingLanguages>`,

--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -41,8 +41,7 @@ Properties
 
 ..  confval:: array of cObjects
     :name: case-array
-
-    :Data type: :ref:`cObject <data-type-cobject>`
+    :type: :ref:`cObject <data-type-cobject>`
 
     Array of cObjects. Use this to define cObjects for the different
     values of :ref:`cobj-case-key`. If :ref:`cobj-case-key` has a certain value,
@@ -56,8 +55,7 @@ cache
 
 ..  confval:: cache
     :name: case-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
@@ -69,8 +67,7 @@ default
 
 ..  confval:: default
     :name: case-default
-
-    :Data type: :ref:`cObject <data-type-cobject>`
+    :type: :ref:`cObject <data-type-cobject>`
 
      Use this to define the rendering for *those* values of :ref:`cobj-case-key` that
      do *not* match any of the values of the :ref:`cobj-case-array-of-cObjects`. If no
@@ -85,8 +82,7 @@ if
 
 ..  confval:: if
     :name: case-if
-
-    :Data type: :ref:`->if <if>`
+    :type: :ref:`->if <if>`
 
     If :ref:`if <if>` returns false, nothing is returned.
 
@@ -98,8 +94,7 @@ key
 
 ..  confval:: key
     :name: case-key
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: default
 
     The key, which determines, which cObject will be rendered. Its
@@ -122,8 +117,7 @@ setCurrent
 
 ..  confval:: setCurrent
     :name: case-setCurrent
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Sets the "current" value.
 
@@ -135,8 +129,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: case-stdWrap
-
-    :Data type: :ref:`stdWrap <stdwrap>`
+    :type: :ref:`stdWrap <stdwrap>`
 
     :ref:`stdWrap` around any object that was rendered no matter what the
     :ref:`cobj-case-key` value is.

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -43,8 +43,7 @@ Properties
 
 ..  confval:: 1,2,3,4...
     :name: coa-array
-
-    :Data type: :ref:`cObject <data-type-cobject>`
+    :type: :ref:`cObject <data-type-cobject>`
 
     Numbered properties to define the different cObjects, which should be
     rendered.
@@ -57,8 +56,7 @@ cache
 
 ..  confval:: cache
     :name: coa-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
@@ -70,8 +68,7 @@ if
 
 ..  confval:: if
     :name: coa-if
-
-    :Data type: :ref:`->if <if>`
+    :type: :ref:`->if <if>`
 
     If `if` returns false, the COA is **not** rendered.
 
@@ -83,8 +80,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: coa-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
     Executed on all rendered cObjects after property :ref:`cobj-coa-wrap`.
 
@@ -96,8 +92,7 @@ wrap
 
 ..  confval:: wrap
     :name: coa-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
 
      Wraps all rendered cObjects. Executed before property :ref:`cobj-coa-stdWrap`.
 

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -38,8 +38,7 @@ select
 
 ..  confval:: select
     :name: content-select
-
-    :Data type: :ref:`select`
+    :type: :ref:`select`
 
     The SQL-statement, a :sql:`SELECT` query, is set here,
     including automatic visibility control.
@@ -52,8 +51,7 @@ table
 
 ..  confval:: table
     :name: content-table
-
-    :Data type:  *table name* / :ref:`stdwrap`
+    :type:  *table name* / :ref:`stdwrap`
 
     The table, the content should come from. Any table can be used;
     a check for a table prefix is not done.
@@ -68,8 +66,7 @@ renderObj
 
 ..  confval:: renderObj
     :name: content-renderObj
-
-    :Data type: :ref:`data-type-cObject`
+    :type: :ref:`data-type-cObject`
     :Default: :typoscript:`< [table name]`
 
     The cObject used for rendering the records resulting from the query in
@@ -90,8 +87,7 @@ slide
 
 ..  confval:: slide
     :name: content-slide
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
 
     If set and no content element is found by the select command, the
     rootLine will be traversed back until some content is found.
@@ -116,8 +112,7 @@ slide.collect
 
 ..  confval:: slide.collect
     :name: content-slide-collect
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
 
     If set, all content elements found on the current and parent pages will be
     collected. Otherwise, the sliding would stop after the first hit. Set this
@@ -132,8 +127,7 @@ slide.collectFuzzy
 
 ..  confval:: slide.collectFuzzy
     :name: content-slide-collectFuzzy
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Only useful with :ref:`slide.collect <cobj-content-slide-collect>`. If no content
     elements have been found for the specified depth in collect mode, traverse
@@ -147,8 +141,7 @@ slide.collectReverse
 
 ..  confval:: slide.collectReverse
     :name: content-slide-collectReverse
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Reverse order of elements in collect mode. If set, elements of the current
     page will be at the bottom.
@@ -161,8 +154,7 @@ wrap
 
 ..  confval:: wrap
     :name: content-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
     Wrap the whole content.
 
@@ -174,8 +166,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: content-stdWrap
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     Apply `stdWrap` functionality.
 
@@ -187,8 +178,7 @@ cache
 
 ..  confval:: cache
     :name: content-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 

--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -27,8 +27,7 @@ extensionName
 
 ..  confval:: extensionName
     :name: extbaseplugin-extensionName
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The :ref:`extension name <t3coreapi:extension-naming-extensionName>`.
 
@@ -40,8 +39,7 @@ pluginName
 
 ..  confval:: pluginName
     :name: extbaseplugin-pluginName
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The plugin name.
 

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -26,8 +26,7 @@ files
 
 ..  confval:: files
     :name: files-files
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Comma-separated list of sys_file UIDs, which are loaded
     into the FILES object.
@@ -47,8 +46,7 @@ references
 
 ..  confval:: references
     :name: files-references
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>` or array
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>` or array
 
     Provides a way to load files from a file field (of type
     IRRE with sys_file_reference as child table). You can either
@@ -96,8 +94,7 @@ collections
 
 ..  confval:: collections
     :name: files-collections
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Comma-separated list of :sql:`sys_file_collection` UIDs, which
     are loaded into the :typoscript:`FILES` object.
@@ -110,8 +107,7 @@ folders
 
 ..  confval:: folders
     :name: files-folders
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Comma-separated list of combined folder identifiers which
     are loaded into the FILES object.
@@ -157,8 +153,7 @@ sorting
 
 ..  confval:: sorting
     :name: files-sorting
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Name of the field, which should be used to sort the files.
 
@@ -170,8 +165,7 @@ sorting.direction
 
 ..  confval:: sorting.direction
     :name: files-sorting-direction
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: asc
 
     The direction, in which the
@@ -186,8 +180,7 @@ begin
 
 ..  confval:: begin
     :name: files-begin
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     The first item to return. If not set (default), items beginning
     with the first one are returned.
@@ -200,8 +193,7 @@ maxItems
 
 ..  confval:: maxItems
     :name: files-maxItems
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     Maximum number of items to return. If not set (default), all items
     are returned. If :ref:`cobj-files-begin` and :ref:`cobj-files-maxItems`
@@ -216,8 +208,7 @@ renderObj
 
 ..  confval:: renderObj
     :name: files-renderObj
-
-    :Data type: :ref:`cObject <data-type-cobject>` :ref:`+optionSplit <optionsplit>`
+    :type: :ref:`cObject <data-type-cobject>` :ref:`+optionSplit <optionsplit>`
 
     The cObject used for rendering the files. It is executed
     once for every file. Note that during each execution you can
@@ -245,8 +236,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: files-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
 
 .. index:: FILES; references
@@ -262,8 +252,7 @@ references.table
 
 ..  confval:: references.table
     :name: files-references-table
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     The table name of the table having the file field.
 
@@ -275,8 +264,7 @@ references.uid
 
 ..  confval:: references.uid
     :name: files-references-uid
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     The UID of the record from which to fetch the referenced files.
 
@@ -288,8 +276,7 @@ references.fieldName
 
 ..  confval:: references.fieldName
     :name: files-references-fieldName
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Field name of the file field in the table.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/CommaSeparatedValueProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/CommaSeparatedValueProcessor.rst
@@ -24,10 +24,9 @@ if
 
 ..  confval:: if
     :name: CommaSeparatedValueProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
-    :default: ''
+    :type: :ref:`if` condition
+    :Default: ''
 
     If the condition is met, the data processor is processed.
 
@@ -38,10 +37,9 @@ fieldName
 
 ..  confval:: fieldName
     :name: CommaSeparatedValueProcessor-fieldName
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ''
 
     Name of the field in the processed ContentObjectRenderer.
 
@@ -53,10 +51,9 @@ as
 
 ..  confval:: as
     :name: CommaSeparatedValueProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: defaults to the fieldName
+    :type: :ref:`data-type-string`
+    :Default: defaults to the fieldName
 
     The variable's name to be used in the Fluid template.
 
@@ -67,10 +64,9 @@ maximumColumns
 
 ..  confval:: maximumColumns
     :name: CommaSeparatedValueProcessor-maximumColumns
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: :typoscript:`0`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: :typoscript:`0`
 
     Maximal number of columns to be transformed. Surplus columns will be
     silently dropped. When set to :typoscript:`0` (default) all columns will be
@@ -84,10 +80,9 @@ fieldDelimiter
 
 ..  confval:: fieldDelimiter
     :name: CommaSeparatedValueProcessor-fieldDelimiter
-
     :Required:  false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: :typoscript:`,`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: :typoscript:`,`
 
     The field delimiter, a character separating the values.
 
@@ -99,10 +94,9 @@ fieldEnclosure
 
 ..  confval:: fieldEnclosure
     :name: CommaSeparatedValueProcessor-fieldEnclosure
-
     :Required:  false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: :typoscript:`"`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: :typoscript:`"`
 
     The field enclosure, a character surrounding the values.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/DatabaseQueryProcessor.rst
@@ -24,10 +24,9 @@ if
 
 ..  confval:: if
     :name: DatabaseQueryProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
-    :default: ''
+    :type: :ref:`if` condition
+    :Default: ''
 
     Only if the condition is met the data processor is executed.
 
@@ -39,10 +38,9 @@ table
 
 ..  confval:: table
     :name: DatabaseQueryProcessor-table
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ''
 
     Name of the table from which the records should be fetched.
 
@@ -53,10 +51,9 @@ as
 
 ..  confval:: as
     :name: DatabaseQueryProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: 'records'
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: 'records'
 
     The variable's name to be used in the Fluid template.
 
@@ -67,10 +64,9 @@ dataProcessing
 
 ..  confval:: dataProcessing
     :name: DatabaseQueryProcessor-dataProcessing
-
     :Required: false
-    :Data type: array of :ref:`dataProcessing`
-    :default: []
+    :type: array of :ref:`dataProcessing`
+    :Default: []
 
     Array of data processors to be applied to all fetched records.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FilesProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FilesProcessor.rst
@@ -27,10 +27,9 @@ if
 
 ..  confval:: if
     :name: FilesProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
-    :default: ''
+    :type: :ref:`if` condition
+    :Default: ''
 
     Only, if the condition is met the data processor is executed.
 
@@ -42,10 +41,9 @@ references
 
 ..  confval:: references
     :name: FilesProcessor-references
-
     :Required: false
-    :Data type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
+    :Default: ''
     :Example: '1,303,42'
 
     If this option contains a comma-separated list of integers, these are
@@ -64,10 +62,9 @@ references.fieldName
 
 ..  confval:: references.fieldName
     :name: FilesProcessor-references-fieldName
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ''
     :Example: 'media'
 
     If both :typoscript:`references.fieldName` and
@@ -83,10 +80,9 @@ references.table
 
 ..  confval:: references.table
     :name: FilesProcessor-references.table
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ''
     :Example: 'tt_content'
 
     If :typoscript:`references` should be interpreted as TypoScript
@@ -101,10 +97,9 @@ files
 
 ..  confval:: files
     :name: FilesProcessor-files
-
     :Required: false
-    :Data type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
+    :Default: ''
     :Example: '1,303,42'
 
     If this option contains a comma-separated list of integers,
@@ -118,10 +113,9 @@ collections
 
 ..  confval:: collections
     :name: FilesProcessor-collections
-
     :Required: false
-    :Data type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` (comma-separated integers) / :ref:`stdWrap`
+    :Default: ''
     :Example: '1,303,42'
 
     If this option contains a comma-separated list of integers,
@@ -136,10 +130,9 @@ folders
 
 ..  confval:: folders
     :name: FilesProcessor-folders
-
     :Required: false
-    :Data type: :ref:`data-type-string` (comma-separated folders), :ref:`stdWrap`
-    :default: ""
+    :type: :ref:`data-type-string` (comma-separated folders), :ref:`stdWrap`
+    :Default: ""
     :Example: "23:/other/folder/"
 
     Fetches all files from the referenced folders. The following syntax is
@@ -163,10 +156,9 @@ folders.recursive
 
 ..  confval:: folders.recursive
     :name: FilesProcessor-folders-recursive
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ""
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ""
     :Example: "1"
 
     If set to a non-empty value file, records will be added from folders
@@ -180,10 +172,9 @@ sorting
 
 ..  confval:: sorting
     :name: FilesProcessor-sorting
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ""
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ""
     :Example: "filesize"
 
     The property of the file records by which they should be sorted.
@@ -197,10 +188,9 @@ sorting.direction
 
 ..  confval:: sorting.direction
     :name: FilesProcessor-sorting-direction
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default:  "ascending"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default:  "ascending"
     :Example: "descending"
 
     The sorting direction (:typoscript:`ascending` or :typoscript:`descending`).
@@ -213,10 +203,9 @@ as
 
 ..  confval:: as
     :name: FilesProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: "files"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: "files"
 
     The variable name to be used in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/FlexFormProcessor.rst
@@ -23,10 +23,9 @@ fieldname
 
 ..  confval:: fieldname
     :name: FlexFormProcessor-fieldname
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: 'pi_flexform'
+    :type: :ref:`data-type-string`
+    :Default: 'pi_flexform'
 
     Field name of the column the FlexForm data is stored in.
 
@@ -40,9 +39,8 @@ references
     :name: FlexFormProcessor-references
 
     ..  versionadded:: 13.0
-
     :Required: false
-    :Data type: array
+    :type: array
 
     Associative array of FlexForm fields (key) and the according database field
     (value).
@@ -62,10 +60,9 @@ as
 
 ..  confval:: as
     :name: FlexFormProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: 'flexFormData'
+    :type: :ref:`data-type-string`
+    :Default: 'flexFormData'
 
     Name for the variable in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/GalleryProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/GalleryProcessor.rst
@@ -22,10 +22,9 @@ if
 
 ..  confval:: if
     :name: GalleryProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
-    :default: ''
+    :type: :ref:`if` condition
+    :Default: ''
 
     Only if the condition is met the data processor is executed.
 
@@ -37,10 +36,9 @@ filesProcessedDataKey
 
 ..  confval:: filesProcessedDataKey
     :name: GalleryProcessor-filesProcessedDataKey
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: 'files'
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: 'files'
     :Example: 'myImages'
 
     Key of the array previously processed by the :php:`FilesProcessor`.
@@ -53,10 +51,9 @@ numberOfColumns
 
 ..  confval:: numberOfColumns
     :name: GalleryProcessor-numberOfColumns
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: field:imagecols
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: field:imagecols
     :Example: 4
 
     Expects the desired number of columns. Defaults to the value of the field
@@ -70,10 +67,9 @@ mediaOrientation
 
 ..  confval:: mediaOrientation
     :name: GalleryProcessor-mediaOrientation
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: field:imageorient
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: field:imageorient
     :Example: 2
 
     Expects the image orientation as used in the field `imageorient` in content
@@ -91,10 +87,9 @@ maxGalleryWidth
 
 ..  confval:: maxGalleryWidth
     :name: GalleryProcessor-maxGalleryWidth
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 600
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 600
 
     Maximal gallery width in pixels.
 
@@ -106,10 +101,9 @@ maxGalleryWidthInText
 
 ..  confval:: maxGalleryWidthInText
     :name: GalleryProcessor-maxGalleryWidthInText
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 300
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 300
 
     Maximal gallery width in pixels if displayed in a text.
 
@@ -121,10 +115,9 @@ equalMediaHeight, equalMediaWidth
 
 ..  confval:: equalMediaHeight, equalMediaWidth
     :name: GalleryProcessor-equalMediaHeight
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: field:imageheight, field:imagewidth
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: field:imageheight, field:imagewidth
     :Example: 300
 
     If set all images get scaled to a uniform height / width. Defaults
@@ -142,10 +135,9 @@ columnSpacing
 
 ..  confval:: columnSpacing
     :name: GalleryProcessor-columnSpacing
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 0
     :Example: 4
 
     Space between columns in pixels
@@ -158,10 +150,9 @@ borderEnabled
 
 ..  confval:: borderEnabled
     :name: GalleryProcessor-borderEnabled
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: field:imageborder
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: field:imageborder
     :Example: 1
 
     Should there be a border around the images? Defaults to the value of the
@@ -175,10 +166,9 @@ borderWidth
 
 ..  confval:: borderWidth
     :name: GalleryProcessor-borderWidth
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 0
     :Example: 2
 
     Width of the border in pixels.
@@ -191,10 +181,9 @@ borderPadding
 
 ..  confval:: borderPadding
     :name: GalleryProcessor-borderPadding
-
     :Required: false
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 0
     :Example: 20
 
     Padding around the border in pixels.
@@ -207,10 +196,9 @@ cropVariant
 
 ..  confval:: cropVariant
     :name: GalleryProcessor-cropVariant
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: "default"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: "default"
     :Example: "mobile"
 
     See :ref:`crop variants in the TCA reference <t3tca:columns-imageManipulation-properties-cropVariants>`
@@ -223,10 +211,9 @@ as
 
 ..  confval:: as
     :name: GalleryProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: "files"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: "files"
 
     The variable name to be used in the Fluid template.
 
@@ -238,10 +225,9 @@ dataProcessing
 
 ..  confval:: dataProcessing
     :name: GalleryProcessor-dataProcessing
-
     :Required: false
-    :Data type: array of :ref:`dataProcessing`
-    :default: []
+    :type: array of :ref:`dataProcessing`
+    :Default: []
 
     Array of data processors to be applied to all fetched records.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/LanguageMenuProcessor.rst
@@ -30,9 +30,8 @@ if
 
 ..  confval:: if
     :name: LanguageMenuProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
+    :type: :ref:`if` condition
 
     Only if the condition is met the data processor is executed.
 
@@ -44,10 +43,9 @@ languages
 
 ..  confval:: languages
     :name: LanguageMenuProcessor-languages
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: "auto"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: "auto"
     :Example: "0,1,2"
 
     A list of comma-separated language IDs (e.g. 0,1,2) to use for the menu
@@ -62,10 +60,9 @@ addQueryString.exclude
 
 ..  confval:: addQueryString.exclude
     :name: LanguageMenuProcessor-addQueryString-exclude
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ""
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ""
     :Example: "gclid,contrast"
 
     A list of comma-separated parameter names to be excluded from the language
@@ -79,10 +76,9 @@ as
 
 ..  confval:: as
     :name: LanguageMenuProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: defaults to the fieldName
+    :type: :ref:`data-type-string`
+    :Default: defaults to the fieldName
 
     The variable name to be used in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/MenuProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/MenuProcessor.rst
@@ -33,10 +33,9 @@ levels
 
 ..  confval:: levels
     :name: MenuProcessor-levels
-
     :Required: true
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
-    :default: 1
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :Default: 1
     :Example: 5
 
     Maximal number of levels to be included in the output array.
@@ -49,10 +48,9 @@ expandAll
 
 ..  confval:: expandAll
     :name: MenuProcessor-expandAll
-
     :Required: true
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-    :default: 1
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :Default: 1
     :Example: 0
 
     Include all submenus (`1`) or only those of the active pages (`0`).
@@ -65,10 +63,9 @@ includeSpacer
 
 ..  confval:: includeSpacer
     :name: MenuProcessor-includeSpacer
-
     :Required: true
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :Default: 0
     :Example: 1
 
     Include pages with type "spacer".
@@ -81,10 +78,9 @@ titleField
 
 ..  confval:: titleField
     :name: MenuProcessor-titleField
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: "nav_title // title"
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: "nav_title // title"
     :Example: "subtitle"
 
     Fields to be used as title.
@@ -97,10 +93,9 @@ as
 
 ..  confval:: as
     :name: MenuProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: "menu"
+    :type: :ref:`data-type-string`
+    :Default: "menu"
 
     Name for the variable in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteLanguageProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteLanguageProcessor.rst
@@ -22,10 +22,9 @@ as
 
 ..  confval:: as
     :name: SiteLanguageProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: "site"
+    :type: :ref:`data-type-string`
+    :Default: "site"
 
     The variable name to be used in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SiteProcessor.rst
@@ -21,10 +21,9 @@ as
 
 ..  confval:: as
     :name: SiteProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: "site"
+    :type: :ref:`data-type-string`
+    :Default: "site"
 
     The variable name to be used in the Fluid template.
 

--- a/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SplitProcessor.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/DataProcessing/SplitProcessor.rst
@@ -21,10 +21,9 @@ if
 
 ..  confval:: if
     :name: splitProcessor-if
-
     :Required: false
-    :Data type: :ref:`if` condition
-    :default: ''
+    :type: :ref:`if` condition
+    :Default: ''
 
     Only if the condition is met the data processor is executed.
 
@@ -36,10 +35,9 @@ fieldName
 
 ..  confval:: fieldName
     :name: splitProcessor-fieldName
-
     :Required: true
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: ''
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: ''
 
     Name of the field to be used.
 
@@ -51,10 +49,9 @@ as
 
 ..  confval:: as
     :name: splitProcessor-as
-
     :Required: false
-    :Data type: :ref:`data-type-string`
-    :default: defaults to the fieldName
+    :type: :ref:`data-type-string`
+    :Default: defaults to the fieldName
 
     The variable name to be used in the Fluid template.
 
@@ -66,10 +63,9 @@ delimiter
 
 ..  confval:: delimiter
     :name: splitProcessor-delimiter
-
     :Required: false
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
-    :default: Line Feed
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
+    :Default: Line Feed
     :Example: ","
 
     The field delimiter, a character separating the values.
@@ -82,10 +78,9 @@ filterIntegers
 
 ..  confval:: filterIntegers
     :name: splitProcessor-filterIntegers
-
     :Required: false
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :Default: 0
     :Example: 1
 
     If set to `1`, all values are being cast to int.
@@ -98,10 +93,9 @@ filterUnique
 
 ..  confval:: filterUnique
     :name: splitProcessor-filterUnique
-
     :Required: false
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :Default: 0
     :Example: 1
 
     If set to `1`, all duplicates will be removed.
@@ -114,10 +108,9 @@ removeEmptyEntries
 
 ..  confval:: removeEmptyEntries
     :name: splitProcessor-removeEmptyEntries
-
     :Required: false
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-    :default: 0
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :Default: 0
     :Example: 1
 
     If set to `1`, all empty values will be removed.

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -70,8 +70,7 @@ dataProcessing
 
 ..  confval:: dataProcessing
     :name: fluidtemplate-dataProcessing
-
-    :Data type: array of class references by full namespace
+    :type: array of class references by full namespace
 
     Add one or multiple processors to manipulate the :php:`$data` variable of
     the currently rendered content object, like tt_content or page. The
@@ -89,8 +88,7 @@ extbase.controllerActionName
 
 ..  confval:: extbase.controllerActionName
     :name: fluidtemplate-extbase-controlleractionname
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Sets the name of the action.
 
@@ -101,8 +99,7 @@ extbase.controllerExtensionName
 
 ..  confval:: extbase.controllerExtensionName
     :name: fluidtemplate-extbase-controllerextensionname
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Sets the extension name of the controller.
 
@@ -131,8 +128,7 @@ extbase.controllerName
 
 ..  confval:: extbase.controllerName
     :name: fluidtemplate-extbase-controllername
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Sets the name of the controller.
 
@@ -143,8 +139,7 @@ extbase.pluginName
 
 ..  confval:: extbase.pluginName
     :name: fluidtemplate-extbase-pluginname
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Sets variables for initializing extbase.
 
@@ -155,8 +150,7 @@ file
 
 ..  confval:: file
     :name: fluidtemplate-file
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     The fluid template file. It is an alternative to ".template" and is used
     only, if ".template" is not set.
@@ -181,8 +175,7 @@ format
 
 ..  confval:: format
     :name: fluidtemplate-format
-
-    :Data type: keyword / :ref:`stdWrap <stdwrap>`
+    :type: keyword / :ref:`stdWrap <stdwrap>`
     :Default: html
 
     :typoscript:`format` sets the format of the current request. It can be something
@@ -196,8 +189,7 @@ layoutRootPath
 
 ..  confval:: layoutRootPath
     :name: fluidtemplate-layoutrootpath
-
-    :Data type: :ref:`data-type-path` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-path` / :ref:`stdWrap <stdwrap>`
 
     Sets a specific layout path, usually
     :file:`EXT:my_extension/Resources/Private/Layouts/` or a folder below that
@@ -216,8 +208,7 @@ layoutRootPaths
 
 ..  confval:: layoutRootPaths
     :name: fluidtemplate-layoutrootpaths
-
-    :Data type: array of :ref:`data-type-path` with :ref:`stdWrap <stdwrap>`
+    :type: array of :ref:`data-type-path` with :ref:`stdWrap <stdwrap>`
 
     .. note:: Mind the plural -s in "layoutRootPaths"!
 
@@ -258,8 +249,7 @@ partialRootPath
 
 ..  confval:: partialRootPath
     :name: fluidtemplate-partialrootpath
-
-    :Data type: :ref:`data-type-path` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-path` / :ref:`stdWrap <stdwrap>`
 
     Sets a specific partial path, usually
     :file:`EXT:my_extension/Resources/Private/Partials/` or a folder below that
@@ -278,8 +268,7 @@ partialRootPaths
 
 ..  confval:: partialRootPaths
     :name: fluidtemplate-partialrootpaths
-
-    :Data type: array of :ref:`data-type-path` with :ref:`stdWrap <stdwrap>`
+    :type: array of :ref:`data-type-path` with :ref:`stdWrap <stdwrap>`
 
     .. note:: Mind the plural -s in "partialRootPaths"!
 
@@ -301,8 +290,7 @@ settings
 
 ..  confval:: settings
     :name: fluidtemplate-settings
-
-    :Data type: array of keys
+    :type: array of keys
 
     Sets the given settings array in the fluid template. In the view, the value
     can then be used.
@@ -339,8 +327,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: fluidtemplate-stdwrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
     Offers the usual stdWrap functionality.
 
@@ -351,8 +338,7 @@ template
 
 ..  confval:: template
     :name: fluidtemplate-template
-
-    :Data type: :ref:`cObject <data-type-cobject>`
+    :type: :ref:`cObject <data-type-cobject>`
 
     Use this property to define a content object, which should be used as
     template file. It is an alternative to ".file"; if ".template" is set, it
@@ -373,8 +359,7 @@ templateName
 
 ..  confval:: templateName
     :name: fluidtemplate-templatename
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     This name is used together with the set format to find the template in the
     given templateRootPaths. Use this property to define a content object, which
@@ -452,8 +437,7 @@ templateRootPath
 
 ..  confval:: templateRootPath
     :name: fluidtemplate-templaterootpath
-
-    :Data type: file path /:ref:`stdWrap <stdwrap>`
+    :type: file path /:ref:`stdWrap <stdwrap>`
 
     Sets a specific template path, usually
     :file:`EXT:my_extension/Resources/Private/Templates/` or a folder below that
@@ -472,8 +456,7 @@ templateRootPaths
 
 ..  confval:: templateRootPaths
     :name: fluidtemplate-templaterootpaths
-
-    :Data type: array of file paths with :ref:`stdWrap <stdwrap>`
+    :type: array of file paths with :ref:`stdWrap <stdwrap>`
 
     .. note:: Mind the plural -s in "templateRootPaths"!
 
@@ -512,8 +495,7 @@ variables
 
 ..  confval:: variables
     :name: fluidtemplate-variables
-
-    :Data type: *(array of cObjects)*
+    :type: *(array of cObjects)*
 
     Sets variables that should be available in the fluid template. The keys are
     the variable names in Fluid.

--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -39,8 +39,7 @@ Properties
 
 ..  confval:: 1, 2, 3, ...
     :name: hmenu-array
-
-    :Data type: :ref:`menu object <data-type-menuobj>`
+    :type: :ref:`menu object <data-type-menuobj>`
     :Default: (no menu)
 
     For every menu level, that should be rendered, an according entry must
@@ -85,8 +84,7 @@ cache_period
 
 ..  confval:: cache_period
     :name: hmenu-cache-period
-
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
 
     The number of seconds a menu may remain in cache. If this value is not
     set, the first available value of the following will be used:
@@ -105,8 +103,7 @@ cache
 
 ..  confval:: cache
     :name: hmenu-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
@@ -118,8 +115,7 @@ entryLevel
 
 ..  confval:: entryLevel
     :name: hmenu-entryLevel
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     Defines at which level in the rootLine the menu should start.
@@ -183,8 +179,7 @@ special
 
 ..  confval:: special
     :name: hmenu-special
-
-    :Data type: *"directory" / "list" / "updated" / "rootline" / "browse" / "keywords"
+    :type: *"directory" / "list" / "updated" / "rootline" / "browse" / "keywords"
          / "categories" / "language" / "userfunction"*
 
     Lets you define special types of menus.
@@ -199,8 +194,7 @@ special.value
 
 ..  confval:: special.value
     :name: hmenu-special-value
-
-    :Data type: *list of page-uid's* / :ref:`stdWrap <stdwrap>`
+    :type: *list of page-uid's* / :ref:`stdWrap <stdwrap>`
 
     List of page uid's to use for the special menu. What they are used
     for depends on the menu type as defined by ".special"; see the
@@ -214,8 +208,7 @@ minItems
 
 ..  confval:: minItems
     :name: hmenu-minItems
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     The minimum number of items in the menu. If the number of pages does
     not reach this level, a dummy-page with the title "..." and
@@ -233,8 +226,7 @@ maxItems
 
 ..  confval:: maxItems
     :name: hmenu-maxItems
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     The maximum number of items in the menu. Additional items will be
     ignored.
@@ -250,8 +242,7 @@ begin
 
 ..  confval:: begin
     :name: hmenu-begin
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
 
     The first item in the menu.
 
@@ -276,8 +267,7 @@ excludeUidList
 
 ..  confval:: excludeUidList
     :name: hmenu-excludeUidList
-
-    :Data type: list of :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: list of :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     This is a list of page uids to exclude when the select statement is
     done. Comma-separated. You may add "current" to the list to exclude
@@ -301,8 +291,7 @@ excludeDoktypes
 
 ..  confval:: excludeDoktypes
     :name: hmenu-excludeDoktypes
-
-    :Data type: list of :ref:`data-type-integer`
+    :type: list of :ref:`data-type-integer`
     :Default: 6,254
 
     Enter the list of page document types (doktype) to exclude from menus.
@@ -316,8 +305,7 @@ includeNotInMenu
 
 ..  confval:: includeNotInMenu
     :name: hmenu-includeNotInMenu
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
 
     If set, pages with the checkbox "Page enabled in menus" disabled will still be included
     in menus.
@@ -329,8 +317,7 @@ alwaysActivePIDlist
 
 ..  confval:: alwaysActivePIDlist
     :name: hmenu-alwaysActivePIDlist
-
-    :Data type: list of :ref:`data-type-integer` /:ref:`stdWrap <stdwrap>`
+    :type: list of :ref:`data-type-integer` /:ref:`stdWrap <stdwrap>`
 
     This is a list of page UID numbers that will always be regarded as
     active menu items and thereby automatically opened regardless of the
@@ -344,8 +331,7 @@ protectLvar
 
 ..  confval:: protectLvar
     :name: hmenu-protectlvar
-
-    :Data type: :ref:`data-type-boolean` / keyword
+    :type: :ref:`data-type-boolean` / keyword
 
     If set, then for each page in the menu it will be checked if an
     Alternative Page Language record for the language defined in
@@ -378,8 +364,7 @@ addQueryString
 
 ..  confval:: addQueryString
     :name: hmenu-addquerystring
-
-    :Data type: :ref:`->addQueryString <typolink-addQueryString>`
+    :type: :ref:`->addQueryString <typolink-addQueryString>`
 
     **Note:** This works only for *special=language*.
 
@@ -391,8 +376,7 @@ if
 
 ..  confval:: if
     :name: hmenu-if
-
-    :Data type: :ref:`->if <if>`
+    :type: :ref:`->if <if>`
 
     If "if" returns false, the menu is not generated.
 
@@ -404,8 +388,7 @@ wrap
 
 ..  confval:: wrap
     :name: hmenu-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
 
     Wrap for the HMENU.
 
@@ -417,8 +400,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: hmenu-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
     (Executed after ".wrap".)
 

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -50,8 +50,7 @@ if
 
 ..  confval:: if
     :name: image-if
-
-    :Data type: :ref:`->if <if>`
+    :type: :ref:`->if <if>`
 
     If "if" returns false, the image is not shown!
 
@@ -63,8 +62,7 @@ file
 
 ..  confval:: file
     :name: image-file
-
-    :Data type: :ref:`->imgResource <imgresource>`
+    :type: :ref:`->imgResource <imgresource>`
 
 
 ..  _cobj-image-params:
@@ -74,8 +72,7 @@ params
 
 ..  confval:: params
     :name: image-params
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     HTML <IMG> parameters
 
@@ -88,16 +85,14 @@ altText / titleText
 
 ..  confval:: altText
     :name: image-altText
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     If no alt text is specified, an empty alt text will be used.
 
 
 ..  confval:: titleText
     :name: image-titleText
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
 
 ..  _cobj-image-emptyTitleHandling:
@@ -107,8 +102,7 @@ emptyTitleHandling
 
 ..  confval:: emptyTitleHandling
     :name: image-emptyTitleHandling
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: useAlt
 
     Value can be "keepEmpty" to preserve an empty title attribute, or
@@ -122,8 +116,7 @@ layoutKey
 
 ..  confval:: layoutKey
     :name: image-layoutKey
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: default
 
     Defines the render layout for the IMAGE. The render layout is the HTML Code for the IMAGE itself.
@@ -180,8 +173,7 @@ layout
 
 ..  confval:: layout
     :name: image-layout
-
-    :Data type: array
+    :type: array
 
     HTML code definition for the different :ref:`cobj-image-layoutkey`.
 
@@ -194,8 +186,7 @@ layout.layoutKey
 
 ..  confval:: layout.layoutKey
     :name: image-layout-layoutkey
-
-    :Data type: array
+    :type: array
 
     Definition for the HTML rendering for the named
     :ref:`cobj-image-layoutkey`. Depending on your needs you can use the
@@ -221,8 +212,7 @@ layout.layoutKey.element
 
 ..  confval:: layout.layoutKey.element
     :name: image-layout-layoutkey-element
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The outer element definition for the HTML rendering of the image.
     Possible markers are mainly all parameters which can be defined in the
@@ -259,8 +249,7 @@ layout.layoutKey.source
 
 ..  confval:: layout.layoutKey.source
     :name: image-layout-layoutkey-source
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the HTML code for the :html:`###SOURCECOLLECTION###`
     of the :ref:`cobj-image-layout-layoutkey-element`.
@@ -295,8 +284,7 @@ sourceCollection
 
 ..  confval:: sourceCollection
     :name: image-sourceCollection
-
-    :Data type: array
+    :type: array
 
     For responsive images you need different image resolutions for each
     output device and output mode (portrait vs. landscape).
@@ -345,8 +333,7 @@ sourceCollection.dataKey
 
 ..  confval:: sourceCollection.dataKey
     :name: image-dataKey
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Definition of your image size definition depending on your responsive
     layout, breakpoints and display density.
@@ -360,8 +347,7 @@ sourceCollection.dataKey.if
 
 ..  confval:: sourceCollection.dataKey.if
     :name: image-datakey-if
-
-    :Data type: :ref:`if <if>`
+    :type: :ref:`if <if>`
 
     Renders only if the condition is met, this is evaluated before any
     execution of code.
@@ -375,8 +361,7 @@ sourceCollection.dataKey.pixelDensity
 
 ..  confval:: sourceCollection.dataKey.pixelDensity
     :name: image-pixeldensity
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdWrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdWrap>`
     :Default: 1
 
     Defines the density of the rendered Image, e.g. a retina display would
@@ -394,8 +379,7 @@ sourceCollection.dataKey.width
 
 ..  confval:: sourceCollection.dataKey.width
     :name: image-datakey-width
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
          Defines the width for the html code of the image defined in this
          source collection. For the image file itself the width will be multiplied by
@@ -410,8 +394,7 @@ sourceCollection.dataKey.height
 
 ..  confval:: sourceCollection.dataKey.height
     :name: image-datakey-height
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the height for the html code of the image defined in this
     source collection. For the image file itself the height will be multiplied by
@@ -426,8 +409,7 @@ sourceCollection.dataKey.maxW
 
 ..  confval:: sourceCollection.dataKey.maxW
     :name: image-datakey-maxW
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the maxW for the html code of the image defined in this
     source collection. For the image file itself the maxW will be multiplied by
@@ -442,8 +424,7 @@ sourceCollection.dataKey.maxH
 
 ..  confval:: sourceCollection.dataKey.maxH
     :name: image-datakey-maxH
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the maxH for the html code of the image defined in this
     source collection. For the image file itself the maxH will be multiplied by
@@ -458,8 +439,7 @@ sourceCollection.dataKey.minW
 
 ..  confval:: sourceCollection.dataKey.minW
     :name: image-datakey-minW
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the minW for the html code of the image defined in this
     source collection. For the image file itself the minW will be multiplied by
@@ -474,8 +454,7 @@ sourceCollection.dataKey.minH
 
 ..  confval:: sourceCollection.dataKey.minH
     :name: image-datakey-minH
-
-    :Data type: :ref:`stdWrap <stdWrap>`
+    :type: :ref:`stdWrap <stdWrap>`
 
     Defines the minH for the html code of the image defined in this
     source collection. For the image file itself the minH will be multiplied by
@@ -490,8 +469,7 @@ sourceCollection.dataKey.quality
 
 ..  confval:: sourceCollection.dataKey.quality
     :name: image-datakey-quality
-
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
 
     Defines the quality of the rendered images on a scale from 1-100.
 
@@ -504,8 +482,7 @@ sourceCollection.dataKey.*
 
 ..  confval:: sourceCollection.dataKey.*
     :name: image-datakey-others
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     You can define additional key value pairs which won't be used for
     setting the image size, but will be available as additional markers for
@@ -519,8 +496,7 @@ linkWrap
 
 ..  confval:: linkWrap
     :name: image-linkWrap
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     (before ".wrap")
 
@@ -532,8 +508,7 @@ imageLinkWrap
 
 ..  confval:: imageLinkWrap
     :name: image-imageLinkWrap
-
-    :Data type: :ref:`data-type-boolean` / :ref:`->imageLinkWrap <imagelinkwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`->imageLinkWrap <imagelinkwrap>`
 
     **Note:** Only active if linkWrap is **not** set and file is
     **not** :ref:`GIFBUILDER <gifbuilder>` (as it works with the original
@@ -547,8 +522,7 @@ wrap
 
 ..  confval:: wrap
     :name: image-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
 
     Wrap for the image tag.
 
@@ -560,8 +534,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: image-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
 
 ..  _cobj-image-examples:

--- a/Documentation/ContentObjects/ImgResource/Index.rst
+++ b/Documentation/ContentObjects/ImgResource/Index.rst
@@ -28,8 +28,7 @@ file
 
 ..  confval:: file
     :name: img-resource-file
-
-    :Data type: :ref:`->imgResource <imgresource>`
+    :type: :ref:`->imgResource <imgresource>`
 
 
 ..  _cobj-img-resource-stdWrap:
@@ -39,5 +38,4 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: img-resource-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`

--- a/Documentation/ContentObjects/LoadRegister/Index.rst
+++ b/Documentation/ContentObjects/LoadRegister/Index.rst
@@ -36,8 +36,7 @@ Properties
 
 ..  confval:: array of field names
     :name: load-register-array
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     **Example:**
 

--- a/Documentation/ContentObjects/Records/Index.rst
+++ b/Documentation/ContentObjects/Records/Index.rst
@@ -41,8 +41,7 @@ source
 
 ..  confval:: source
     :name: records-source
-
-    :Data type: *records-list* / :ref:`stdWrap <stdwrap>`
+    :type: *records-list* / :ref:`stdWrap <stdwrap>`
 
     List of record id's, optionally with prepended table names.
 
@@ -61,8 +60,7 @@ categories
 
 ..  confval:: categories
     :name: records-categories
-
-    :Data type: *categories-list* / :ref:`stdWrap <stdwrap>`
+    :type: *categories-list* / :ref:`stdWrap <stdwrap>`
 
     Comma-separated list of system categories uid's.
     Records related to these categories will be retrieved
@@ -98,8 +96,7 @@ tables
 
 ..  confval:: tables
     :name: records-tables
-
-    :Data type: *list of tables* / :ref:`stdWrap <stdwrap>`
+    :type: *list of tables* / :ref:`stdWrap <stdwrap>`
 
     List of accepted tables. For items listed in the
     :ref:`source <cobj-records-properties-source>` property
@@ -129,8 +126,7 @@ conf
 
 ..  confval:: conf.[*table name*]
     :name: records-conf
-
-    :Data type: :ref:`cObject <data-type-cobject>`
+    :type: :ref:`cObject <data-type-cobject>`
 
     Configuration array, which defines the rendering for records from
     table *table name*.
@@ -148,8 +144,7 @@ dontCheckPid
 
 ..  confval:: dontCheckPid
     :name: records-dontCheckPid
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     Normally a record cannot be selected, if its parent page (pid) is not
@@ -163,8 +158,7 @@ wrap
 
 ..  confval:: wrap
     :name: records-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
 
     Wraps the output. Executed before :ref:`stdWrap <cobj-records-properties-stdwrap>`.
 
@@ -176,8 +170,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: records-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
     Executed after :ref:`wrap <cobj-records-properties-wrap>`.
 
@@ -189,8 +182,7 @@ cache
 
 ..  confval:: cache
     :name: records-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -25,8 +25,7 @@ width
 
 ..  confval:: width
     :name: svg-width
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
     :Default: 600
 
     Width of the SVG.
@@ -39,8 +38,7 @@ height
 
 ..  confval:: height
     :name: svg-height
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
     :Default: 400
 
     Height of the SVG.
@@ -53,8 +51,7 @@ src
 
 ..  confval:: src
     :name: svg-src
-
-    :Data type: :ref:`data-type-resource` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-resource` / :ref:`stdWrap <stdwrap>`
 
     SVG file resource, can also be referenced via :file:`EXT:` prefix to
     point to files of extensions.
@@ -74,8 +71,7 @@ renderMode
 
 ..  confval:: renderMode
     :name: svg-renderMode
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Setting `renderMode` to inline will render an inline version of the SVG.
 
@@ -87,8 +83,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: svg-stdWrap
-
-    :Data type: :ref:`->stdWrap <stdwrap>`
+    :type: :ref:`->stdWrap <stdwrap>`
 
 
 .. _cobj-svg-examples:

--- a/Documentation/ContentObjects/Text/Index.rst
+++ b/Documentation/ContentObjects/Text/Index.rst
@@ -32,8 +32,7 @@ value
 
 ..  confval:: value
     :name: text-value
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Text, which you want to output.
 
@@ -45,8 +44,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: text-stdWrap
-
-    :Data type: :ref:`stdWrap <stdwrap>`
+    :type: :ref:`stdWrap <stdwrap>`
 
     stdWrap properties are available on the very root level of the
     object. This is non-standard! You should use these stdWrap
@@ -61,8 +59,7 @@ cache
 
 ..  confval:: cache
     :name: text-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -46,8 +46,7 @@ userFunc
 
 ..  confval:: userFunc
     :name: user-userFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     The name of the function, which should be called. If you specify the
     name with a '->' in it, then it is interpreted as a call to a method in
@@ -73,8 +72,7 @@ userFunc
 
 ..  confval:: (properties you define)
     :name: user-defined-properties
-
-    :Data type: (the data type you want)
+    :type: (the data type you want)
 
     Apart from the properties "userFunc" and "stdWrap", which are defined for
     all USER/USER\_INT objects by default, you can add additional properties
@@ -90,8 +88,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: user-stdWrap
-
-    :Data type: :ref:`stdWrap`.
+    :type: :ref:`stdWrap`.
 
 ..  _cobj-user-cache:
 
@@ -100,8 +97,7 @@ cache
 
 ..  confval:: cache
     :name: user-cache
-
-    :Data type: :ref:`cache <cache>`
+    :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 

--- a/Documentation/DataTypes/Index.rst
+++ b/Documentation/DataTypes/Index.rst
@@ -30,7 +30,6 @@ align
 
 ..  confval:: align
     :name: data-type-align
-
     :Default: :typoscript:`left`
     :Allowed values: :typoscript:`left`, :typoscript:`center`, :typoscript:`right`
 

--- a/Documentation/Functions/Cache.rst
+++ b/Documentation/Functions/Cache.rst
@@ -38,8 +38,7 @@ key
 
 ..  confval:: key
     :name: cache-key
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     The cache identifier that is used to store the rendered content into
     the cache and to read it from there.
@@ -58,8 +57,7 @@ lifetime
 
 ..  confval:: lifetime
     :name: cache-lifetime
-
-    :Data type: mixed / :ref:`stdwrap`
+    :type: mixed / :ref:`stdwrap`
     :Default: default
 
     Lifetime of the content in cache.
@@ -90,8 +88,7 @@ tags
 
 ..  confval:: tags
     :name: cache-tags
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Can hold a comma-separated list of tags. These tags will be attached
     to the entry added to the `cache_hash` cache (and to

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -166,7 +166,7 @@ date
 
 ..  confval:: date
     :name: data-date
-    :default: :typoscript:`d/m Y`
+    :Default: :typoscript:`d/m Y`
 
     Can be used with a colon and :ref:`data-type-date-conf`.
 

--- a/Documentation/Functions/Encapslines.rst
+++ b/Documentation/Functions/Encapslines.rst
@@ -45,8 +45,7 @@ encapsTagList
 
 ..  confval:: encapsTagList
     :name: encapslines-encapsTagList
-
-    :Data type: list of :ref:`data-type-string`
+    :type: list of :ref:`data-type-string`
 
     List of tags which qualify as encapsulating tags. Must be lowercase.
 
@@ -77,8 +76,7 @@ remapTag.[*tagname*]
 
 ..  confval:: remapTag
     :name: encapslines-remapTag
-
-    :Data type: array of :ref:`data-type-string`
+    :type: array of :ref:`data-type-string`
 
     Enter a new tag name here if you wish the tag name of any encapsulation
     to be unified to a single tag name.
@@ -107,8 +105,7 @@ addAttributes.[*tagname*]
 
 ..  confval:: addAttributes
     :name: encapslines-addAttributes
-
-    :Data type: array of :ref:`data-type-string`
+    :type: array of :ref:`data-type-string`
     :Default: Always override/set the value of the attributes.
 
     Attributes to set in the encapsulation tag.
@@ -145,8 +142,7 @@ removeWrapping
 
 ..  confval:: removeWrapping
     :name: encapslines-removeWrapping
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, then all existing wrapping will be removed.
 
@@ -178,8 +174,7 @@ wrapNonWrappedLines
 
 ..  confval:: wrapNonWrappedLines
     :name: encapslines-wrapNonWrappedLines
-
-    :Data type: :ref:`stdwrap-wrap`
+    :type: :ref:`stdwrap-wrap`
 
     Wrapping for non-encapsulated lines
 
@@ -212,8 +207,7 @@ innerStdWrap\_all
 
 ..  confval:: innerStdWrap_all
     :name: encapslines-innerStdWrap-all
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     Wraps the content inside all lines, whether they are encapsulated or
     not.
@@ -226,8 +220,7 @@ encapsLinesStdWrap.[*tagname*]
 
 ..  confval:: encapsLinesStdWrap
     :name: encapslines-encapsLinesStdWrap
-
-    :Data type: array of :ref:`data-type-string` / :ref:`stdWrap`
+    :type: array of :ref:`data-type-string` / :ref:`stdWrap`
 
     Wraps the content inside all encapsulated lines.
 
@@ -241,8 +234,7 @@ defaultAlign
 
 ..  confval:: defaultAlign
     :name: encapslines-defaultAlign
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If set, this value is set as the default "align" value of the wrapping
     tags, both from :ref:`encapslines-encapsTagList` and
@@ -256,8 +248,7 @@ nonWrappedTag
 
 ..  confval:: nonWrappedTag
     :name: encapslines-nonWrappedTag
-
-    :Data type: :typoscript:`tagname`
+    :type: :typoscript:`tagname`
 
     For all non-wrapped lines, you can here set a tag in which they
     should be wrapped. Example would be "p". This is an alternative to

--- a/Documentation/Functions/Htmlparser.rst
+++ b/Documentation/Functions/Htmlparser.rst
@@ -23,8 +23,7 @@ allowTags
 
 ..  confval:: allowTags
     :name: htmlparser-allowTags
-
-    :Data type: list of tags
+    :type: list of tags
 
     Default allowed tags.
 
@@ -36,8 +35,7 @@ stripEmptyTags
 
 ..  confval:: stripEmptyTags
     :name: htmlparser-stripEmptyTags
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Passes the content to PHPs :php:`strip_tags()`.
 
@@ -49,8 +47,7 @@ stripEmptyTags.keepTags
 
 ..  confval:: stripEmptyTags.keepTags
     :name: htmlparser-stripEmptyTags-keepTags
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Comma separated list of tags to keep when applying :php:`strip_tags()`.
 
@@ -62,8 +59,7 @@ tags.[tagname]
 
 ..  confval:: tags
     :name: htmlparser-tags
-
-    :Data type: :ref:`data-type-boolean` / string of :ref:`htmlparser-tags`
+    :type: :ref:`data-type-boolean` / string of :ref:`htmlparser-tags`
 
     Either set this property to `0` or `1` to allow or deny the tag. If you
     enter :ref:`htmlparser-tags` properties, those will automatically overrule
@@ -79,8 +75,7 @@ localNesting
 
 ..  confval:: localNesting
     :name: htmlparser-localNesting
-
-    :Data type: list of tags, must be among preserved tags
+    :type: list of tags, must be among preserved tags
 
     List of tags (among the already set tags), which will be forced to
     have the nesting-flag set to true.
@@ -93,8 +88,7 @@ globalNesting
 
 ..  confval:: globalNesting
     :name: htmlparser-globalNesting
-
-    :Data type: (ibid)
+    :type: (ibid)
 
     List of tags (among the already set tags), which will be forced to
     have the nesting-flag set to "global".
@@ -107,8 +101,7 @@ rmTagIfNoAttrib
 
 ..  confval:: rmTagIfNoAttrib
     :name: htmlparser-rmTagIfNoAttrib
-
-    :Data type: (ibid)
+    :type: (ibid)
 
     List of tags (among the already set tags), which will be forced to
     have the :ref:`htmlparser-rmTagIfNoAttrib` set to true.
@@ -121,8 +114,7 @@ noAttrib
 
 ..  confval:: noAttrib
     :name: htmlparser-noAttrib
-
-    :Data type: (ibid)
+    :type: (ibid)
 
     List of tags (among the already set tags), which will be forced to
     have the allowedAttribs value set to zero (which means, all attributes
@@ -136,8 +128,7 @@ removeTags
 
 ..  confval:: removeTags
     :name: htmlparser-removeTags
-
-    :Data type: (ibid)
+    :type: (ibid)
 
     List of tags (among the already set tags), which will be configured so
     they are surely removed.
@@ -150,8 +141,7 @@ keepNonMatchedTags
 
 ..  confval:: keepNonMatchedTags
     :name: htmlparser-keepNonMatchedTags
-
-    :Data type: :ref:`data-type-boolean` / "protect"
+    :type: :ref:`data-type-boolean` / "protect"
 
     If set (:typoscript:`1`), then all tags are kept regardless of tags present as
     keys in :php:`$tags`-array.
@@ -170,8 +160,7 @@ htmlSpecialChars
 
 ..  confval:: htmlSpecialChars
     :name: htmlparser-htmlSpecialChars
-
-    :Data type: -1 / 0 / 1 / 2
+    :type: -1 / 0 / 1 / 2
 
     This regards all content which is **not** tags:
 

--- a/Documentation/Functions/HtmlparserTags.rst
+++ b/Documentation/Functions/HtmlparserTags.rst
@@ -23,8 +23,7 @@ overrideAttribs
 
 ..  confval:: overrideAttribs
     :name: htmlparser-tags-overrideAttribs
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If set, this string is preset as the attributes of the tag.
 
@@ -36,8 +35,7 @@ allowedAttribs
 
 ..  confval:: allowedAttribs
     :name: htmlparser-tags-allowedAttribs
-
-    :Data type: mixed
+    :type: mixed
 
     Defines the allowed attributes.
 
@@ -60,8 +58,7 @@ fixAttrib.[attribute].set
 
 ..  confval:: fixAttrib.[attribute].set
     :name: htmlparser-tags-fixAttrib-set
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Force the attribute value to this value.
 
@@ -73,8 +70,7 @@ fixAttrib.[attribute].unset
 
 ..  confval:: fixAttrib.[attribute].unset
     :name: htmlparser-tags-fixAttrib-unset
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the attribute is unset.
 
@@ -86,8 +82,7 @@ fixAttrib.[attribute].default
 
 ..  confval:: fixAttrib.[attribute].default
     :name: htmlparser-tags-fixAttrib-default
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If no attribute exists by this name, this value is set as default
     value (if this value is not blank)
@@ -100,8 +95,7 @@ fixAttrib.[attribute].always
 
 ..  confval:: fixAttrib.[attribute].always
     :name: htmlparser-tags-fixAttrib-always
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the attribute is always processed. Normally an attribute is
     processed only if it exists
@@ -114,8 +108,7 @@ fixAttrib.[attribute].trim
 
 ..  confval:: fixAttrib.[attribute].trim
     :name: htmlparser-tags-fixAttrib-trim
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -128,8 +121,7 @@ fixAttrib.[attribute].intval
 
 ..  confval:: fixAttrib.[attribute].intval
     :name: htmlparser-tags-fixAttrib-intval
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If true, the value is passed through the
     respective PHP-function.
@@ -142,8 +134,7 @@ fixAttrib.[attribute].upper
 
 ..  confval:: fixAttrib.[attribute].upper
     :name: htmlparser-tags-fixAttrib-upper
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If true, the value is passed through the PHP function
     `strtoupper() <https://www.php.net/manual/en/function.strtoupper.php>`__.
@@ -156,8 +147,7 @@ fixAttrib.[attribute].lower
 
 ..  confval:: fixAttrib.[attribute].lower
     :name: htmlparser-tags-fixAttrib-lower
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If true, the value is passed through the PHP function
     `strtolower() <https://www.php.net/manual/en/function.strtolower.php>`__.
@@ -170,8 +160,7 @@ fixAttrib.[attribute].range
 
 ..  confval:: fixAttrib.[attribute].range
     :name: htmlparser-tags-fixAttrib-range
-
-    :Data type: [low],[high]
+    :type: [low],[high]
 
     Setting integer range.
 
@@ -183,8 +172,7 @@ fixAttrib.[attribute].list
 
 ..  confval:: fixAttrib.[attribute].list
     :name: htmlparser-tags-fixAttrib-list
-
-    :Data type: list of values, trimmed
+    :type: list of values, trimmed
 
     Attribute value must be in this list. If not, the value is set to the
     first element.
@@ -197,8 +185,7 @@ fixAttrib.[attribute].removeIfFalse
 
 ..  confval:: fixAttrib.[attribute].removeIfFalse
     :name: htmlparser-tags-fixAttrib-removeIfFalse
-
-    :Data type: :ref:`data-type-boolean` / :typoscript:`blank` string
+    :type: :ref:`data-type-boolean` / :typoscript:`blank` string
 
     If set, then the attribute is removed if it is false (= :typoscript:`0`).
     If this value is set to :typoscript:`blank` then the value must be a blank string
@@ -212,8 +199,7 @@ fixAttrib.[attribute].removeIfEquals
 
 ..  confval:: fixAttrib.[attribute].removeIfEquals
     :name: htmlparser-tags-fixAttrib-removeIfEquals
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If the attribute value matches the value set here, then it is removed.
 
@@ -225,8 +211,7 @@ fixAttrib.[attribute].casesensitiveComp
 
 ..  confval:: fixAttrib.[attribute].casesensitiveComp
     :name: htmlparser-tags-fixAttrib-casesensitiveComp
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the comparison in :ref:`htmlparser-tags-fixAttrib-removeIfEquals`
     and :ref:`htmlparser-tags-fixAttrib-list` will be case-sensitive.
@@ -240,8 +225,7 @@ fixAttrib.[attribute].prefixRelPathWith
 
 ..  confval:: fixAttrib.[attribute].prefixRelPathWith
     :name: htmlparser-tags-fixAttrib-prefixRelPathWith
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If the value of the attribute seems to be a relative URL (no scheme
     like "http" and no "/" as first char) then the value of this property
@@ -262,8 +246,7 @@ fixAttrib.[attribute].userFunc
 
 ..  confval:: fixAttrib.[attribute].userFunc
     :name: htmlparser-tags-fixAttrib-userFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     User function for processing of the attribute. The return value
     of this function will be used as the new tag value.
@@ -301,8 +284,7 @@ protect
 
 ..  confval:: protect
     :name: htmlparser-tags-protect
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the tag :html:`<>` is converted to :html:`&lt;` and :html:`&gt;`
 
@@ -314,8 +296,7 @@ remap
 
 ..  confval:: remap
     :name: htmlparser-tags-remap
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If set, the tagname is remapped to this tagname
 
@@ -327,8 +308,7 @@ rmTagIfNoAttrib
 
 ..  confval:: rmTagIfNoAttrib
     :name: htmlparser-tags-rmTagIfNoAttrib
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, then the tag is removed if no attributes happened to be there.
 
@@ -340,8 +320,7 @@ nesting
 
 ..  confval:: nesting
     :name: htmlparser-tags-nesting
-
-    :Data type: mixed
+    :type: mixed
 
     If set true, then this tag must have starting and ending tags in the
     correct order. Any tags not in this order will be discarded. Thus

--- a/Documentation/Functions/If.rst
+++ b/Documentation/Functions/If.rst
@@ -37,8 +37,7 @@ bitAnd
 
 ..  confval:: bitAnd
     :name: if-bitAnd
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     Returns true, if the value is part of the bit set.
 
@@ -71,8 +70,7 @@ contains
 
 ..  confval::  contains
     :name: if-contains
-
-    :Data type:  value / :ref:`stdwrap`
+    :type:  value / :ref:`stdwrap`
 
     Returns true, if the content contains :typoscript:`value`.
 
@@ -105,8 +103,7 @@ directReturn
 
 ..  confval:: directReturn
     :name: if-directReturn
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If this property exists, no other conditions will be checked. Instead
     the true/false of this value is returned. Can be used to set
@@ -122,8 +119,7 @@ endsWith
 
 ..  confval::  endsWith
     :name: if-endsWith
-
-    :Data type:  value / :ref:`stdwrap`
+    :type:  value / :ref:`stdwrap`
 
     Returns true, if the content ends with :typoscript:`value`.
 
@@ -150,8 +146,7 @@ equals
 
 ..  confval:: equals
     :name: if-equals
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     Returns true, if the content is equal to :typoscript:`value`.
 
@@ -171,8 +166,7 @@ isFalse
 
 ..  confval:: isFalse
     :name: if-isFalse
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If the content is "false", which is empty or zero.
 
@@ -184,8 +178,7 @@ isGreaterThan
 
 ..  confval:: isGreaterThan
     :name: if-isGreaterThan
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     Returns true, if the content is greater than :typoscript:`value`.
 
@@ -197,8 +190,7 @@ isInList
 
 ..  confval:: isInList
     :name: if-isInList
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     Returns true, if the content is in the comma-separated list
     :typoscript:`.value`.
@@ -223,8 +215,7 @@ isLessThan
 
 ..  confval:: isLessThan
     :name: if-isLessThan
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     Returns true, if the content is less than :typoscript:`value`.
 
@@ -236,8 +227,7 @@ isNull
 
 ..  confval:: isNull
     :name: if-isNull
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     If the resulting content of the :typoscript:`stdWrap` is null (:php:`NULL` type in PHP).
 
@@ -267,8 +257,7 @@ isPositive
 
 ..  confval:: isPositive
     :name: if-isPositive
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap` \+ :ref:`objects-calc`
 
     Returns true, if the content is positive.
 
@@ -280,8 +269,7 @@ isTrue
 
 ..  confval:: isTrue
     :name: if-isTrue
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If the content is "true", which is not empty string and not zero.
 
@@ -293,8 +281,7 @@ negate
 
 ..  confval:: negate
     :name: if-negate
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     This property is checked after all other properties. If set, it
@@ -315,8 +302,7 @@ startsWith
 
 ..  confval::  startsWith
     :name: if-startsWith
-
-    :Data type:  value / :ref:`stdwrap`
+    :type:  value / :ref:`stdwrap`
 
     Returns true, if the content starts with :typoscript:`value`.
 
@@ -342,8 +328,7 @@ value
 
 ..  confval:: value
     :name: if-value
-
-    :Data type: value / :ref:`stdwrap`
+    :type: value / :ref:`stdwrap`
 
     The value to check. This is the comparison value mentioned above.
 

--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -25,9 +25,7 @@ enable
 
 ..  confval:: imageLinkWrap.enable
     :name: imagelinkwrap-enable
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     Whether or not to link the image. Must be set to True to make
@@ -41,8 +39,7 @@ file
 
 ..  confval:: imageLinkWrap.file
     :name: imagelinkwrap-file
-
-    :Data type: :ref:`stdwrap`
+    :type: :ref:`stdwrap`
 
     Apply :ref:`stdwrap` functionality to the file path.
 
@@ -54,9 +51,7 @@ width
 
 ..  confval:: imageLinkWrap.width
     :name: imagelinkwrap-width
-
-    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
     :Default: 0
 
     Width of the image to be shown in pixels. If you add "m" to
@@ -72,9 +67,7 @@ height
 
 ..  confval:: imageLinkWrap.height
     :name: imagelinkwrap-height
-
-    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
     :Default: 0
 
     Width of the image to be shown in pixels. If you add "m" to
@@ -90,9 +83,7 @@ effects
 
 ..  confval:: imageLinkWrap.effects
     :name: imagelinkwrap-effects
-
-    :Data type: like :ref:`gifbuilder-effect` of :ref:`GIFBUILDER`
-
+    :type: like :ref:`gifbuilder-effect` of :ref:`GIFBUILDER`
     :Default: 0
 
     Apply image effects to the preview image.
@@ -120,9 +111,7 @@ sample
 
 ..  confval:: imageLinkWrap.sample
     :name: imagelinkwrap-sample
-
-    :Data type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-positive-integer` / :ref:`stdwrap`
     :Default: 0
 
     :typoscript:`sample` is a switch which determines how the image
@@ -141,8 +130,7 @@ title
 
 ..  confval:: imageLinkWrap.title
     :name: imagelinkwrap-title
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Specifies the html-page-title of the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -155,8 +143,7 @@ bodyTag
 
 ..  confval:: imageLinkWrap.bodyTag
     :name: imagelinkwrap-bodyTag
-
-    :Data type: :ref:`data-type-tag` / :ref:`stdwrap`
+    :type: :ref:`data-type-tag` / :ref:`stdwrap`
 
     This is the `<body>`-tag of the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -181,8 +168,7 @@ wrap
 
 ..  confval:: imageLinkWrap.wrap
     :name: imagelinkwrap-wrap
-
-    :Data type: :ref:`data-type-wrap`
+    :type: :ref:`data-type-wrap`
 
     This wrap is placed around the `<img>`-tag in the preview window.
     Needs :typoscript:`JSwindow = 1`.
@@ -195,9 +181,7 @@ target
 
 ..  confval:: imageLinkWrap.target
     :name: imagelinkwrap-target
-
-    :Data type: :ref:`data-type-target` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-target` / :ref:`stdwrap`
     :Default: :typoscript:`thePicture`
 
     This specifies the `target` attribute of the link. The attribute
@@ -225,9 +209,7 @@ JSwindow
 
 ..  confval:: imageLinkWrap.JSwindow
     :name: imagelinkwrap-JSwindow
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If true (:typoscript:`JSwindow = 1`) Javascript will be used to open
@@ -242,9 +224,7 @@ JSwindow.expand
 
 ..  confval:: imageLinkWrap.JSwindow.expand
     :name: imagelinkwrap-JSwindow-expand
-
-    :Data type: :typoscript:`x`, :typoscript:`y` / :ref:`stdwrap`
-
+    :type: :typoscript:`x`, :typoscript:`y` / :ref:`stdwrap`
     :Default: 0
 
     :typoscript:`x` and :typoscript:`x` are of data type
@@ -260,9 +240,7 @@ JSwindow.newWindow
 
 ..  confval:: JSwindow.newWindow
     :name: imagelinkwrap-JSwindow-newWindow
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If the :ref:`Doctype <setup-config-doctype>` allows the :ref:`data-type-target`
@@ -282,8 +260,7 @@ JSwindow.altUrl
 
 ..  confval:: imageLinkWrap.JSwindow.altUrl
     :name: imagelinkwrap-JSwindow-altUrl
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If this returns anything then it is used as URL of the preview window.
     Otherwise the default "showpic" script will be used.
@@ -296,9 +273,7 @@ JSwindow.altUrl\_noDefaultParams
 
 ..  confval:: imageLinkWrap.JSwindow.altUrl_noDefaultParams
     :name: imagelinkwrap-JSwindow-altUrl-noDefaultParams
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If true (:typoscript:`JSwindow.altUrl_noDefaultParams = 1`) then the
@@ -314,8 +289,7 @@ typolink
 
 ..  confval:: imageLinkWrap.typolink
     :name: imagelinkwrap-typolink
-
-    :Data type: :ref:`typolink` / :ref:`stdwrap`
+    :type: :ref:`typolink` / :ref:`stdwrap`
 
     If this returns anything it will be used as link and override
     everything else.
@@ -328,9 +302,7 @@ directImageLink
 
 ..  confval:: imageLinkWrap.directImageLink
     :name: imagelinkwrap-directImageLink
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If true (:typoscript:`directImageLink = 1`) then a link will be
@@ -345,8 +317,7 @@ linkParams
 
 ..  confval:: imageLinkWrap.linkParams
     :name: imagelinkwrap-linkParams
-
-    :Data type: :ref:`typolink` / :ref:`stdwrap`
+    :type: :ref:`typolink` / :ref:`stdwrap`
 
     When the direct link for the preview image is calculated all
     attributes of :typoscript:`linkParams` are used as settings for the
@@ -379,8 +350,7 @@ stdWrap
 
 ..  confval:: imageLinkWrap.stdWrap
     :name: imagelinkwrap-stdWrap
-
-    :Data type: :ref:`stdwrap`
+    :type: :ref:`stdwrap`
 
     This adds :ref:`stdwrap` functionality to the almost final
     result.

--- a/Documentation/Functions/Imgresource.rst
+++ b/Documentation/Functions/Imgresource.rst
@@ -27,9 +27,7 @@ ext
 
 ..  confval:: ext
     :name: imgresource-ext
-
-    :Data type: :ref:`data-type-imageExtension` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-imageExtension` / :ref:`stdwrap`
     :Default: web
 
     Target file extension for the processed image. The value :typoscript:`web` checks if
@@ -47,8 +45,7 @@ width
 
 ..  confval:: width
     :name: imgresource-width
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     If both the width and the height are set and one of the numbers is
     appended by an :typoscript:`m`, the proportions will be preserved and thus
@@ -110,8 +107,7 @@ height
 
 ..  confval:: height
     :name: imgresource-height
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     See :ref:`imgresource-width`.
 
@@ -123,8 +119,7 @@ params
 
 ..  confval:: params
     :name: imgresource-params
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     GraphicsMagick/ImageMagick command line:
 
@@ -138,8 +133,7 @@ sample
 
 ..  confval:: sample
     :name: imgresource-sample
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, `-sample` is used to scale images instead of `-geometry`. Sample
@@ -153,8 +147,7 @@ noScale
 
 ..  confval:: noScale
     :name: imgresource-noScale
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If set, the image itself will never be scaled. Only width and height
@@ -190,8 +183,7 @@ crop
 
 ..  confval:: crop
     :name: imgresource-crop
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: not-set (when file/image is a file_reference the crop value of
 
     It is possible to define an area that should be taken (cropped) from the image.
@@ -224,8 +216,7 @@ cropVariant
 
 ..  confval:: cropVariant
     :name: imgresource-cropVariant
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Default: default
 
     Since it's possible to define certain :ref:`crop variants <t3coreapi:cropvariants>`
@@ -252,8 +243,7 @@ frame
 
 ..  confval:: frame
     :name: imgresource-frame
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Chooses the frame in a PDF or GIF file.
 
@@ -267,8 +257,7 @@ import
 
 ..  confval:: import
     :name: imgresource-import
-
-    :Data type: :ref:`data-type-path` / :ref:`stdwrap`
+    :type: :ref:`data-type-path` / :ref:`stdwrap`
 
     *value* should be set to the path of the file
 
@@ -296,8 +285,7 @@ treatIdAsReference
 
 ..  confval:: treatIdAsReference
     :name: imgresource-treatIdAsReference
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     If set, given UIDs are interpreted as UIDs to sys_file_reference
@@ -312,8 +300,7 @@ maxW
 
 ..  confval:: maxW
     :name: imgresource-maxW
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Maximum width
 
@@ -325,8 +312,7 @@ maxH
 
 ..  confval:: maxH
     :name: imgresource-maxH
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Maximum height
 
@@ -338,8 +324,7 @@ minW
 
 ..  confval:: minW
     :name: imgresource-minW
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Minimum width (overrules maxW/maxH)
 
@@ -351,8 +336,7 @@ minH
 
 ..  confval:: minH
     :name: imgresource-minH
-
-    :Data type: :ref:`data-type-pixels` / :ref:`stdwrap`
+    :type: :ref:`data-type-pixels` / :ref:`stdwrap`
 
     Minimum height (overrules maxW/maxH)
 
@@ -364,8 +348,7 @@ stripProfile
 
 ..  confval:: stripProfile
     :name: imgresource-stripProfile
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the GraphicsMagick/ImageMagick-command will use a
@@ -404,8 +387,7 @@ m.mask
 
 ..  confval:: m.mask
     :name: imgresource-masking-mask
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     The mask with which the image is masked onto :typoscript:`m.bgImg`. Both :typoscript:`m.mask`
     and :typoscript:`m.bgImg` **is scaled to fit** the size of the imgResource image!
@@ -420,8 +402,7 @@ m.bgImg
 
 ..  confval:: m.bgImg
     :name: imgresource-masking-bgImg
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     **Note:** Both :typoscript:`m.mask` and :typoscript:`m.bgImg` must be valid images.
 
@@ -433,8 +414,7 @@ m.bottomImg
 
 ..  confval:: m.bottomImg
     :name: imgresource-masking-bottomImg
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     An image masked by :typoscript:`m.bottomImg_mask` onto :typoscript:`m.bgImg` before the
     imgResources is masked by :typoscript:`m.mask`.
@@ -455,8 +435,7 @@ m.bottomImg\_mask
 
 ..  confval:: m.bottomImg_mask
     :name: imgresource-masking-bottomImg-mask
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     (optional)
 

--- a/Documentation/Functions/Makelinks.rst
+++ b/Documentation/Functions/Makelinks.rst
@@ -49,8 +49,7 @@ http.extTarget
 
 ..  confval:: http.extTarget
     :name: makelinks-http-extTarget
-
-    :Data type: :ref:`data-type-target`
+    :type: :ref:`data-type-target`
     :Default: \_top
 
     The target of the link.
@@ -63,8 +62,7 @@ http.wrap
 
 ..  confval:: http.wrap
     :name: makelinks-http-wrap
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdwrap`
+    :type: :ref:`data-type-wrap` / :ref:`stdwrap`
 
     Wrap around the link.
 
@@ -75,8 +73,7 @@ http.ATagBeforeWrap
 
 ..  confval:: http.ATagBeforeWrap
     :name: makelinks-http-ATagBeforeWrap
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with :typoscript:`http.wrap` and then the
@@ -90,8 +87,7 @@ http.keep
 
 ..  confval:: http.keep
     :name: makelinks-http-keep
-
-    :Data type: list: "scheme","path","query"
+    :type: list: "scheme","path","query"
 
     As default the link-text will be the full domain-name of the link.
 
@@ -115,8 +111,7 @@ http.ATagParams
 
 ..  confval:: http.ATagParams
     :name: makelinks-http-ATagParams
-
-    :Data type: :ref:`data-type-tag-params` / :ref:`stdwrap`
+    :type: :ref:`data-type-tag-params` / :ref:`stdwrap`
 
     Additional parameters
 
@@ -147,8 +142,7 @@ mailto.wrap
 
 ..  confval:: mailto.wrap
     :name: makelinks-mailto.wrap
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdwrap`
+    :type: :ref:`data-type-wrap` / :ref:`stdwrap`
 
     Wrap around the link.
 
@@ -159,8 +153,7 @@ mailto.ATagBeforeWrap
 
 ..  confval:: mailto.ATagBeforeWrap
     :name: makelinks-mailto.ATagBeforeWrap
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with mailto :typoscript:`wrap` and then the
@@ -174,8 +167,7 @@ mailto.ATagParams
 
 ..  confval:: mailto.ATagParams
     :name: makelinks-mailto.ATagParams
-
-    :Data type: :ref:`data-type-tag-params` / :ref:`stdwrap`
+    :type: :ref:`data-type-tag-params` / :ref:`stdwrap`
 
     Additional parameters
 

--- a/Documentation/Functions/Numberformat.rst
+++ b/Documentation/Functions/Numberformat.rst
@@ -33,8 +33,7 @@ decimals
 
 ..  confval:: decimals
     :name: numberformat-decimals
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
 
     Number of decimals the formatted number will have.
@@ -50,8 +49,7 @@ dec\_point
 
 ..  confval:: dec_point
     :name: numberformat-dec-point
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
     :Default: .
 
     Character that divides the decimals from the rest of the number.
@@ -64,8 +62,7 @@ thousands\_sep
 
 ..  confval:: thousands_sep
     :name: numberformat-thousands-sep
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: ,
 
     Character that divides the thousands of the number.

--- a/Documentation/Functions/Numrows.rst
+++ b/Documentation/Functions/Numrows.rst
@@ -28,8 +28,7 @@ table
 
 ..  confval:: table
     :name: _numrows-table
-
-    :Data type: Table name
+    :type: Table name
 
     Name of the database table to query.
 
@@ -40,8 +39,7 @@ select
 
 ..  confval:: select
     :name: numrows-select
-
-    :Data type: :ref:`select`
+    :type: :ref:`select`
 
     Select query for the operation.
 

--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -27,8 +27,7 @@ externalBlocks
 
 ..  confval:: externalBlocks
     :name: parsefunc-externalBlocks
-
-    :Data type: list of tagnames / +properties
+    :type: list of tagnames / +properties
 
     This allows you to pre-split the content passed to parseFunc so that
     only content outside the blocks with the given tags is parsed.
@@ -121,8 +120,7 @@ short
 
 ..  confval:: short
     :name: arsefunc-short
-
-    :Data type: *(array of strings)*
+    :type: *(array of strings)*
 
     If this property is set, you can use markers (the short name
     wrapped in "###") in your text. TYPO3 then substitutes the markers
@@ -152,8 +150,7 @@ plainTextStdWrap
 
 ..  confval:: plainTextStdWrap
     :name: parsefunc-plainTextStdWrap
-
-    :Data type: :ref:`stdwrap`
+    :type: :ref:`stdwrap`
 
     This is :ref:`stdwrap` properties for all non-tag content.
 
@@ -165,8 +162,7 @@ userFunc
 
 ..  confval:: userFunc
     :name: parsefunc-userFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     This passes the non-tag content to a function of your own choice.
     Similar to, for example, :ref:`stdwrap-postUserFunc` in :ref:`stdWrap`.
@@ -181,8 +177,7 @@ nonTypoTagStdWrap
 
 ..  confval:: nonTypoTagStdWrap
     :name: parsefunc-nonTypoTagStdWrap
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     Like :ref:`parsefunc-plainTextStdWrap`. Difference:
 
@@ -199,8 +194,7 @@ nonTypoTagUserFunc
 
 ..  confval:: nonTypoTagUserFunc
     :name: parsefunc-nonTypoTagUserFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     Like :ref:`parsefunc-userFunc`.
     Differences is (like :ref:`parsefunc-nonTypoTagStdWrap`)
@@ -217,8 +211,7 @@ makelinks
 
 ..  confval:: makelinks
     :name: parsefunc-makelinks
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Convert web addresses prefixed with `http://` and mail addresses
     prefixed with `mailto:` to links.
@@ -231,8 +224,7 @@ tags
 
 ..  confval:: tags
     :name: parsefunc-tags
-
-    :Data type: :ref:`tags`
+    :type: :ref:`tags`
 
     Here you can define **custom tags** that will parse the content to
     something.
@@ -245,8 +237,7 @@ allowTags
 
 ..  confval:: allowTags
     :name: parsefunc-allowTags
-
-    :Data type: list of strings
+    :type: list of strings
 
     List of tags, which are allowed to exist in code!
 
@@ -261,8 +252,7 @@ denyTags
 
 ..  confval:: denyTags
     :name: parsefunc-denyTags
-
-    :Data type: list of strings
+    :type: list of strings
 
     List of tags, which may **not** exist in code! (use :typoscript:`*` for all.)
 
@@ -291,8 +281,7 @@ if
 
 .. confval:: if
     :name: parsefunc-if
-
-    :Data type: :ref:`if`
+    :type: :ref:`if`
 
     if "if" returns false, the input value is not parsed, but returned
     directly.

--- a/Documentation/Functions/Replacement.rst
+++ b/Documentation/Functions/Replacement.rst
@@ -30,8 +30,7 @@ search
 
 ..  confval:: search
     :name: replacement-search
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Defines the string that shall be replaced.
 
@@ -43,8 +42,7 @@ replace
 
 ..  confval:: replace
     :name: replacement-replace
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Defines the string to be used for the replacement.
 
@@ -56,8 +54,7 @@ useRegExp
 
 ..  confval:: useRegExp
     :name: replacement-useRegExp
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     Defines that the search and replace strings are considered as PCRE
@@ -82,8 +79,7 @@ useOptionSplitReplace
 
 ..  confval:: useOptionSplitReplace
     :name: replacement-useOptionSplitReplace
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
     :Default: 0
 
     This property allows to use :ref:`optionsplit` for the replace

--- a/Documentation/Functions/Round.rst
+++ b/Documentation/Functions/Round.rst
@@ -29,8 +29,7 @@ roundType
 
 ..  confval:: roundType
     :name: round-roundType
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: round
 
     Round method which should be used.
@@ -54,8 +53,7 @@ decimals
 
 ..  confval:: decimals
     :name: round-decimals
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
 
     Number of decimals the rounded value will have. Only used with the
@@ -70,8 +68,7 @@ round
 
 ..  confval:: round
     :name: round-round
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     Set round = 1 to enable rounding.

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -38,8 +38,7 @@ uidInList
 
 ..  confval:: uidInList
     :name: select-uidInList
-
-    :Data type: *list of record\_ids* / :ref:`stdWrap`
+    :type: *list of record\_ids* / :ref:`stdWrap`
 
     Comma-separated list of record uids from the according database table.
     For example when the select function works on the table `tt_content`, then
@@ -73,8 +72,7 @@ pidInList
 
 ..  confval:: pidInList
     :name: select_pidInList
-
-    :Data type: *list of page\_ids* / :ref:`stdWrap`
+    :type: *list of page\_ids* / :ref:`stdWrap`
     :Default: :typoscript:`this`
 
     Comma-separated list of pids of the record. This will be page uids (pids). For
@@ -143,8 +141,7 @@ recursive
 
 ..  confval:: recursive
     :name: select-recursive
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
     :Default: 0
 
     Number of recursive levels for the pidInList.
@@ -157,8 +154,7 @@ orderBy
 
 ..  confval:: orderBy
     :name: select-orderBy
-
-    :Data type: *SQL-orderBy* / :ref:`stdWrap`
+    :type: *SQL-orderBy* / :ref:`stdWrap`
 
     ORDER BY clause without the words "ORDER BY".
 
@@ -177,8 +173,7 @@ groupBy
 
 ..  confval:: groupBy
     :name: select-groupBy
-
-    :Data type: *SQL-groupBy* / :ref:`stdWrap`
+    :type: *SQL-groupBy* / :ref:`stdWrap`
 
     GROUP BY clause without the words "GROUP BY".
 
@@ -197,8 +192,7 @@ max
 
 ..  confval:: max
     :name: select-max
-
-    :Data type: :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
     Max records
 
@@ -212,8 +206,7 @@ begin
 
 ..  confval:: begin
     :name: select-begin
-
-    :Data type: :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` + :ref:`objects-calc` +"total" / :ref:`stdWrap`
 
     Begin with record number *value*.
 
@@ -228,8 +221,7 @@ where
 
 ..  confval:: where
     :name: select-where
-
-    :Data type: *SQL-where* / :ref:`stdWrap`
+    :type: *SQL-where* / :ref:`stdWrap`
 
     WHERE clause without the word "WHERE".
 
@@ -256,8 +248,7 @@ languageField
 
 ..  confval:: languageField
     :name: select-languageField
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     This defaults to whatever is defined in TCA "ctrl"-section in the
     "languageField". Change it to overwrite the behaviour in your query.
@@ -275,8 +266,7 @@ includeRecordsWithoutDefaultTranslation
 
 ..  confval:: includeRecordsWithoutDefaultTranslation
     :name: select-includeRecordsWithoutDefaultTranslation
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
     :Default: 0
 
     If content language overlay is activated and the option :typoscript:`languageField` is not disabled,
@@ -291,8 +281,7 @@ selectFields
 
 ..  confval:: selectFields
     :name: select-selectFields
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
     :Default: \*
 
     List of fields to select, or :php:`count(*)`.
@@ -310,8 +299,7 @@ join, leftjoin, rightjoin
 
 ..  confval:: join, leftjoin, rightjoin
     :name: select-join
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Enter the JOIN clause without :sql:`JOIN`, :sql:`LEFT OUTER JOIN` and :sql:`RIGHT OUTER JOIN`
     respectively.
@@ -344,8 +332,7 @@ markers
 
 ..  confval:: markers
     :name: select-markers
-
-    :Data type: *(array of markers)*
+    :type: *(array of markers)*
 
     The markers defined in this section can be used, wrapped in the usual
     ###markername### way, in any other property of select. Each value is

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -28,8 +28,7 @@ token
 
 ..  confval:: token
     :name: split-token
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     String or character (token) used to split the value.
 
@@ -41,8 +40,7 @@ max
 
 ..  confval:: max
     :name: split-max
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Maximum number of splits.
 
@@ -54,8 +52,7 @@ min
 
 ..  confval:: min
     :name: split-min
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Minimum number of splits.
 
@@ -67,8 +64,7 @@ returnKey
 
 ..  confval:: returnKey
     :name: split-returnKey
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
 
     Instead of parsing the split result, return the element of the
     index with this number immediately and stop processing of the split
@@ -82,8 +78,7 @@ returnCount
 
 ..  confval:: returnCount
     :name: split-returnCount
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     Counts all elements resulting from the split, returns their number
     and stops processing of the split function.
@@ -109,8 +104,7 @@ cObjNum
 
 ..  confval:: cObjNum
     :name: split-cObjNum
-
-    :Data type: *cObjNum* + :ref:`optionsplit` / :ref:`stdwrap`
+    :type: *cObjNum* + :ref:`optionsplit` / :ref:`stdwrap`
 
     This is a pointer the array of this object ("1,2,3,4"), that should
     treat the items, resulting from the split.
@@ -123,8 +117,7 @@ cObjNum
 
 ..  confval:: 1,2,3,4,...
     :name: split-cObject
-
-    :Data type: :ref:`cObject <data-type-cobject>` / :ref:`stdwrap`
+    :type: :ref:`cObject <data-type-cobject>` / :ref:`stdwrap`
 
     The object that should treat the value.
 
@@ -157,8 +150,7 @@ wrap
 
 ..  confval:: wrap
     :name: split-wrap
-
-    :Data type: wrap + :ref:`optionsplit` / :ref:`stdwrap`
+    :type: wrap + :ref:`optionsplit` / :ref:`stdwrap`
 
     Defines a wrap for each item.
 

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -71,8 +71,7 @@ setContentToCurrent
 
 ..  confval:: setContentToCurrent
     :name: stdwrap-setContentToCurrent
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Sets the current value to the incoming content of the function.
 
@@ -83,8 +82,7 @@ addPageCacheTags
 
 ..  confval:: addPageCacheTags
     :name: stdwrap-addpagecachetags
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Comma-separated list of cache tags, which should be added to the page
     cache.
@@ -114,8 +112,7 @@ setCurrent
 
 ..  confval:: setCurrent
     :name: stdwrap-setCurrent
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Sets the "current"-value. This is normally set from some outside
     routine, so be careful with this. But it might be handy to do this
@@ -128,8 +125,7 @@ lang
 
 ..  confval:: lang
     :name: stdwrap-lang
-
-    :Data type: Array of language keys / :ref:`stdWrap`
+    :type: Array of language keys / :ref:`stdWrap`
 
     This is used to define optional language specific values based on the
     :ref:`current site language <t3coreapi:sitehandling-addingLanguages>`.
@@ -153,8 +149,7 @@ data
 
 ..  confval:: data
     :name: stdwrap-data
-
-    :Data type: :ref:`data-type-gettext` / :ref:`stdWrap`
+    :type: :ref:`data-type-gettext` / :ref:`stdWrap`
 
 
 ..  _stdwrap-field:
@@ -164,8 +159,7 @@ field
 
 ..  confval:: field
     :name: stdwrap-field
-
-    :Data type: Field name / :ref:`stdWrap`
+    :type: Field name / :ref:`stdWrap`
 
     Sets the content to the value of the according field
     (which comes from :php:`$cObj->data[*field*]`).
@@ -203,8 +197,7 @@ current
 
 ..  confval:: current
     :name: stdwrap-current
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Sets the content to the "current" value (see :ref:`->split <split>`)
 
@@ -216,8 +209,7 @@ cObject
 
 ..  confval:: cObject
     :name: stdwrap-cObject
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     Loads content from a content object.
 
@@ -229,8 +221,7 @@ numRows
 
 ..  confval:: numRows
     :name: stdwrap-numRows
-
-    :Data type: :ref:`->numRows <numrows>` / :ref:`stdWrap`
+    :type: :ref:`->numRows <numrows>` / :ref:`stdWrap`
 
     Returns the number of rows resulting from the supplied :sql:`SELECT` query.
 
@@ -242,8 +233,7 @@ preUserFunc
 
 ..  confval:: preUserFunc
     :name: stdwrap-preUserFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -269,8 +259,7 @@ override
 
 ..  confval:: override
     :name: stdwrap-override
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If `override` returns something else than "" or zero (trimmed), the
     content is loaded with this!
@@ -283,8 +272,7 @@ preIfEmptyListNum
 
 ..  confval:: preIfEmptyListNum
     :name: stdwrap-preIfEmptyListNum
-
-    :Data type: (as ":ref:`stdwrap-listNum`" below)
+    :type: (as ":ref:`stdwrap-listNum`" below)
 
 
 ..  _stdwrap-ifNull:
@@ -294,8 +282,7 @@ ifNull
 
 ..  confval:: ifNull
     :name: stdwrap-ifNull
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If the content is null (:php:`NULL` type in PHP), the content is overridden
     with the value defined here.
@@ -324,8 +311,7 @@ ifEmpty
 
 ..  confval:: ifEmpty
     :name: stdwrap-ifEmpty
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     If the trimmed content is empty at this point, the content is loaded
     with :typoscript:`ifEmpty`. Zeros are treated as empty values!
@@ -338,8 +324,7 @@ ifBlank
 
 ..  confval:: ifBlank
     :name: stdwrap-ifBlank
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Same as :typoscript:`ifEmpty` but the check is done against ''. Zeros are not
     treated as blank values!
@@ -352,8 +337,7 @@ listNum
 
 ..  confval:: listNum
     :name: stdwrap-listNum
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Explodes the current content :ref:`stdwrap-listNum-splitChar`
     (Default: `,`) and returns the object specified by `listNum`.
@@ -404,8 +388,7 @@ listNum.splitChar
 
 ..  confval:: listNum.splitChar
     :name: stdwrap-listNum-splitChar
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Default: `,` (comma)
 
     .. rubric:: Examples
@@ -434,8 +417,7 @@ trim
 
 ..  confval:: trim
     :name: stdwrap-trim
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     If set, the PHP-function :php:`trim()` will be used to remove whitespaces
     around the value.
@@ -448,8 +430,7 @@ strPad
 
 ..  confval:: strPad
     :name: stdwrap-strPad
-
-    :Data type: :ref:`strPad`
+    :type: :ref:`strPad`
 
     Pads the current content to a certain length. You can define the padding
     characters and the side(s), on which the padding should be added.
@@ -462,8 +443,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: stdwrap-stdWrap
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     Recursive call to the :typoscript:`stdWrap` function.
 
@@ -475,8 +455,7 @@ required
 
 ..  confval:: required
     :name: stdwrap-required
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     This flag requires the content to be set to some value after any
     content-import and treatment that might have happened until now
@@ -493,8 +472,7 @@ if
 
 ..  confval:: if
     :name: stdwrap-if
-
-    :Data type: :ref:`if`
+    :type: :ref:`if`
 
     If the if-object returns false, stdWrap returns "" immediately.
 
@@ -506,8 +484,7 @@ fieldRequired
 
 ..  confval:: fieldRequired
     :name: stdwrap-fieldRequired
-
-    :Data type: Field name / :ref:`stdWrap`
+    :type: Field name / :ref:`stdWrap`
 
     The value in this field **must** be set.
 
@@ -523,8 +500,7 @@ csConv
 
 ..  confval:: csConv
     :name: stdwrap-csConv
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Convert the charset of the string from the charset given as value to
     the current rendering charset of the frontend (UTF-8).
@@ -537,8 +513,7 @@ parseFunc
 
 ..  confval:: parseFunc
     :name: stdwrap-parseFunc
-
-    :Data type: object path reference / :ref:`parsefunc` / :ref:`stdWrap`
+    :type: object path reference / :ref:`parsefunc` / :ref:`stdWrap`
 
     Processing instructions for the content.
 
@@ -619,8 +594,7 @@ HTMLparser
 
 ..  confval:: HTMLparser
     :name: stdwrap-htmlparser
-
-    :Data type: :ref:`data-type-boolean` / :ref:`htmlparser` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`htmlparser` / :ref:`stdWrap`
 
     This object allows you to parse the HTML-content and perform all kinds of
     advanced filtering on the content.
@@ -637,8 +611,7 @@ split
 
 ..  confval:: split
     :name: stdwrap-split
-
-    :Data type: :ref:`split` / :ref:`stdWrap`
+    :type: :ref:`split` / :ref:`stdWrap`
 
 
 ..  _stdwrap-replacement:
@@ -648,8 +621,7 @@ replacement
 
 ..  confval:: replacement
     :name: stdwrap-replacement
-
-    :Data type: :ref:`replacement` / :ref:`stdWrap`
+    :type: :ref:`replacement` / :ref:`stdWrap`
 
     Performs an ordered search/replace on the current content with the
     possibility of using PCRE regular expressions. An array with numeric
@@ -664,8 +636,7 @@ prioriCalc
 
 ..  confval:: prioriCalc
     :name: stdwrap-prioriCalc
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Calculation of the value using operators -+\*/%^ plus respects
     priority to + and - operators and parenthesis levels ().
@@ -702,8 +673,7 @@ char
 
 ..  confval:: char
     :name: stdwrap-char
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap`
 
     Content is set to :php:`chr(*value*)`. This returns a one-character
     string containing the character specified by ascii code. Reliable
@@ -723,8 +693,7 @@ intval
 
 ..  confval:: intval
     :name: stdwrap-intval
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     PHP function :php:`intval()` returns an integer:
 
@@ -740,8 +709,7 @@ hash
 
 ..  confval:: hash
     :name: stdwrap-hash
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Returns a hashed value of the current content. Set to one of the
     algorithms which are available in PHP. For a list of supported
@@ -766,8 +734,7 @@ round
 
 ..  confval:: round
     :name: stdwrap-round
-
-    :Data type: :ref:`round` / :ref:`stdWrap`
+    :type: :ref:`round` / :ref:`stdWrap`
 
     Round the value with the selected method to the given number of
     decimals.
@@ -780,8 +747,7 @@ numberFormat
 
 ..  confval:: numberFormat
     :name: stdwrap-numberFormat
-
-    :Data type: :ref:`numberformat`
+    :type: :ref:`numberformat`
 
     Format a float value to any number format you need (e.g. useful for
     prices).
@@ -794,8 +760,7 @@ date
 
 ..  confval:: date
     :name: stdwrap-date
-
-    :Data type: :ref:`data-type-date-conf` / :ref:`stdWrap`
+    :type: :ref:`data-type-date-conf` / :ref:`stdWrap`
 
     The content should be data-type "UNIX-time". Returns the content
     formatted as a date. See the PHP manual (`datetime.format <https://www.php.net/manual/en/datetime.createfromformat.php>`_)
@@ -837,8 +802,7 @@ strtotime
 
 ..  confval:: strtotime
     :name: stdwrap-strtotime
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Allows conversion of formatted dates to timestamp, e.g. to perform date calculations.
 
@@ -873,8 +837,7 @@ strftime
 
 ..  confval:: strftime
     :name: stdwrap-strftime
-
-    :Data type: :ref:`data-type-strftime-conf` / :ref:`stdWrap`
+    :type: :ref:`data-type-strftime-conf` / :ref:`stdWrap`
 
     Very similar to "date", but using a different format. See the PHP manual (`strftime <https://www.php.net/strftime>`_) for the
     format codes.
@@ -908,8 +871,7 @@ formattedDate
 
 ..  confval:: formattedDate
     :name: stdwrap-formattedDate
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The function renders date and time based on formats/patterns defined by
     the International Components for Unicode standard (ICU). ICU-based date and
@@ -987,8 +949,7 @@ age
 
 ..  confval:: age
     :name: stdwrap-age
-
-    :Data type: :ref:`data-type-boolean` or :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` or :ref:`data-type-string` / :ref:`stdWrap`
 
     If enabled with a "1" (number, integer) the content is seen as a date
     (UNIX-time) and the difference from present time and the content-time
@@ -1029,8 +990,7 @@ case
 
 ..  confval:: case
     :name: stdwrap-case
-
-    :Data type: :ref:`data-type-case` / :ref:`stdWrap`
+    :type: :ref:`data-type-case` / :ref:`stdWrap`
 
     Converts case
 
@@ -1044,9 +1004,7 @@ bytes
 
 ..  confval:: bytes
     :name: stdwrap-bytes
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
-
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
     :Default: iec, 1024
 
     This is for number values. When the 'bytes' property is added and set
@@ -1213,8 +1171,7 @@ substring
 
 ..  confval:: substring
     :name: stdwrap-substring
-
-    :Data type: [p1], [p2] / :ref:`stdWrap`
+    :type: [p1], [p2] / :ref:`stdWrap`
 
     Returns the substring with [p1] and [p2] sent as the 2nd and 3rd
     parameter to the PHP `mb_substr <https://www.php.net/mb_substr>`__ function.
@@ -1229,8 +1186,7 @@ cropHTML
 
 ..  confval:: cropHTML
     :name: stdwrap-cropHTML
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Crops the content to a certain length. In contrast to :typoscript:`stdWrap.crop` it
     respects HTML tags. It does not crop inside tags and closes open tags.
@@ -1248,8 +1204,7 @@ stripHtml
 
 ..  confval:: stripHtml
     :name: stdwrap-stripHtml
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Strips all HTML tags.
 
@@ -1261,8 +1216,7 @@ crop
 
 ..  confval:: crop
     :name: stdwrap-crop
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Crops the content to a certain length.
 
@@ -1308,8 +1262,7 @@ rawUrlEncode
 
 ..  confval:: rawUrlEncode
     :name: stdwrap-rawUrlEncode
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Passes the content through the PHP function `rawurlencode() <https://www.php.net/rawurlencode>`_.
 
@@ -1321,8 +1274,7 @@ htmlSpecialChars
 
 ..  confval:: htmlSpecialChars
     :name: stdwrap-htmlSpecialChars
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Passes the content through the PHP function `htmlspecialchars() <https://www.php.net/htmlspecialchars>`_.
 
@@ -1337,8 +1289,7 @@ encodeForJavaScriptValue
 
 ..  confval:: encodeForJavaScriptValue
     :name: stdwrap-encodeForJavaScriptValue
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Encodes content to be used safely inside strings in JavaScript.
     Characters, which can cause problems inside JavaScript strings, are
@@ -1368,8 +1319,7 @@ doubleBrTag
 
 ..  confval:: doubleBrTag
     :name: stdwrap-doubleBrTag
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     All double line breaks are substituted with this value.
 
@@ -1381,8 +1331,7 @@ br
 
 ..  confval:: br
     :name: stdwrap-br
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Pass the value through the PHP function `nl2br() <https://www.php.net/nl2br>`__. This
     converts each line break to a :html:`<br />` or a :html:`<br>` tag depending on doctype.
@@ -1395,8 +1344,7 @@ brTag
 
 ..  confval:: brTag
     :name: stdwrap-brTag
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     All ASCII codes of "10" (line feed, LF) are substituted with the
     *value*, which has been provided in this property.
@@ -1409,8 +1357,7 @@ encapsLines
 
 ..  confval:: encapsLines
     :name: stdwrap-encapsLines
-
-    :Data type: :ref:`encapslines` / :ref:`stdWrap`
+    :type: :ref:`encapslines` / :ref:`stdWrap`
 
     Lets you split the content by :php:`chr(10)` and process each line
     independently. Used to format content made with the RTE.
@@ -1423,8 +1370,7 @@ keywords
 
 ..  confval:: keywords
     :name: stdwrap-keywords
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Splits the content by characters "," ";" and php:`chr(10)` (return), trims
     each value and returns a comma-separated list of the values.
@@ -1437,8 +1383,7 @@ innerWrap
 
 ..  confval:: innerWrap
     :name: stdwrap-innerWrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
     Wraps the content.
 
@@ -1450,8 +1395,7 @@ innerWrap2
 
 ..  confval:: innerWrap2
     :name: stdwrap-innerWrap2
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
     Same as :typoscript:`innerWrap` (but watch the order in which they are executed).
 
@@ -1463,8 +1407,7 @@ preCObject
 
 ..  confval:: preCObject
     :name: stdwrap-preCObject
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     :ref:`stdwrap-cObject` prepended the content.
 
@@ -1476,8 +1419,7 @@ postCObject
 
 ..  confval:: postCObject
     :name: stdwrap-postCObject
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     :ref:`stdwrap-cObject` appended the content.
 
@@ -1489,8 +1431,7 @@ wrapAlign
 
 ..  confval:: wrapAlign
     :name: stdwrap-wrapAlign
-
-    :Data type: :ref:`data-type-align` / :ref:`stdWrap`
+    :type: :ref:`data-type-align` / :ref:`stdWrap`
 
     Wraps content with :typoscript:`<div style=text-align:[*value*];"> | </div>`
     *if* align is set.
@@ -1503,8 +1444,7 @@ typolink
 
 ..  confval:: typolink
     :name: stdwrap-typolink
-
-    :Data type: :ref:`typolink` / :ref:`stdWrap`
+    :type: :ref:`typolink` / :ref:`stdWrap`
 
     Wraps the content with a link tag.
 
@@ -1516,8 +1456,7 @@ wrap
 
 ..  confval:: wrap
     :name: stdwrap-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
     :typoscript:`splitChar` defines an alternative splitting character (default is "\|"
     - the vertical line)
@@ -1529,8 +1468,7 @@ noTrimWrap
 
 ..  confval:: noTrimWrap
     :name: stdwrap-noTrimWrap
-
-    :Data type: "special" wrap /+.splitChar / :ref:`stdWrap`
+    :type: "special" wrap /+.splitChar / :ref:`stdWrap`
 
     This wraps the content *without* trimming the values. That means that
     surrounding whitespaces stay included! Note that this kind of wrap
@@ -1577,8 +1515,7 @@ wrap2
 
 ..  confval:: wrap2
     :name: stdwrap-wrap2
-
-    :Data type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
     same as :ref:`stdwrap-wrap` (but watch the order in which they are executed)
 
@@ -1590,8 +1527,7 @@ dataWrap
 
 ..  confval:: dataWrap
     :name: stdwrap-dataWrap
-
-    :Data type: mixed / :ref:`stdWrap`
+    :type: mixed / :ref:`stdWrap`
 
     The content is parsed for pairs of curly braces. The content of the
     curly braces is of the type :ref:`data-type-gettext` and is substituted with the result
@@ -1615,8 +1551,7 @@ prepend
 
 ..  confval:: prepend
     :name: stdwrap-prepend
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     :ref:`stdwrap-cObject` prepended to content (before)
 
@@ -1628,8 +1563,7 @@ append
 
 ..  confval:: append
     :name: stdwrap-append
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     :ref:`stdwrap-cObject` appended to content (after)
 
@@ -1641,8 +1575,7 @@ wrap3
 
 ..  confval:: wrap3
     :name: stdwrap-wrap3
-
-    :Data type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` /+.splitChar / :ref:`stdWrap`
 
     same as :typoscript:`wrap` (but watch the order in which they are executed)
 
@@ -1654,8 +1587,7 @@ orderedStdWrap
 
 ..  confval:: orderedStdWrap
     :name: stdwrap-orderedStdWrap
-
-    :Data type: Array of numeric keys with / :ref:`stdWrap` each
+    :type: Array of numeric keys with / :ref:`stdWrap` each
 
     Execute multiple :typoscript:`stdWrap` statements in a freely selectable order. The order
     is determined by the numeric order of the keys. This allows to use multiple
@@ -1694,8 +1626,7 @@ outerWrap
 
 ..  confval:: outerWrap
     :name: stdwrap-outerWrap
-
-    :Data type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
+    :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
     Wraps the complete content
 
@@ -1707,8 +1638,7 @@ insertData
 
 ..  confval:: insertData
     :name: stdwrap-insertData
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     If set, then the content string is parsed like :typoscript:`dataWrap` above.
 
@@ -1741,8 +1671,7 @@ postUserFunc
 
 ..  confval:: postUserFunc
     :name: stdwrap-postUserFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -1849,8 +1778,7 @@ postUserFuncInt
 
 ..  confval:: postUserFuncInt
     :name: stdwrap-postUserFuncInt
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     Calls the provided PHP function. If you specify the name with a '->'
     in it, then it is interpreted as a call to a method in a class.
@@ -1874,8 +1802,7 @@ prefixComment
 
 ..  confval:: prefixComment
     :name: stdwrap-prefixComment
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap`
+    :type: :ref:`data-type-string` / :ref:`stdWrap`
 
     Prefixes content with an HTML comment with the second part of input
     string (divided by "\|") where first part is an integer telling how
@@ -1900,8 +1827,7 @@ htmlSanitize
 
 ..  confval:: htmlSanitize
     :name: stdwrap-htmlSanitize
-
-    :Data type: :ref:`data-type-boolean` / array with key "build"
+    :type: :ref:`data-type-boolean` / array with key "build"
 
     The property controls the sanitization and removal of XSS from markup. It
     strips tags, attributes and values that are not explicitly allowed.
@@ -1956,8 +1882,7 @@ cache
 
 ..  confval:: cache
     :name: stdwrap-cache
-
-    :Data type: :ref:`cache`
+    :type: :ref:`cache`
 
     Caches rendered content in the caching framework.
 
@@ -1969,8 +1894,7 @@ debug
 
 ..  confval:: debug
     :name: stdwrap-debug
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints content with :php:`HTMLSpecialChars()` and :html:`<pre></pre>`:
     Useful for debugging which value :typoscript:`stdWrap` actually ends up with,
@@ -1988,8 +1912,7 @@ debugFunc
 
 ..  confval:: debugFunc
     :name: stdwrap-debugFunc
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints the content directly to browser with the :php:`debug()` function.
 
@@ -2007,8 +1930,7 @@ debugData
 
 ..  confval:: debugData
     :name: stdwrap-debugData
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap`
 
     Prints the current data-array, :php:`$cObj->data`, directly to browser. This
     is where :typoscript:`field` gets data from.

--- a/Documentation/Functions/Strpad.rst
+++ b/Documentation/Functions/Strpad.rst
@@ -27,9 +27,7 @@ length
 
 ..  confval:: length
     :name: strpad-length
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-integer` / :ref:`stdwrap`
     :Default: 0
 
     The length of the output string. If the value is negative, less
@@ -43,8 +41,7 @@ padWith
 
 ..  confval:: padWith
     :name: strpad-padWith
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
     :Default: (space character)
 
 
@@ -62,8 +59,7 @@ type
 
 ..  confval:: type
     :name: strpad-type
-
-    :Data type: *(list of keywords)* / :ref:`stdwrap`
+    :type: *(list of keywords)* / :ref:`stdwrap`
     :Default: right
 
 

--- a/Documentation/Functions/Tags.rst
+++ b/Documentation/Functions/Tags.rst
@@ -27,8 +27,7 @@ Properties
 
 ..  confval:: array of strings
     :name: tags-array
-
-    :Data type: :ref:`data-type-cobject`
+    :type: :ref:`data-type-cobject`
 
     Every entry in the array of strings corresponds to a tag, that will
     be parsed. The elements **must** be in lowercase.

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -35,9 +35,7 @@ extTarget
 
 ..  confval:: extTarget
     :name: typolink-extTarget
-
-    :Data type: :ref:`data-type-target` / :ref:`stdwrap`
-
+    :type: :ref:`data-type-target` / :ref:`stdwrap`
     :Default: `_top`
 
     Target used for external links
@@ -50,8 +48,7 @@ fileTarget
 
 ..  confval:: fileTarget
     :name: typolink-fileTarget
-
-    :Data type: :ref:`data-type-target` / :ref:`stdwrap`
+    :type: :ref:`data-type-target` / :ref:`stdwrap`
 
     Target used for file links
 
@@ -63,8 +60,7 @@ language
 
 ..  confval:: language
     :name: typolink-language
-
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
 
     Language uid for link target
 
@@ -91,8 +87,7 @@ target
 
 ..  confval:: target
     :name: typolink-target
-
-    :Data type: :ref:`data-type-target` / :ref:`stdwrap`
+    :type: :ref:`data-type-target` / :ref:`stdwrap`
 
     Target used for internal links
 
@@ -104,8 +99,7 @@ no\_cache
 
 ..  confval:: no_cache
     :name: typolink-no-cache
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdwrap`
+    :type: :ref:`data-type-boolean` / :ref:`stdwrap`
 
     Adds `&no_cache=1` to the link
 
@@ -117,8 +111,7 @@ additionalParams
 
 ..  confval:: additionalParams
     :name: _typolink-additionalParams
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     This is parameters that are added to the end of the URL. This must be
     code ready to insert after the last parameter.
@@ -152,8 +145,7 @@ addQueryString
 
 ..  confval:: addQueryString
     :name: typolink-addQueryString
-
-    :Data type: :ref:`data-type-boolean` / :ref:`data-type-string`
+    :type: :ref:`data-type-boolean` / :ref:`data-type-string`
 
     Add the current query string to the start of the link.
 
@@ -200,8 +192,7 @@ addQueryString.exclude
 
 ..  confval:: addQueryString.exclude
     :name: typolink-addQueryString-exclude
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     List of query arguments to exclude from the link. Typical examples are
     :typoscript:`L` or :typoscript:`cHash`.
@@ -228,8 +219,7 @@ wrap
 
 ..  confval:: wrap
     :name: typolink-wrap
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdwrap`
+    :type: :ref:`data-type-wrap` / :ref:`stdwrap`
 
     Wraps the links.
 
@@ -241,8 +231,7 @@ ATagBeforeWrap
 
 ..  confval:: ATagBeforeWrap
     :name: typolink-ATagBeforeWrap
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 0
 
     If set, the link is first wrapped with :typoscript:`wrap` and then the
@@ -256,8 +245,7 @@ parameter
 
 ..  confval:: parameter
     :name: typolink-parameter
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     This is the main data that is used for creating the link. It can be
     the id of a page, the URL of some external page, an email address or
@@ -398,9 +386,7 @@ forceAbsoluteUrl
 
 ..  confval:: forceAbsoluteUrl
     :name: typolink-forceAbsoluteUrl
-
-    :Data type: :ref:`data-type-boolean`
-
+    :type: :ref:`data-type-boolean`
     :Default: :php:`false`
 
     Forces links to internal pages to be absolute, thus having a proper
@@ -420,8 +406,7 @@ forceAbsoluteUrl.scheme
 
 ..  confval:: forceAbsoluteUrl.scheme
     :name: typolink-forceAbsoluteUrl-scheme
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     :Values: :php:`http` / :php:`https`
     :Default: :php:`http`
@@ -446,8 +431,7 @@ title
 
 ..  confval:: title
     :name: typolink-title
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     Sets the title parameter of the A-tag.
 
@@ -459,8 +443,7 @@ JSwindow\_params
 
 ..  confval:: JSwindow_params
     :name: typolink-JSwindow-params
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Preset values for opening the window. This example lists almost all
     possible attributes:
@@ -478,8 +461,7 @@ returnLast
 
 ..  confval:: returnLast
     :name: typolink-returnLast
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If set to "url", then it will return the URL of the link
     (:php:`$this->lastTypoLinkUrl`).
@@ -511,8 +493,7 @@ section
 
 ..  confval:: section
     :name: typolink-section
-
-    :Data type: :ref:`data-type-string` / :ref:`stdwrap`
+    :type: :ref:`data-type-string` / :ref:`stdwrap`
 
     If this value is present, it's prepended with a "#" and placed after
     any internal URL to another page in TYPO3.
@@ -528,8 +509,7 @@ ATagParams
 
 ..  confval:: ATagParams
     :name: typolink-ATagParams
-
-    :Data type: <A>-params / :ref:`stdwrap`
+    :type: <A>-params / :ref:`stdwrap`
 
     Additional parameters
 
@@ -548,8 +528,7 @@ linkAccessRestrictedPages
 
 ..  confval:: linkAccessRestrictedPages
     :name: typolink-linkAccessRestrictedPages
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, typolinks pointing to access restricted pages will still link
     to the page even though the page cannot be accessed.
@@ -562,8 +541,7 @@ userFunc
 
 ..  confval:: userFunc
     :name: typolink-userFunc
-
-    :Data type: :ref:`data-type-function-name`
+    :type: :ref:`data-type-function-name`
 
     This passes the link-data compiled by the typolink function to a user-
     defined function for final manipulation.
@@ -649,8 +627,7 @@ page
 
 ..  confval:: page
     :name: typolink-handler-page
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/PageLinkHandler.php`
     :Example:  `t3://page?uid=42&type=3`
 
@@ -663,8 +640,7 @@ page.uid
 
 ..  confval:: page.uid
     :name: typolink-handler-page-uid
-
-    :Data Type: :ref:`data-type-integer` / :ref:`data-type-string`
+    :type: :ref:`data-type-integer` / :ref:`data-type-string`
     :Example:  `t3://page?uid=13`
 
     The UID (field :sql:`uid`) of a page record, or "current" to reference
@@ -680,8 +656,7 @@ page.alias
 
 ..  confval:: page.alias
     :name: typolink-handler-page-alias
-
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Example: `t3://page?alias=myfunkyalias`
 
     The alias (field :sql:`alias`) of a page record (as an alternative to
@@ -694,8 +669,7 @@ page.type
 
 ..  confval:: page.type
     :name: typolink-handler-page-type
-
-    :Data Type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Default: 0
     :Example: `t3://page?uid=13&type=3`
 
@@ -709,8 +683,7 @@ page.parameters
 
 ..  confval:: page.parameters
     :name: typolink-handler-page-parameters
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Example: `t3://page?uid=1313&my=param&will=get&added=here`
 
     String of parameters, prefixed with `&`, to be added to the URL.
@@ -722,8 +695,7 @@ page.fragment
 
 ..  confval:: page.fragment
     :name: typolink-handler-page-fragment
-
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Example: `t3://page?uid=13&type=3#123`
 
     The anchor or section to jump to. Must be prefixed with `#`.
@@ -737,8 +709,7 @@ file
 
 ..  confval:: file
     :name: typolink-handler-file
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/FileLinkHandler.php`
     :Example:  `t3://file?uid=13`
 
@@ -751,8 +722,7 @@ file.uid
 
 ..  confval:: file.uid
     :name: typolink-handler-file-uid
-
-    :Data Type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Example:  `t3://file?uid=13`
 
     The UID of a file within the file abstraction layer (FAL) database table
@@ -765,8 +735,7 @@ file.identifier
 
 ..  confval:: file.identifier
     :name: typolink-handler-file-identifier
-
-    :Data Type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Example: `t3://file?identifier=fileadmin/path/myfile.jpg`
 
     The identifier of a file using combined `<storage>:<path>` reference or a direct
@@ -791,8 +760,7 @@ folder
 
 ..  confval:: folder
     :name: typolink-handler-folder
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/FolderLinkHandler.php`
     :Example:  `t3://folder?storage=1&identifier=myfolder`
 
@@ -805,8 +773,7 @@ folder.identifier
 
 ..  confval:: folder.identifier
     :name: typolink-handler-folder-identifier
-
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Example:  `t3://folder?identifier=fileadmin`
 
     The identifier of a given folder.
@@ -818,8 +785,7 @@ folder.storage
 
 ..  confval:: folder.storage
     :name: typolink-handler-folder-storage
-
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Example: `t3://folder?storage=1&identifier=myfolder`
     :Default: 0
 
@@ -833,8 +799,7 @@ email
 
 ..  confval:: email
     :name: typolink-handler-email
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/EmailLinkHandler.php`
     :Example:  `t3://email?email=mailto:user@example.org`
 
@@ -848,8 +813,7 @@ url
 
 ..  confval:: url
     :name: typolink-handler-url
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/EmailLinkHandler.php`
     :Example:  `t3://url?url=example.org`
 
@@ -874,8 +838,7 @@ record
 
 ..  confval:: record
     :name: typolink-handler-record
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/RecordLinkHandler.php`
     :Example: `t3://record?identifier=my_content&uid=123`
 
@@ -894,8 +857,7 @@ record.identifier
 
 ..  confval:: record.identifier
     :name: typolink-handler-record-identifier
-
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The (individual) identifier of the link building configuration to be used.
 
@@ -910,8 +872,7 @@ record.uid
 
 ..  confval:: record.uid
     :name: typolink-handler-record-uid
-
-    :Data Type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
 
     The UID of the referenced record to be linked.
 
@@ -924,8 +885,7 @@ phone
 
 ..  confval:: phone
     :name: typolink-handler-phone
-
-    :Data Type: string of parameters
+    :type: string of parameters
     :Implementation: :t3src:`core/Classes/LinkHandling/TelephoneLinkHandler.php`
     :Example:  `t3://phone?phone=tel:+4912345678`
 

--- a/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
@@ -38,8 +38,7 @@ inputLevels
 
 ..  confval:: inputLevels
     :name: gifbuilder-adjust-inputLevels
-
-    :Data type: low, high (int<0,255>, int<0, 255>)
+    :type: low, high (int<0,255>, int<0, 255>)
 
     With this option you can remap the tone of the image to make shadows
     darker, highlights lighter and increase contrast.
@@ -70,8 +69,7 @@ outputLevels
 
 ..  confval:: outputLevels
     :name: gifbuilder-adjust-outputLevels
-
-    :Data type: low, high (int<0,255>, int<0, 255>)
+    :type: low, high (int<0,255>, int<0, 255>)
 
     With this option you can remap the tone of the image to make shadows
     lighter, highlights darker and decrease contrast.

--- a/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
@@ -44,8 +44,7 @@ align
 
 ..  confval:: align
     :name: gifbuilder-box-align
-
-    :Data type: VHalign / :ref:`stdWrap <stdwrap>`
+    :type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: l, t
 
     Pair of values, which defines the horizontal and vertical alignment of
@@ -92,8 +91,7 @@ color
 
 ..  confval:: color
     :name: gifbuilder-box-color
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the box.
@@ -106,8 +104,7 @@ dimensions
 
 ..  confval:: dimensions
     :name: gifbuilder-box-dimensions
-
-    :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Dimensions of a filled box.
 
@@ -124,8 +121,7 @@ opacity
 
 ..  confval:: opacity
     :name: gifbuilder-box-opacity
-
-    :Data type: positive integer (1-100) / :ref:`stdWrap <stdwrap>`
+    :type: positive integer (1-100) / :ref:`stdWrap <stdwrap>`
     :Default: 100
 
     The degree to which the box conceals the background.

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -25,8 +25,7 @@ align
 
 ..  confval:: align
     :name: gifbuilder-crop-align
-
-    :Data type: VHalign / :ref:`stdWrap <stdwrap>`
+    :type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: l, t
 
     Pair of values, which defines the horizontal and vertical alignment of
@@ -73,8 +72,7 @@ backColor
 
 ..  confval:: backColor
     :name: gifbuilder-crop-backColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: The original background color
 
     Background color.
@@ -86,8 +84,7 @@ crop
 
 ..  confval:: crop
     :name: gifbuilder-crop-crop
-
-    :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` /:ref:`stdWrap <stdwrap>`
+    :type: x,y,w,h :ref:`+calc <gifbuilder-calc>` /:ref:`stdWrap <stdwrap>`
 
     x,y is the offset of the crop frame from the position specified by
     :ref:`align <gifbuilder-crop-align>`.

--- a/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
@@ -65,8 +65,7 @@ blur
 
 ..  confval:: blur
     :name: gifbuilder-effect-blur
-
-    :Data type: integer (1-99)
+    :type: integer (1-99)
     :Default: 0
 
     Blurs the edges inside the image.
@@ -87,8 +86,7 @@ charcoal
 
 ..  confval:: charcoal
     :name: gifbuilder-effect-charcoal
-
-    :Data type: integer (0-100)
+    :type: integer (0-100)
     :Default: 0
 
     Makes the image look as if it has been drawn with charcoal and defines
@@ -110,8 +108,7 @@ colors
 
 ..  confval:: colors
     :name: gifbuilder-effect-colors
-
-    :Data type: integer (2-255)
+    :type: integer (2-255)
 
     Defines the number of different colors to use in the image.
 
@@ -131,8 +128,7 @@ edge
 
 ..  confval:: edge
     :name: gifbuilder-effect-edge
-
-    :Data type: integer (0-99)
+    :type: integer (0-99)
     :Default: 0
 
     Detect edges within an image. This is a gray-scale operator, so it is
@@ -213,8 +209,7 @@ gamma
 
 ..  confval:: gamma
     :name: gifbuilder-effect-gamma
-
-    :Data type: double (0.5 - 3.0)
+    :type: double (0.5 - 3.0)
     :Default: 1.0
 
     Sets the `gamma <https://en.wikipedia.org/wiki/Gamma_correction>`__ value.
@@ -276,8 +271,7 @@ rotate
 
 ..  confval:: rotate
     :name: gifbuilder-effect-rotate
-
-    :Data type: integer (0-360)
+    :type: integer (0-360)
     :Default: 0
 
     Number of degrees for a clockwise rotation.
@@ -301,8 +295,7 @@ sharpen
 
 ..  confval:: sharpen
     :name: gifbuilder-effect-sharpen
-
-    :Data type: integer (0-99)
+    :type: integer (0-99)
     :Default: 0
 
     Sharpens the edges inside the image.
@@ -323,8 +316,7 @@ shear
 
 ..  confval:: shear
     :name: gifbuilder-effect-shear
-
-    :Data type: integer (-90 - 90)
+    :type: integer (-90 - 90)
     :Default: 0
 
     Number of degrees for a horizontal shearing. Horizontal shearing
@@ -348,8 +340,7 @@ solarize
 
 ..  confval:: solarize
     :name: gifbuilder-effect-solarize
-
-    :Data type: integer (0-99)
+    :type: integer (0-99)
     :Default: 0
 
     Color reduction, "burning" the brightest colors black. The brighter the
@@ -374,8 +365,7 @@ swirl
 
 ..  confval:: swirl
     :name: gifbuilder-effect-swirl
-
-    :Data type: integer (0-1000)
+    :type: integer (0-1000)
     :Default: 0
 
     The image is swirled or spun from its center.
@@ -396,8 +386,7 @@ wave
 
 ..  confval:: wave
     :name: gifbuilder-effect-wave
-
-    :Data type: integer,integer (both 0-99)
+    :type: integer,integer (both 0-99)
     :Default: 0,0
 
     Provide values for the amplitude and the length of a wave, separated by

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -42,8 +42,7 @@ color
 
 ..  confval:: color
     :name: gifbuilder-ellipse-color
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     Fill color of the ellipse.
@@ -56,8 +55,7 @@ dimensions
 
 ..  confval:: dimensions
     :name: gifbuilder-ellipse-dimensions
-
-    :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Dimensions of a filled ellipse.
 

--- a/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Emboss/Index.rst
@@ -26,8 +26,7 @@ blur
 
 ..  confval:: blur
     :name: gifbuilder-emboss-blur
-
-    :Data type: integer (1-99) / :ref:`stdWrap <stdwrap>`
+    :type: integer (1-99) / :ref:`stdWrap <stdwrap>`
 
     Blurring of the shadow. Above 40 only values of 40, 50, 60, 70, 80, 90
     are relevant.
@@ -40,8 +39,7 @@ highColor
 
 ..  confval:: highColor
     :name: gifbuilder-emboss-highColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Upper border color.
 
@@ -53,8 +51,7 @@ intensity
 
 ..  confval:: intensity
     :name: gifbuilder-emboss-intensity
-
-    :Data type: integer (0-100) / :ref:`stdWrap <stdwrap>`
+    :type: integer (0-100) / :ref:`stdWrap <stdwrap>`
 
     How "massive" the emboss is. This value can - if it has a high value
     combined with a blurred shadow - create a kind of soft-edged outline.
@@ -67,8 +64,7 @@ lowColor
 
 ..  confval:: lowColor
     :name: gifbuilder-emboss-lowColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Lower border color.
 
@@ -80,8 +76,7 @@ opacity
 
 ..  confval:: opacity
     :name: gifbuilder-emboss-opacity
-
-    :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
+    :type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
     The degree to which the shadow conceals the background. Mathematically
     speaking: Opacity = Transparency^-1. For example, 100% opacity = 0%
@@ -97,8 +92,7 @@ offset
 
 ..  confval:: offset
     :name: gifbuilder-emboss-offset
-
-    :Data type: x,y / :ref:`stdWrap <stdwrap>`
+    :type: x,y / :ref:`stdWrap <stdwrap>`
 
     Offset of the emboss.
 
@@ -110,8 +104,7 @@ textObjNum
 
 ..  confval:: textObjNum
     :name: _gifbuilder-emboss-textObjNum
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Must point to the :ref:`TEXT <gifbuilder-text>` object, if these
     :typoscript:`EMBOSS` properties are not properties to a TEXT object directly

--- a/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
@@ -24,8 +24,7 @@ align
 
 ..  confval:: align
     :name: gifbuilder-image-align
-
-    :Data type: VHalign / :ref:`stdWrap <stdwrap>`
+    :type: VHalign / :ref:`stdWrap <stdwrap>`
     :Default: 1,1
 
     Pair of values, which defines the horizontal and vertical alignment of
@@ -72,8 +71,7 @@ file
 
 ..  confval:: file
     :name: gifbuilder-image-file
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     The image file.
 
@@ -85,8 +83,7 @@ mask
 
 ..  confval:: mask
     :name: gifbuilder-image-mask
-
-    :Data type: :ref:`data-type-imgResource`
+    :type: :ref:`data-type-imgResource`
 
     Optional mask image for the image file.
 
@@ -98,8 +95,7 @@ offset
 
 ..  confval:: offset
     :name: gifbuilder-image-offset
-
-    :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
 
     Offset of the image.
@@ -112,8 +108,7 @@ tile
 
 ..  confval:: tile
     :name: gifbuilder-image-tile
-
-    :Data type: x,y / :ref:`stdWrap <stdwrap>`
+    :type: x,y / :ref:`stdWrap <stdwrap>`
     :Default: 1,1
 
     Repeat the image x,y times (which creates the look of tiles).

--- a/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Outline/Index.rst
@@ -30,8 +30,7 @@ color
 
 ..  confval:: color
     :name: gifbuilder-outline-color
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Color of the outline.
 
@@ -43,8 +42,7 @@ textObjNum
 
 ..  confval:: textObjNum
     :name: gifbuilder-outline-textObjNum
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Must point to the :ref:`TEXT <gifbuilder-text>` object, if these outline
     properties are not properties to a TEXT object directly ("stand-alone
@@ -62,7 +60,6 @@ thickness
 
 ..  confval:: thickness
     :name: gifbuilder-outline-thickness
-
-    :Data type: x,y / :ref:`stdWrap <stdwrap>`
+    :type: x,y / :ref:`stdWrap <stdwrap>`
 
     Thickness in each direction, range 1-2.

--- a/Documentation/Gifbuilder/ObjectNames/Scale/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Scale/Index.rst
@@ -28,8 +28,7 @@ height
 
 ..  confval:: height
     :name: gifbuilder-scale-height
-
-    :Data type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Height of the scaled image.
 
@@ -41,8 +40,7 @@ params
 
 ..  confval:: params
     :name: gifbuilder-scale-params
-
-    :Data type: GraphicsMagick/ImageMagick parameters
+    :type: GraphicsMagick/ImageMagick parameters
 
     Parameters to be used for the processing.
 
@@ -54,7 +52,6 @@ width
 
 ..  confval:: width
     :name: gifbuilder-scale-width
-
-    :Data type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: pixels :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Width of the scaled image.

--- a/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Shadow/Index.rst
@@ -24,8 +24,7 @@ blur
 
 ..  confval:: blur
     :name: gifbuilder-shadow-blur
-
-    :Data type: integer (1-99) / :ref:`stdWrap <stdwrap>`
+    :type: integer (1-99) / :ref:`stdWrap <stdwrap>`
 
     Blurring of the shadow. Above 40 only values of 40,50,60,70,80,90
     are relevant.
@@ -38,8 +37,7 @@ color
 
 ..  confval:: color
     :name: gifbuilder-shadow-color
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     The color of the shadow.
 
@@ -51,8 +49,7 @@ intensity
 
 ..  confval:: intensity
     :name: gifbuilder-shadow-intensity
-
-    :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
+    :type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
     How "massive" the shadow is. This value can - if it has a high value
     combined with a blurred shadow - create a kind of soft-edged outline.
@@ -65,8 +62,7 @@ offset
 
 ..  confval:: offset
     :name: gifbuilder-shadow-offset
-
-    :Data type: x,y / :ref:`stdWrap <stdwrap>`
+    :type: x,y / :ref:`stdWrap <stdwrap>`
 
     The offset of the shadow.
 
@@ -78,8 +74,7 @@ opacity
 
 ..  confval:: opacity
     :name: gifbuilder-shadow-opacity
-
-    :Data type: integer (1-100) / :ref:`stdWrap <stdwrap>`
+    :type: integer (1-100) / :ref:`stdWrap <stdwrap>`
 
     The degree to which the shadow conceals the background. Mathematically
     speaking: Opacity = Transparency^-1. E.g. 100% opacity = 0%
@@ -95,8 +90,7 @@ textObjNum
 
 ..  confval:: textObjNum
     :name: gifbuilder-shadow-textObjNum
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Must point to the :ref:`TEXT <gifbuilder-text>` object, if these shadow
     properties are not properties to a TEXT object directly ("stand-alone

--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -24,8 +24,7 @@ align
 
 ..  confval:: align
     :name: gifbuilder-text-align
-
-    :Data type: align / :ref:`stdWrap <stdwrap>`
+    :type: align / :ref:`stdWrap <stdwrap>`
     :Default: left
 
     The alignment of the :ref:`gifbuilder-text-text`.
@@ -44,8 +43,7 @@ angle
 
 ..  confval:: angle
     :name: gifbuilder-text-angle
-
-    :Data type: :ref:`data-type-degree`
+    :type: :ref:`data-type-degree`
     :Default: 0
     :Range: -90 to 90
 
@@ -63,8 +61,7 @@ antiAlias
 
 ..  confval:: antiAlias
     :name: gifbuilder-text-antiAlias
-
-    :Data type: boolean
+    :type: boolean
     :Default: 1 (true)
 
     The FreeType antialiasing.
@@ -84,8 +81,7 @@ breakSpace
 
 ..  confval:: breakSpace
     :name: gifbuilder-text-breakSpace
-
-    :Data type: float
+    :type: float
     :Default: 1.0
 
     Defines a value that is multiplied by the line height of the current
@@ -99,8 +95,7 @@ breakWidth
 
 ..  confval:: breakWidth
     :name: gifbuilder-text-breakWidth
-
-    :Data type: integer / :ref:`stdWrap <stdwrap>`
+    :type: integer / :ref:`stdWrap <stdwrap>`
 
     Defines the maximum width for an object, overlapping elements will
     force an automatic line break.
@@ -113,8 +108,7 @@ doNotStripHTML
 
 ..  confval:: doNotStripHTML
     :name: gifbuilder-text-doNotStripHTML
-
-    :Data type: boolean
+    :type: boolean
     :Default: 0 (false)
 
     If set, HTML tags inserted in the :ref:`gifbuilder-text-text` are
@@ -128,8 +122,7 @@ emboss
 
 ..  confval:: emboss
     :name: gifbuilder-text-emboss
-
-    :Data type: GIFBUILDER object :ref:`->EMBOSS <gifbuilder-emboss>`
+    :type: GIFBUILDER object :ref:`->EMBOSS <gifbuilder-emboss>`
 
 
 ..  _gifbuilder-text-fontColor:
@@ -139,8 +132,7 @@ fontColor
 
 ..  confval:: fontColor
     :name: gifbuilder-text-fontColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: black
 
     The font color.
@@ -153,8 +145,7 @@ fontFile
 
 ..  confval:: fontFile
     :name: gifbuilder-text-fontFile
-
-    :Data type: resource / :ref:`stdWrap <stdwrap>`
+    :type: resource / :ref:`stdWrap <stdwrap>`
     :Default: Nimbus (Arial clone)
 
     The font face (TrueType :file:`*.ttf` and OpenType :file:`*.otf` fonts can be
@@ -168,8 +159,7 @@ fontSize
 
 ..  confval:: fontSize
     :name: gifbuilder-text-fontSize
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 12
 
     The font size.
@@ -182,8 +172,7 @@ hide
 
 ..  confval:: hide
     :name: gifbuilder-text-hide
-
-    :Data type: boolean / :ref:`stdWrap <stdwrap>`
+    :type: boolean / :ref:`stdWrap <stdwrap>`
     :Default: 0 (false)
 
     If this is true, the text is **not** printed.
@@ -200,8 +189,7 @@ iterations
 
 ..  confval:: iterations
     :name: gifbuilder-text-iterations
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 1
 
     How many times the :ref:`gifbuilder-text-text` should be "printed"
@@ -219,8 +207,7 @@ maxWidth
 
 ..  confval:: maxWidth
     :name: gifbuilder-text-maxWidth
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Sets the maximum width in pixels, the :ref:`gifbuilder-text-text`
     must be. Reduces the :ref:`gifbuilder-text-fontSize`, if the
@@ -237,8 +224,7 @@ niceText
 
 ..  confval:: niceText
     :name: gifbuilder-text-niceText
-
-    :Data type: boolean / :ref:`stdWrap <stdwrap>`
+    :type: boolean / :ref:`stdWrap <stdwrap>`
 
     This is a very popular feature that helps to render small letters much nicer
     than the FreeType library can normally do. But it also loads the system
@@ -285,8 +271,7 @@ scaleFactor
 
 ..  confval:: niceText.scaleFactor
     :name: gifbuilder-text-niceText-scaleFactor
-
-    :Data type: integer (2-5)
+    :type: integer (2-5)
 
     The scaling factor.
 
@@ -298,8 +283,7 @@ sharpen
 
 ..  confval:: niceText.sharpen
     :name: gifbuilder-text-niceText-sharpen
-
-    :Data type: integer (0-99)
+    :type: integer (0-99)
 
     The sharpen value for the mask (after scaling). This enables you to make the
     text crisper, if it is too blurred!
@@ -312,8 +296,7 @@ offset
 
 ..  confval:: offset
     :name: gifbuilder-text-offset
-
-    :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
 
     The offset of the :ref:`gifbuilder-text-text`.
@@ -326,8 +309,7 @@ outline
 
 ..  confval:: outline
     :name: gifbuilder-text-outline
-
-    :Data type: GIFBUILDER object :ref:`->OUTLINE <gifbuilder-outline>`
+    :type: GIFBUILDER object :ref:`->OUTLINE <gifbuilder-outline>`
 
 
 ..  _gifbuilder-text-shadow:
@@ -337,8 +319,7 @@ shadow
 
 ..  confval:: shadow
     :name: gifbuilder-text-shadow
-
-    :Data type: GIFBUILDER object :ref:`->SHADOW <gifbuilder-shadow>`
+    :type: GIFBUILDER object :ref:`->SHADOW <gifbuilder-shadow>`
 
 
 ..  _gifbuilder-text-spacing:
@@ -348,8 +329,7 @@ spacing
 
 ..  confval:: spacing
     :name: gifbuilder-text-spacing
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     The pixel distance between letters. This may render ugly!
@@ -362,8 +342,7 @@ splitRendering
 
 ..  confval:: splitRendering
     :name: gifbuilder-text-splitRendering
-
-    :Data type: integer / *(array of keys)*
+    :type: integer / *(array of keys)*
 
     Split the rendering of a string into separate processes with individual
     configurations. By this method a certain range of characters can be rendered
@@ -384,8 +363,7 @@ splitRendering
 
 ..  confval:: splitRendering.[array]
     :name: gifbuilder-text-splitRendering-array
-
-    :Data type: integer
+    :type: integer
 
     With keyword being [charRange, highlightWord].
 
@@ -469,8 +447,7 @@ compX
 
 ..  confval:: splitRendering.compX
     :name: gifbuilder-text-splitRendering-compX
-
-    :Data type: integer
+    :type: integer
 
     Additional pixel space between parts, x direction.
 
@@ -482,8 +459,7 @@ compY
 
 ..  confval:: splitRendering.compY
     :name: gifbuilder-text-splitRendering-compY
-
-    :Data type: integer
+    :type: integer
 
     Additional pixel space between parts, y direction.
 
@@ -495,8 +471,7 @@ text
 
 ..  confval:: text
     :name: gifbuilder-text-text
-
-    :Data type: string / :ref:`stdWrap <stdwrap>`
+    :type: string / :ref:`stdWrap <stdwrap>`
 
     This is text on the image file. The item is rendered only, if this string is
     not empty.
@@ -512,8 +487,7 @@ textMaxLength
 
 ..  confval:: textMaxLength
     :name: gifbuilder-text-textMaxLength
-
-    :Data type: integer
+    :type: integer
     :Default: 100
 
     The maximum length of the :ref:`gifbuilder-text-text`. This is just a
@@ -527,8 +501,7 @@ wordSpacing
 
 ..  confval:: wordSpacing
     :name: gifbuilder-text-wordSpacing
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
     :Default: :ref:`spacing <gifbuilder-text-spacing>` * 2
 
     The pixel distance between words.

--- a/Documentation/Gifbuilder/ObjectNames/Workarea/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Workarea/Index.rst
@@ -23,8 +23,7 @@ clear
 
 ..  confval:: clear
     :name: gifbuilder-workarea-clear
-
-    :Data type: string
+    :type: string
 
     Sets the current work area to the default work area.
 
@@ -39,8 +38,7 @@ set
 
 ..  confval:: set
     :name: gifbuilder-workarea-set
-
-    :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Sets the dimensions of the work area.
 

--- a/Documentation/Gifbuilder/Properties.rst
+++ b/Documentation/Gifbuilder/Properties.rst
@@ -16,8 +16,7 @@ Properties
 
 ..  confval:: 1,2,3,4...
     :name: gifbuilder-properties-array
-
-    :Data type: :ref:`Gifbuilder Object <gifbuilder-object-names>` + .if (:ref:`->if <if>`)
+    :type: :ref:`Gifbuilder Object <gifbuilder-object-names>` + .if (:ref:`->if <if>`)
 
     :typoscript:`.if` is a property of all GIFBUILDER objects. If the property
     is present and **not** set, the object is **not** rendered! This
@@ -32,8 +31,7 @@ backColor
 
 ..  confval:: backColor
     :name: gifbuilder-properties-backColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
     :Default: white
 
     Background color of the image.
@@ -51,8 +49,7 @@ charRangeMap
 
 ..  confval:: charRangeMap.[array]
     :name: gifbuilder-properties-charRangeMap-array
-
-    :Data type: string
+    :type: string
 
     Basename of font file to match for this configuration. Notice that
     only the *filename* of the font file is used - the path is stripped
@@ -86,8 +83,7 @@ charRangeMap
 
 ..  confval:: charRangeMap.[array].charMapConfig
     :name: gifbuilder-properties-charRangeMap-charMapConfig
-
-    :Data type: :ref:`TEXT <gifbuilder-text>` / :ref:`splitRendering.[array] <gifbuilder-text-splitRendering>` configuration
+    :type: :ref:`TEXT <gifbuilder-text>` / :ref:`splitRendering.[array] <gifbuilder-text-splitRendering>` configuration
 
     splitRendering configuration to set.
     See :ref:`GIFBUILDER TEXT object <gifbuilder-text>` for details.
@@ -100,8 +96,7 @@ charRangeMap
 
 ..  confval:: charRangeMap.[array].fontSizeMultiplicator
     :name: gifbuilder-properties-charRangeMap-fontSizeMultiplicator
-
-    :Data type: double
+    :type: double
 
     If set, this will take the font size of the
     :ref:`GIFBUILDER TEXT object <gifbuilder-text>` and multiply with this
@@ -116,8 +111,7 @@ charRangeMap
 
 ..  confval:: charRangeMap.[array].pixelSpaceFontSizeRef
     :name: gifbuilder-properties-charRangeMap-pixelSpaceFontSizeRef
-
-    :Data type: double
+    :type: double
 
     If set, this will multiply the four [x/y]Space[Before/After]
     properties of split rendering with the relationship between the
@@ -167,8 +161,7 @@ format
 
 ..  confval:: format
     :name: gifbuilder-properties-format
-
-    :Data type: "gif" / "jpg" / "jpeg" / "png" / "webp"
+    :type: "gif" / "jpg" / "jpeg" / "png" / "webp"
     :Default: png
 
     File type of the output image.
@@ -188,8 +181,7 @@ maxHeight
 
 ..  confval:: maxHeight
     :name: gifbuilder-properties-maxHeight
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Maximal height of the image file.
 
@@ -201,8 +193,7 @@ maxWidth
 
 ..  confval:: maxWidth
     :name: gifbuilder-properties-maxWidth
-
-    :Data type: positive integer / :ref:`stdWrap <stdwrap>`
+    :type: positive integer / :ref:`stdWrap <stdwrap>`
 
     Maximal width of the image file.
 
@@ -214,8 +205,7 @@ offset
 
 ..  confval:: offset
     :name: gifbuilder-properties-offset
-
-    :Data type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
     :Default: 0,0
 
     Offset all objects on the image.
@@ -231,8 +221,7 @@ quality
 
 ..  confval:: quality
     :name: gifbuilder-properties-quality
-
-    :Data type: Between 10 (lowest quality) and 100 (highest quality) / additionally, 101 (lossless) for WebP
+    :type: Between 10 (lowest quality) and 100 (highest quality) / additionally, 101 (lossless) for WebP
 
     Sets the quality of the image:
 
@@ -250,8 +239,7 @@ transparentBackground
 
 ..  confval:: transparentBackground
     :name: gifbuilder-properties-transparentBackground
-
-    :Data type: boolean / :ref:`stdWrap <stdwrap>`
+    :type: boolean / :ref:`stdWrap <stdwrap>`
 
     Set this flag to render the background transparent. TYPO3 makes the
     color found at position 0,0 of the image (upper left corner) transparent.
@@ -269,8 +257,7 @@ transparentColor
 
 ..  confval:: transparentColor
     :name: gifbuilder-properties-transparentColor
-
-    :Data type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-GraphicColor` / :ref:`stdWrap <stdwrap>`
 
     Specify a color that should be transparent.
 
@@ -282,8 +269,7 @@ closest
 
 ..  confval:: transparentColor.closest
     :name: gifbuilder-properties-transparentColor-closest
-
-    :Data Type: boolean
+    :type: boolean
 
     This will allow for the closest color to be matched instead. You may
     need this, if your image is not guaranteed "clean".
@@ -300,8 +286,7 @@ workArea
 
 ..  confval:: workArea
     :name: gifbuilder-properties-workArea
-
-    :Data type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
+    :type: x,y,w,h :ref:`+calc <gifbuilder-calc>` / :ref:`stdWrap <stdwrap>`
 
     Define the work area on the image file. All the
     :ref:`GIFBUILDER objects <gifbuilder-object-names>` will see this as the
@@ -317,8 +302,7 @@ XY
 
 ..  confval:: XY
     :name: gifbuilder-properties-XY
-
-    :Data type: x,y :ref:`+calc <gifbuilder-calc>` (1-2000) / :ref:`stdWrap <stdwrap>`
+    :type: x,y :ref:`+calc <gifbuilder-calc>` (1-2000) / :ref:`stdWrap <stdwrap>`
     :Default: 120,50
 
     Size of the image file.

--- a/Documentation/MenuObjects/Tmenu/Index.rst
+++ b/Documentation/MenuObjects/Tmenu/Index.rst
@@ -42,8 +42,7 @@ NO
 
 ..  confval:: NO
     :name: tmenu-common-property-no
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 1 (true)
 
 
@@ -73,9 +72,7 @@ IFSUB
 
 ..  confval:: IFSUB
     :name: tmenu-common-property-ifsub
-
-    :Data type: :ref:`data-type-boolean` / (config)
-
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for menu items which has subpages.
@@ -88,8 +85,7 @@ ACT
 
 ..  confval:: ACT
     :name: tmenu-common-property-act
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for menu items which are found in the rootLine.
@@ -102,8 +98,7 @@ ACTIFSUB
 
 ..  confval:: ACTIFSUB
     :name: tmenu-common-property-actifsub
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for menu items which are found in the rootLine
@@ -117,8 +112,7 @@ CUR
 
 ..  confval:: CUR
     :name: tmenu-common-property-cur
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
 
@@ -132,8 +126,7 @@ CURIFSUB
 
 ..  confval:: CURIFSUB
     :name: tmenu-common-property-curifsub
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for a menu item if the item is the current page
@@ -147,8 +140,7 @@ USR
 
 ..  confval:: USR
     :name: tmenu-common-property-usr
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for menu items which are access restricted pages
@@ -162,8 +154,7 @@ SPC
 
 ..  confval:: SPC
     :name: tmenu-common-property-spc
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
     :Default: 0
 
     Enable/Configuration for 'Spacer' pages.
@@ -179,8 +170,7 @@ USERDEF1
 
 ..  confval:: USERDEF1
     :name: tmenu-common-property-userdef1
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
 
     User-defined, see :ref:`menu-common-properties-itemArrayProcFunc` for details on how
     to use this.
@@ -197,8 +187,7 @@ USERDEF2
 
 ..  confval:: USERDEF2
     :name: tmenu-common-property-userdef2
-
-    :Data type: :ref:`data-type-boolean` / (config)
+    :type: :ref:`data-type-boolean` / (config)
 
     Same like :ref:`USERDEF1 <tmenu-common-property-userdef1>` but has a higher
     priority.
@@ -218,8 +207,7 @@ expAll
 
 ..  confval:: expAll
     :name: menu-common-properties-expAll
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
 
     If this is true, the menu will always show the menu on the level
     underneath the menu item. This corresponds to a situation where a user
@@ -250,8 +238,7 @@ default with colPos=0!).
 
 ..  confval:: sectionIndex
     :name: menu-common-properties-sectionIndex
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If you set this, all content elements (from tt\_content table) of
     "Column" = "Normal" *and* the "Index"-check box clicked are selected.
@@ -265,8 +252,7 @@ sectionIndex.type
 
 ..  confval:: sectionIndex.type
     :name: menu-common-properties-sectionIndex-type
-
-    :Data type: :ref:`data-type-string` ("all" / "header")
+    :type: :ref:`data-type-string` ("all" / "header")
 
     "all"
         The "Index"-checkbox is not considered and all content elements - by
@@ -286,8 +272,7 @@ sectionIndex.includeHiddenHeaders
 
 ..  confval:: sectionIndex.includeHiddenHeaders
     :name: menu-common-properties-sectionIndex-includeHiddenHeaders
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
      If you set this and sectionIndex.type is set to "header",
      also elements with a header layout set to "Hidden" will appear
@@ -301,8 +286,7 @@ sectionIndex.useColPos
 
 ..  confval:: sectionIndex.useColPos
     :name: menu-common-properties-sectionIndex-useColPos
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     This property allows you to set the colPos which should be used in the
@@ -374,8 +358,7 @@ target
 
 ..  confval:: target
     :name: menu-common-properties-target
-
-    :Data type: :ref:`data-type-target`
+    :type: :ref:`data-type-target`
     :Default: self
 
     Target of the menu links
@@ -388,8 +371,7 @@ forceTypeValue
 
 ..  confval:: forceTypeValue
     :name: menu-common-properties-forceTypeValue
-
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
 
     If set, the `&type` parameter of the link is forced to this value
     regardless of target.
@@ -402,8 +384,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: menu-common-properties-stdWrap
-
-    :Data type: :ref:`stdWrap <stdwrap>`
+    :type: :ref:`stdWrap <stdwrap>`
 
 
     Wraps the whole block of sub items.
@@ -429,8 +410,7 @@ wrap
 
 ..  confval:: wrap
     :name: menu-common-properties-wrap
-
-    :Data type: :ref:`wrap <data-type-wrap>`
+    :type: :ref:`wrap <data-type-wrap>`
 
     Wraps the whole block of sub items, but only if there were items in the menu!
 
@@ -442,8 +422,7 @@ IProcFunc
 
 ..  confval:: IProcFunc
     :name: menu-common-properties-IProcFunc
-
-    :Data type: function name
+    :type: function name
 
     The internal array "I" is passed to this function and expected
     returned as well. Subsequent to this function call the menu item is
@@ -461,8 +440,7 @@ Item States
 
 ..  confval:: [Item States, like NO, ACT, CUR etc]
     :name: menu-common-properties-item-states
-
-    :Data type: ->TMENUITEM
+    :type: ->TMENUITEM
 
 
      This is the TMENUITEM-options for each category of a menu item that can
@@ -481,8 +459,7 @@ alternativeSortingField
 
 ..  confval:: alternativeSortingField
     :name: menu-common-properties-alternativeSortingField
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Normally the menu items are sorted by the fields "sorting" in the
     pages- and tt\_content-table. Here you can enter a list of fields that
@@ -508,8 +485,7 @@ minItems
 
 ..  confval:: minItems
     :name: menu-common-properties-minItems
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
     The minimum items in the menu. If the number of pages does not reach
     this level, a dummy-page with the title "..." and
@@ -525,8 +501,7 @@ maxItems
 
 ..  confval:: maxItems
     :name: menu-common-properties-maxItems
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
 
 
     The maximum items in the menu. More items will be ignored.
@@ -541,8 +516,7 @@ begin
 
 ..  confval:: begin
     :name: menu-common-properties-begin
-
-    :Data type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
+    :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
 
 
     The first item in the menu.
@@ -567,8 +541,7 @@ debugItemConf
 
 ..  confval:: debugItemConf
     :name: menu-common-properties-debugItemConf
-
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Outputs (by the :php:`debug()` function) the configuration arrays for each
     menu item. Useful to debug :ref:`optionsplit` things and such...
@@ -581,8 +554,7 @@ overrideId
 
 ..  confval:: overrideId
     :name: menu-common-properties-overrideId
-
-    :Data type: :ref:`data-type-integer` (page id)
+    :type: :ref:`data-type-integer` (page id)
 
     If set, then all links in the menu will point to this pageid. Instead
     the real uid of the page is sent by the parameter "&real\_uid=[uid]".
@@ -599,8 +571,7 @@ addParams
 
 ..  confval:: addParams
     :name: menu-common-properties-addParams
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Additional parameter for the menu links.
 
@@ -619,8 +590,7 @@ showAccessRestrictedPages
 
 ..  confval:: showAccessRestrictedPages
     :name: menu-common-properties-showaccessrestrictedpages
-
-    :Data type: :ref:`data-type-integer` (page ID) / keyword "NONE"
+    :type: :ref:`data-type-integer` (page ID) / keyword "NONE"
 
 
     If set, pages in the menu will include pages with frontend user group
@@ -670,8 +640,7 @@ additionalWhere
 
 ..  confval:: additionalWhere
     :name: menu-common-properties-additionalWhere
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Adds an additional part to the WHERE clause for this menu.
     Make sure to start the part with "AND "!
@@ -693,8 +662,7 @@ itemArrayProcFunc
 
 ..  confval:: itemArrayProcFunc
     :name: menu-common-properties-itemArrayProcFunc
-
-    :Data type: function name
+    :type: function name
 
 
     The first variable passed to this function is the "menuArr" array with
@@ -723,8 +691,7 @@ submenuObjSuffixes
 
 ..  confval:: submenuObjSuffixes
     :name: menu-common-properties-submenuObjSuffixes
-
-    :Data type: :ref:`data-type-string` / :ref:`optionsplit`
+    :type: :ref:`data-type-string` / :ref:`optionsplit`
 
     Defines a suffix for alternative sub-level menu objects. Useful to
     create special submenus depending on their parent menu element. See

--- a/Documentation/MenuObjects/Tmenuitem/Index.rst
+++ b/Documentation/MenuObjects/Tmenuitem/Index.rst
@@ -20,8 +20,7 @@ allWrap
 
 ..  confval:: allWrap
     :name: tmenuitem-allWrap
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     Wraps the whole item.
 
@@ -33,8 +32,7 @@ wrapItemAndSub
 
 ..  confval:: wrapItemAndSub
     :name: tmenuitem-wrapItemAndSub
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     Wraps the whole item and any submenu concatenated to it.
 
@@ -46,9 +44,7 @@ subst_elementUid
 
 ..  confval:: subst_elementUid
     :name: tmenuitem-subst-elementUid
-
-    :Data type: :ref:`data-type-boolean`
-
+    :type: :ref:`data-type-boolean`
     :Default: 0 (false)
 
     If set, all appearances of the string '{elementUid}' in the HTML code of the
@@ -66,8 +62,7 @@ before
 
 ..  confval:: before
     :name: tmenuitem-before
-
-    :Data type: HTML / :ref:`stdWrap <stdwrap>`
+    :type: HTML / :ref:`stdWrap <stdwrap>`
 
 
 ..  _tmenuitem-beforeWrap:
@@ -77,8 +72,7 @@ beforeWrap
 
 ..  confval:: beforeWrap
     :name: tmenuitem-beforeWrap
-
-    :Data type: :ref:`data-type-wrap`
+    :type: :ref:`data-type-wrap`
 
     Wrap around the :ref:`.before <tmenuitem-before>` code.
 
@@ -90,8 +84,7 @@ after
 
 ..  confval:: after
     :name: tmenuitem-after
-
-    :Data type: HTML / :ref:`stdWrap <stdwrap>`
+    :type: HTML / :ref:`stdWrap <stdwrap>`
 
 
 ..  _tmenuitem-afterWrap:
@@ -101,8 +94,7 @@ afterWrap
 
 ..  confval:: afterWrap
     :name: tmenuitem-afterWrap
-
-    :Data type: :ref:`data-type-wrap`
+    :type: :ref:`data-type-wrap`
 
     Wrap around the :ref:`.after <tmenuitem-after>` code.
 
@@ -114,8 +106,7 @@ linkWrap
 
 ..  confval:: linkWrap
     :name: tmenuitem-linkWrap
-
-    :Data type: :ref:`data-type-wrap`
+    :type: :ref:`data-type-wrap`
 
 
 ..  _tmenuitem-stdWrap:
@@ -125,8 +116,7 @@ stdWrap
 
 ..  confval:: stdWrap
     :name: tmenuitem-stdWrap
-
-    :Data type: :ref:`stdWrap`
+    :type: :ref:`stdWrap`
 
     stdWrap to the link text.
 
@@ -138,9 +128,7 @@ ATagBeforeWrap
 
 ..  confval:: ATagBeforeWrap
     :name: tmenuitem-ATagBeforeWrap
-
-    :Data type: :ref:`data-type-boolean`
-
+    :type: :ref:`data-type-boolean`
     :Default: 0 (false)
 
     If set, the link is first wrapped with :ref:`*.linkWrap* <tmenuitem-linkWrap>`
@@ -154,8 +142,7 @@ ATagParams
 
 ..  confval:: ATagParams
     :name: tmenuitem-ATagParams
-
-    :Data type: *<A>-params* / :ref:`stdWrap <stdwrap>`
+    :type: *<A>-params* / :ref:`stdWrap <stdwrap>`
 
     Additional parameters
 
@@ -174,8 +161,7 @@ ATagTitle
 
 ..  confval:: ATagTitle
     :name: tmenuitem-ATagTitle
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Allows you to specify the "title" attribute of the :html:`<a>` tag around
     the menu item.
@@ -198,8 +184,7 @@ additionalParams
 
 ..  confval:: additionalParams
     :name: tmenuitem-additionalParams
-
-    :Data type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Define parameters that are added to the end of the URL. This must be
     code ready to insert after the last parameter.
@@ -214,8 +199,7 @@ doNotLinkIt
 
 ..  confval:: doNotLinkIt
     :name: tmenuitem-doNotLinkIt
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     If set, the link texts are not linked at all.
@@ -228,8 +212,7 @@ doNotShowLink
 
 ..  confval:: doNotShowLink
     :name: tmenuitem-doNotShowLink
-
-    :Data type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
     :Default: 0
 
     If set, the text will not be shown at all (smart with spacers).
@@ -242,8 +225,7 @@ stdWrap2
 
 ..  confval:: stdWrap2
     :name: tmenuitem-stdWrap2
-
-    :Data type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
+    :type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
     :Default: \|
 
     stdWrap to the total link text and :html:`<a>` tag. (Notice that the plain
@@ -257,8 +239,7 @@ altTarget
 
 ..  confval:: altTarget
     :name: tmenuitem-altTarget
-
-    :Data type: :ref:`data-type-target`
+    :type: :ref:`data-type-target`
 
     Alternative target overriding the target property of the
     ref:`TMENU <tmenu>`, if set.
@@ -271,7 +252,6 @@ allStdWrap
 
 ..  confval:: allStdWrap
     :name: tmenuitem-allStdWrap
-
-    :Data type: :ref:`stdWrap <stdwrap>`
+    :type: :ref:`stdWrap <stdwrap>`
 
     stdWrap of the whole item.

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -52,8 +52,7 @@ absRefPrefix
 
 ..  confval:: absRefPrefix
     :name: config-absrefprefix
-
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Special value: "auto"
 
     If set, the string is prepended to all relative links that TYPO3 generates.
@@ -107,8 +106,7 @@ additionalHeaders
 
 ..  confval:: additionalHeaders
     :name: config-additionalheaders
-
-    :Data type: numerically indexed array of "HTTP header entries".
+    :type: numerically indexed array of "HTTP header entries".
 
     By means of :typoscript:`config.additionalHeaders` as series of additional HTTP headers
     can be configured. An entry has the following structure:
@@ -198,7 +196,7 @@ ATagParams
 
 ..  confval:: ATagParams
     :name: config-ATagParams
-    :Data type: *<A>-params*
+    :type: *<A>-params*
 
     Additional parameters to all links in TYPO3 (excluding menu-links).
 
@@ -211,7 +209,7 @@ cache
 
 ..  confval:: cache
     :name: config-cache
-    :Data type: array
+    :type: array
 
     Determine the maximum cache lifetime of a page.
 
@@ -283,7 +281,7 @@ cache\_clearAtMidnight
 
 ..  confval:: cache_clearAtMidnight
     :name: config-cache-clearAtMidnight
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `false`
 
     With this setting the cache always expires at midnight of the day, the
@@ -298,7 +296,7 @@ cache\_period
 
 ..  confval:: cache_period
     :name: config-cache-period
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Default: `86400` *(= 24 hours)*
 
 The number of second a page may remain in cache.
@@ -314,7 +312,7 @@ compressCss
 
 ..  confval:: compressCss
     :name: config-compressCss
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     If set, CSS files referenced in :typoscript:`page.includeCSS` and the like will be
@@ -355,7 +353,7 @@ compressJs
 
 ..  confval:: compressJs
     :name: config-compressJs
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     Enabling this option together with
@@ -399,7 +397,7 @@ concatenateCss
 
 ..  confval:: concatenateCss
     :name: config-concatenateCss
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     Setting :typoscript:`config.concatenateCss` merges Stylesheet files referenced in
@@ -434,7 +432,7 @@ concatenateJs
 
 ..  confval:: concatenateJs
     :name: config-concatenateJs
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     Setting :typoscript:`config.concatenateJs` merges JavaScript files referenced in
@@ -481,7 +479,7 @@ contentObjectExceptionHandler
 
 ..  confval:: contentObjectExceptionHandler
     :name: config-contentObjectExceptionHandler
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     Exceptions which occur during rendering of content objects (typically plugins)
@@ -541,7 +539,7 @@ debug
 
 ..  confval:: debug
     :name: config-debug
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, then debug information in the TypoScript code is sent.
     This applies e.g. to menu objects and the parsetime output.
@@ -557,7 +555,7 @@ disableAllHeaderCode
 
 ..  confval:: disableAllHeaderCode
     :name: config-disableAllHeaderCode
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `false`
 
     If this is not set or set to false, the :ref:`page` object automatically
@@ -603,7 +601,7 @@ disableBodyTag
 
 ..  confval:: disableBodyTag
     :name: config-disableBodyTag
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `false`
 
     If this option is set, the TYPO3 core will not generate the
@@ -625,7 +623,7 @@ disableCanonical
 
 ..  confval:: disableCanonical
     :name: config-disableCanonical
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     When the system extension SEO is installed, canonical tags are generated
     automatically to prevent duplicate content. A good canonical is added
@@ -641,7 +639,7 @@ disableHrefLang
 
 ..  confval:: disableHrefLang
     :name: config-disableHrefLang
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     When the system extension SEO is installed, hreflang tags are generated
     automatically in multi-language setups. By settings this option to true
@@ -655,7 +653,7 @@ disablePrefixComment
 
 ..  confval:: disablePrefixComment
     :name: config-disablePrefixComment
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the stdWrap property :ref:`stdwrap-prefixComment` will be disabled, thus
     preventing any revealing and space-consuming comments in the HTML
@@ -671,7 +669,7 @@ disablePreviewNotification
 
 ..  confval:: disablePreviewNotification
     :name: config-disablePreviewNotification
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     Disables the "preview" notification box completely.
@@ -685,7 +683,7 @@ disableLanguageHeader
 
 ..  confval:: disableLanguageHeader
     :name: config-disableLanguageHeader
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     TYPO3 by default sends a `Content-language: XX` HTTP header,
@@ -704,7 +702,7 @@ doctype
 
 ..  confval:: doctype
     :name: config-doctype
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If set, then a document type declaration (and an XML prologue) will be
     generated. The value can either be a complete doctype or one of the
@@ -742,7 +740,7 @@ enableContentLengthHeader
 
 ..  confval:: enableContentLengthHeader
     :name: config-enableContentLengthHeader
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `1`
 
     If set, a header "content-length: [bytes of content]" is sent.
@@ -760,7 +758,7 @@ extTarget
 
 ..  confval:: extTarget
     :name: config-extTarget
-    :Data type: target
+    :type: target
     :Default: `_top`
 
     Default external target. Used by :ref:`typolink` if no extTarget is set.
@@ -775,7 +773,7 @@ fileTarget
 
 ..  confval:: fileTarget
     :name: config-fileTarget
-    :Data type: target
+    :type: target
 
     Default file link target. Used by :ref:`typolink` if no fileTarget is set.
 
@@ -791,7 +789,7 @@ forceAbsoluteUrls
 
 ..  confval:: forceAbsoluteUrls
     :name: config-forceAbsoluteUrls
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     If this option is set, all links, reference to images or assets
@@ -816,7 +814,7 @@ forceTypeValue
 
 ..  confval:: forceTypeValue
     :name: config-forceTypeValue
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Force the `&type` value of all TYPO3 generated links to a specific value
     (except if overruled by local :typoscript:`forceTypeValue` values).
@@ -835,7 +833,7 @@ headerComment
 
 ..  confval:: headerComment
     :name: config-headerComment
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     The content is added before the "TYPO3 Content Management Framework"
     comment in the <head> section of the page. Use this to insert a note
@@ -849,7 +847,7 @@ htmlTag.attributes
 
 ..  confval:: htmlTag.attributes
     :name: config-htmlTag-attributes
-    :Data type: array
+    :type: array
 
     Sets the attributes for the :html:`<html>` tag on the page. Allows to override
     and add custom attributes via TypoScript without having to re-add the
@@ -904,7 +902,7 @@ htmlTag\_setParams
 
 ..  confval:: htmlTag_setParams
     :name: config-htmlTag-setParams
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Sets the attributes for the :html:`<html>` tag on the page. If you set
     :ref:`setup-config-doctype` to a keyword enabling XHTML then some attributes are
@@ -940,7 +938,7 @@ htmlTag\_stdWrap
 
 ..  confval:: htmlTag_stdWrap
     :name: config-htmlTag-stdWrap
-    :Data type: :ref:`stdwrap`
+    :type: :ref:`stdwrap`
 
     Modify the whole :html:`<html>` tag with stdWrap functionality. This can be
     used to extend or override this tag.
@@ -953,7 +951,7 @@ index\_descrLgd
 
 ..  confval:: index_descrLgd
     :name: config-index-descrLgd
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Default: `200`
 
     This indicates how many chars to preserve as description for an
@@ -967,7 +965,7 @@ index\_enable
 
 ..  confval:: index_enable
     :name: config-index-enable
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Enables cached pages to be indexed.
 
@@ -983,7 +981,7 @@ index\_externals
 
 ..  confval:: index_externals
     :name: config-index-externals
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, external media linked to on the pages is indexed as well.
 
@@ -999,7 +997,7 @@ index\_metatags
 
 ..  confval:: index_metatags
     :name: config-index-metatags
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `true`
 
     This allows to turn on or off the indexing of metatags. It is turned
@@ -1015,7 +1013,7 @@ inlineStyle2TempFile
 
 ..  confval:: inlineStyle2TempFile
     :name: config-inlineStyle2TempFile
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `1`
 
     If set, the inline styles TYPO3 controls in the core are written to a
@@ -1040,7 +1038,7 @@ intTarget
 
 ..  confval:: intTarget
     :name: config-intTarget
-    :Data type: target
+    :type: target
 
     Default internal target. Used by :ref:`typolink` if no target is set.
 
@@ -1053,7 +1051,7 @@ linkVars
 
 ..  confval:: linkVars
     :name: config-linkVars
-    :Data type: list
+    :type: list
 
     :php:`HTTP_GET_VARS`, which should be passed on with links in TYPO3. This
     is compiled into a string stored in :php:`$GLOBALS['TSFE']->linkVars`
@@ -1111,7 +1109,7 @@ message\_preview
 
 ..  confval:: message_preview
     :name: config-message_preview
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Alternative message in HTML that appears when the preview function is
     active.
@@ -1126,7 +1124,7 @@ message\_preview\_workspace
 
 ..  confval:: message_preview_workspace
     :name: config-message-preview-workspace
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Alternative message in HTML that appears when the preview function is
     active in a draft workspace. You can use sprintf() placeholders for
@@ -1165,7 +1163,7 @@ moveJsFromHeaderToFooter
 
 ..  confval:: moveJsFromHeaderToFooter
     :name: config-moveJsFromHeaderToFooter
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, all JavaScript (includes and inline) will be moved to the
     bottom of the HTML document, which is after the content and before the
@@ -1180,7 +1178,7 @@ MP\_defaults
 
 ..  confval:: MP_defaults
     :name: config-MP-defaults
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     Allows you to set a list of page id numbers which will always have a
     certain "&MP=..." parameter added.
@@ -1211,7 +1209,7 @@ MP\_disableTypolinkClosestMPvalue
 
 ..  confval:: MP_disableTypolinkClosestMPvalue
     :name: config-MP-disableTypolinkClosestMPvalue
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     If set, the :ref:`typolink` function will not try to find the closest MP
     value for the id.
@@ -1224,7 +1222,7 @@ MP\_mapRootPoints
 
 ..  confval:: MP_mapRootPoints
     :name: config-MP-mapRootPoints
-    :Data type: list of PIDs / :ref:`data-type-string`
+    :type: list of PIDs / :ref:`data-type-string`
 
     Defines a list of ID numbers from which the MP-vars are automatically
     calculated for the branch.
@@ -1253,7 +1251,7 @@ namespaces
 
 ..  confval:: namespaces
     :name: config-namespaces
-    :Data type: *(array of strings)*
+    :type: *(array of strings)*
 
     This property enables you to add xml namespaces (xmlns) to the :html:`<html>`
     tag. This is especially useful if you want to add RDFa or microformats
@@ -1284,7 +1282,7 @@ no\_cache
 
 ..  confval:: no_cache
     :name: config-no-cache
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     If this is set to `1`, it disables the `pages` cache, meaning that the
@@ -1311,7 +1309,7 @@ noPageTitle
 
 ..  confval:: noPageTitle
     :name: config-noPageTitle
-    :Data type: :ref:`data-type-integer`
+    :type: :ref:`data-type-integer`
     :Default: `0`
 
      If you only want to have the site name (from the template record) in
@@ -1331,7 +1329,7 @@ pageRendererTemplateFile
 
 ..  confval:: pageRendererTemplateFile
     :name: config-pageRendererTemplateFile
-    :Data type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Default: file:`EXT:core/Resources/Private/Templates/PageRenderer.html`
 
 
@@ -1355,7 +1353,7 @@ pageTitle
 
 ..  confval:: pageTitle
     :name: config-pageTitle
-    :Data type: :ref:`stdwrap`
+    :type: :ref:`stdwrap`
 
     stdWrap for the page title. This option will be executed *after* all
     other processing options like :ref:`setup-config-pageTitleFirst`.
@@ -1368,7 +1366,7 @@ pageTitleFirst
 
 ..  confval:: pageTitleFirst
     :name: config-pageTitleFirst
-    :Data type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: `0`
 
     TYPO3 by default prints a title tag in the format "website: page
@@ -1388,7 +1386,7 @@ pageTitleProviders
 
 ..  confval:: pageTitleProviders
     :name: config-pageTitleProviders
-    :Data type: array
+    :type: array
 
     In order to keep setting the titles in control, an API to set the page title is available. The API uses
     :typoscript:`PageTitleProviders` to define the page title based on page record and the content on the page.
@@ -1436,7 +1434,7 @@ pageTitleSeparator
 
 ..  confval:: pageTitleSeparator
     :name: config-pageTitleSeparator
-    :Data type: array
+    :type: array
     :Default: `:` *(colon with following space)*
 
     The signs which should be printed in the title tag between the website
@@ -1493,7 +1491,7 @@ recordLinks
 
 ..  confval:: recordLinks
     :name: config-recordLinks
-    :Data Type: array of link configurations
+    :type: array of link configurations
 
     ..  code-block:: typoscript
         :caption: Frontend TypoScript definition for identifier `my_content`
@@ -1520,7 +1518,7 @@ removeDefaultCss
 
 ..  confval:: removeDefaultCss
     :name: config-removeDefaultCss
-    :Data Type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
     Remove CSS generated by :ref:`\_CSS\_DEFAULT\_STYLE
     <setup-plugin-css-default-style>` configuration of extensions.
@@ -1535,7 +1533,7 @@ removeDefaultJS
 
 ..  confval:: removeDefaultJS
     :name: config-removeDefaultJS
-    :Data Type: :ref:`data-type-boolean` / :ref:`data-type-string`
+    :type: :ref:`data-type-boolean` / :ref:`data-type-string`
 
     If set, the default JavaScript in the header will be removed.
 
@@ -1563,7 +1561,7 @@ sendCacheHeaders
 
 ..  confval:: sendCacheHeaders
     :name: config-sendCacheHeaders
-    :Data Type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
 
      If set, TYPO3 will output cache-control headers to the client based
      mainly on whether the page was cached internally. This feature allows
@@ -1621,7 +1619,7 @@ showWebsiteTitle
 
 ..  confval:: showWebsiteTitle
     :name: config-showWebsiteTitle
-    :Data Type: :ref:`data-type-boolean`
+    :type: :ref:`data-type-boolean`
     :Default: 1
 
     The option can be used to specify whether the website title defined in
@@ -1640,7 +1638,7 @@ spamProtectEmailAddresses
 
 ..  confval:: spamProtectEmailAddresses
     :name: config-spamProtectEmailAddresses
-    :Data Type: `-10` to `10`
+    :type: `-10` to `10`
 
     If set, then all email addresses in typolinks will be encrypted so
     that it is harder for spam bots to detect them.
@@ -1668,7 +1666,7 @@ spamProtectEmailAddresses\_atSubst
 
 ..  confval:: spamProtectEmailAddresses_atSubst
     :name: config-spamProtectEmailAddresses-atSubst
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Default: `(at)`
 
     Substitute label for the at-sign (`@`).
@@ -1682,7 +1680,7 @@ spamProtectEmailAddresses\_lastDotSubst
 
 ..  confval:: spamProtectEmailAddresses_lastDotSubst
     :name: config-spamProtectEmailAddresses-lastDotSubst
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
     :Default: `.` *(just a simple dot)*
 
     Substitute label for the last dot in the email address.
@@ -1704,7 +1702,7 @@ tx\_[extension key with no underscores]\_[\*]
 
 ..  confval:: tx_[extension key with no underscores]_[*]
     :name: config-tx-extension-key-with-no-underscores
-    :Data Type: array
+    :type: array
 
     Configuration space for extensions. This can be used – for example –
     by plugins that need some TypoScript configuration, but that don't
@@ -1731,7 +1729,7 @@ typolinkLinkAccessRestrictedPages
 
 ..  confval:: typolinkLinkAccessRestrictedPages
     :name: config-typolinkLinkAccessRestrictedPages
-    :Data Type: :ref:`data-type-integer` (page id) / keyword "NONE"
+    :type: :ref:`data-type-integer` (page id) / keyword "NONE"
 
     If set, typolinks pointing to access restricted pages will still link
     to the page even though the page cannot be accessed. If the value of
@@ -1757,7 +1755,7 @@ typolinkLinkAccessRestrictedPages.ATagParams
 
 ..  confval:: typolinkLinkAccessRestrictedPages.ATagParams
     :name: config-typolinkLinkAccessRestrictedPages-ATagParams
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     `typolinkLinkAccessRestrictedPages.ATagParams` Add custom attributes to the anchor tag.
 
@@ -1784,7 +1782,7 @@ typolinkLinkAccessRestrictedPages\_addParams
 
 ..  confval:: typolinkLinkAccessRestrictedPages_addParams
     :name: config-typolinkLinkAccessRestrictedPages-addParams
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     See :ref:`setup-config-typolinklinkaccessrestrictedpages` above.
 
@@ -1798,7 +1796,7 @@ xmlprologue
 
 ..  confval:: typolinkLinkAccessRestrictedPages_xmlprologue
     :name: config-typolinkLinkAccessRestrictedPages-xmlprologue
-    :Data Type: :ref:`data-type-string`
+    :type: :ref:`data-type-string`
 
     If empty (not set) then the default XML 1.0 prologue is set, when the
     doctype is set to a known keyword (e.g. :typoscript:`xhtml_11`):

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -196,7 +196,7 @@ bodyTag
 ..  confval:: bodyTag
     :name: page-bodyTag
     :type: :ref:`data-type-tag`
-    :default: `<body>`
+    :Default: `<body>`
 
     Body tag on the page
 


### PR DESCRIPTION
turn `:Data type:` into `:type:` as the latter is a standard property while the first is just any named label.

Remove empty lines from in-beetween confval properties. These turn the later part into definition lists.

Unify how to write `:Default:` and `:Required:`

No other changes made.

Releases: main, 12.4