### PR TITLE
[BUGFIX] Resolve duplicate link anchors

### DIFF
--- a/Documentation/DataTypes/Index.rst
+++ b/Documentation/DataTypes/Index.rst
@@ -227,7 +227,7 @@ function name
 
 
 ..  index:: Simple data types; getText
-..  _data-type-getText:
+..  _data-type-function-getText:
 
 getText
 =======

--- a/Documentation/Functions/Htmlparser.rst
+++ b/Documentation/Functions/Htmlparser.rst
@@ -52,7 +52,7 @@ stripEmptyTags.keepTags
     Comma separated list of tags to keep when applying :php:`strip_tags()`.
 
 
-..  _htmlparser-tags:
+..  _htmlparser-function-tags:
 
 tags.[tagname]
 --------------

--- a/Documentation/Functions/OptionSplit.rst
+++ b/Documentation/Functions/OptionSplit.rst
@@ -135,6 +135,7 @@ Full example to see how it works
 Let's look at a full example that visualizes what we have said so far.
 
 .. _optionsplit-example-three-by-three-items:
+
 Three by three items
 --------------------
 
@@ -283,7 +284,8 @@ And again:
       20     a r r r r r r r r r r r r r r r r r r z
 
 
-.. _optionsplit-example-three-by-three-items:
+.. _optionsplit-example-two-by-three-items:
+
 Two by three items
 ------------------
 

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -10,7 +10,7 @@ CROP
     This object resets :ref:`gifbuilder-properties-workArea` to the
     new dimensions of the image!
 
-..  _gifbuilder-properties:
+..  _gifbuilder-crop-properties:
 
 Properties
 ==========

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -26,7 +26,7 @@ Example
       10.color = red
     }
 
-..  _gifbuilder-properties:
+..  _gifbuilder-ellipse-properties:
 
 Properties
 ==========

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -130,7 +130,7 @@ Good, general PAGE object names to use are:
 These are just recommendations. However, especially the name page for the content bearing page
 is very common and most documentation will imply that your main page object is called page.
 
-..  _page_examples:
+..  _page_examples-link:
 
 Examples
 ========


### PR DESCRIPTION
They cause warnings since the newest version of the render-guides