### PR TITLE
[BUGFIX] Add missing cache property to content elements

### DIFF
--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -20,6 +20,18 @@ The content object :typoscript:`EXTBASEPLUGIN` allows to render
 Properties
 ==========
 
+..  _cobj-extbaseplugin-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: extbaseplugin-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
+
+
 ..  _cobj-extbaseplugin-extensionName:
 
 extensionName

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -19,6 +19,18 @@ A content object of type FILES uses the :ref:`File Abstraction Layer <t3coreapi:
 Properties
 ==========
 
+..  _cobj-files-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: files-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
+
+
 .. _cobj-files-files:
 
 files

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -63,6 +63,17 @@ receive a complete listing of the available data using the magic `{_all}` variab
 Properties
 ==========
 
+..  _cobj-_fluidtemplate-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: _fluidtemplate-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
+
 .. _fluidtemplate-dataProcessing:
 
 dataProcessing

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -42,6 +42,16 @@ If you only need the file path to the image; regardless of whether it's been res
 Properties
 ==========
 
+..  _cobj-image-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: image-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
 
 ..  _cobj-image-if:
 

--- a/Documentation/ContentObjects/ImgResource/Index.rst
+++ b/Documentation/ContentObjects/ImgResource/Index.rst
@@ -21,6 +21,17 @@ Depending on your use case you might prefer using the cObject
 Properties
 ==========
 
+..  _cobj-img-resource-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: img-resource-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
+
 ..  _cobj-img-resource-file:
 
 file

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -18,6 +18,17 @@ or reference a file.
 Properties
 ==========
 
+..  _cobj-svg-cache:
+
+cache
+-----
+
+..  confval:: cache
+    :name: svg-cache
+    :type: :ref:`cache <cache>`
+
+    See :ref:`cache function description <cache>` for details.
+
 ..  _cobj-svg-width:
 
 width


### PR DESCRIPTION
since https://docs.typo3.org/c/typo3/cms-core/master/en-us/Changelog/7.4/Feature-64200-AllowIndividualContentCaching.html

Every content object supports cache property.

Releases: main, 12.4, 11.5
Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/237