### PR TITLE
[BACKPORT 12.4][TASK] Introduce `Build/Scripts/runTests.sh`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint:
+    name: Linting
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php:
+          - '8.2'
+          - '8.3'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint PHP
+        run: Build/Scripts/runTests.sh -p ${{ matrix.php }} -s lint
+
+  quality:
+    name: Quality
+    runs-on: ubuntu-latest
+    env:
+      php: '8.2'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install testing system
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerUpdate
+
+      - name: Composer validate
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerValidate
+
+      - name: Composer normalize
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s composerNormalize -n
+
+      - name: CGL
+        run: Build/Scripts/runTests.sh -n -p ${{ env.php }} -s cgl -n
+
+      - name: Lint YAML
+        run: Build/Scripts/runTests.sh -p ${{ env.php }} -s yamlLint

--- a/Build/.gitignore
+++ b/Build/.gitignore
@@ -1,0 +1,1 @@
+testing-docker/.env

--- a/Build/.php-cs-fixer.dist.php
+++ b/Build/.php-cs-fixer.dist.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use PhpCsFixer\Config;
+use PhpCsFixer\Finder;
+
+return (new Config())
+    ->setFinder(
+        (new Finder())
+            ->in(__DIR__.'/../Documentation')
+    )
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@DoctrineAnnotation' => true,
+        // @todo: Switch to @PER-CS2.0 once php-cs-fixer's todo list is done: https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/7247
+        '@PER-CS1.0' => true,
+        'array_indentation' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'cast_spaces' => ['space' => 'none'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'concat_space' => ['spacing' => 'one'],
+        'declare_equal_normalize' => ['space' => 'none'],
+        'declare_parentheses' => true,
+        'dir_constant' => true,
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'function_declaration' => [
+            'closure_fn_spacing' => 'none',
+        ],
+        'function_to_constant' => ['functions' => ['get_called_class', 'get_class', 'get_class_this', 'php_sapi_name', 'phpversion', 'pi']],
+        'type_declaration_spaces' => true,
+        'global_namespace_import' => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+        'list_syntax' => ['syntax' => 'short'],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'method_argument_space' => true,
+        'modernize_strpos' => true,
+        'modernize_types_casting' => true,
+        'native_function_casing' => true,
+        'no_alias_functions' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_empty_phpdoc' => true,
+        'no_empty_statement' => true,
+        'no_extra_blank_lines' => true,
+        'no_leading_namespace_whitespace' => true,
+        'no_null_property_initialization' => true,
+        'no_short_bool_cast' => true,
+        'no_singleline_whitespace_before_semicolons' => true,
+        'no_superfluous_elseif' => true,
+        'no_trailing_comma_in_singleline' => true,
+        'no_unneeded_control_parentheses' => true,
+        'no_unused_imports' => true,
+        'no_useless_nullsafe_operator' => true,
+        'ordered_imports' => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+        'php_unit_construct' => ['assertions' => ['assertEquals', 'assertSame', 'assertNotEquals', 'assertNotSame']],
+        'php_unit_mock_short_will_return' => true,
+        'php_unit_test_case_static_method_calls' => ['call_type' => 'self'],
+        'phpdoc_no_access' => true,
+        'phpdoc_no_empty_return' => true,
+        'phpdoc_no_package' => true,
+        'phpdoc_scalar' => true,
+        'phpdoc_trim' => true,
+        'phpdoc_types' => true,
+        'phpdoc_types_order' => ['null_adjustment' => 'always_last', 'sort_algorithm' => 'none'],
+        'return_type_declaration' => ['space_before' => 'none'],
+        'single_quote' => true,
+        'single_space_around_construct' => true,
+        'single_line_comment_style' => ['comment_types' => ['hash']],
+        // @todo: Can be dropped once we enable @PER-CS2.0
+        'single_line_empty_body' => true,
+        'trailing_comma_in_multiline' => ['elements' => ['arguments', 'arrays', 'match', 'parameters']],
+        'whitespace_after_comma_in_array' => ['ensure_single_space' => true],
+        'yoda_style' => ['equal' => false, 'identical' => false, 'less_and_greater' => false],
+
+        // We need this for documentation!
+        'no_useless_else' => false, // We want to preserve else with comments only
+    ]);

--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -1,0 +1,367 @@
+#!/usr/bin/env bash
+
+#
+# EXT:examples test runner based on docker/podman.
+#
+
+cleanUp() {
+    ATTACHED_CONTAINERS=$(${CONTAINER_BIN} ps --filter network=${NETWORK} --format='{{.Names}}')
+    for ATTACHED_CONTAINER in ${ATTACHED_CONTAINERS}; do
+        ${CONTAINER_BIN} rm -f ${ATTACHED_CONTAINER} >/dev/null
+    done
+    ${CONTAINER_BIN} network rm ${NETWORK} >/dev/null
+}
+
+cleanCacheFiles() {
+    echo -n "Clean caches ... "
+    rm -rf \
+        .Build/.cache \
+        .php-cs-fixer.cache
+    echo "done"
+}
+
+cleanRenderedDocumentationFiles() {
+    echo -n "Clean rendered documentation files ... "
+    rm -rf \
+        Documentation-GENERATED-temp
+    echo "done"
+}
+
+loadHelp() {
+    # Load help text into $HELP
+    read -r -d '' HELP <<EOF
+EXT:examples test runner. Check code styles, lint PHP files and some other details.
+
+Usage: $0 [options] [file]
+
+Options:
+    -s <...>
+        Specifies which test suite to run
+            - cgl: cgl test and fix all php files
+            - clean: Clean temporary files
+            - cleanCache: Clean cache folds for files.
+            - cleanRenderedDocumentation: Clean existing rendered documentation output.
+            - composer: "composer" with all remaining arguments dispatched.
+            - composerNormalize: "composer normalize"
+            - composerUpdate: "composer update", handy if host has no PHP
+            - composerValidate: "composer validate"
+            - lint: PHP linting
+            - phpstan: PHPStan static analysis
+            - phpstanBaseline: Generate PHPStan baseline
+            - rector: Apply Rector rules
+            - renderDocumentation
+            - testRenderDocumentation
+            - yamlLint: YAML linting
+
+    -b <docker|podman>
+        Container environment:
+            - docker
+            - podman
+
+        If not specified, podman will be used if available. Otherwise, docker is used.
+
+    -p <8.2|8.3>
+        Specifies the PHP minor version to be used
+            - 8.2: (default) use PHP 8.2
+            - 8.3: use PHP 8.3
+    -n
+        Only with -s cgl, composerNormalize, rector
+        Activate dry-run in CGL check and composer normalize that does not actively change files and only prints broken ones.
+
+    -u
+        Update existing typo3/core-testing-*:latest container images and remove dangling local volumes.
+        New images are published once in a while and only the latest ones are supported by core testing.
+        Use this if weird test errors occur. Also removes obsolete image versions of typo3/core-testing-*.
+
+    -h
+        Show this help.
+
+Examples:
+    # Run unit tests using PHP 8.2
+    ./Build/Scripts/runTests.sh
+EOF
+}
+
+# Test if docker exists, else exit out with error
+if ! type "docker" >/dev/null 2>&1 && ! type "podman" >/dev/null 2>&1; then
+    echo "This script relies on docker or podman. Please install" >&2
+    exit 1
+fi
+
+# Option defaults
+TEST_SUITE="cgl"
+PHP_VERSION="8.2"
+PHP_XDEBUG_ON=0
+PHP_XDEBUG_PORT=9003
+CGLCHECK_DRY_RUN=0
+CI_PARAMS="${CI_PARAMS:-}"
+DOCS_PARAMS="${DOCS_PARAMS:=--pull always}"
+CONTAINER_BIN=""
+CONTAINER_HOST="host.docker.internal"
+
+# Option parsing updates above default vars
+# Reset in case getopts has been used previously in the shell
+OPTIND=1
+# Array for invalid options
+INVALID_OPTIONS=()
+# Simple option parsing based on getopts (! not getopt)
+while getopts "b:s:p:xy:nhu" OPT; do
+    case ${OPT} in
+        s)
+            TEST_SUITE=${OPTARG}
+            ;;
+        b)
+            if ! [[ ${OPTARG} =~ ^(docker|podman)$ ]]; then
+                INVALID_OPTIONS+=("${OPTARG}")
+            fi
+            CONTAINER_BIN=${OPTARG}
+            ;;
+        p)
+            PHP_VERSION=${OPTARG}
+            if ! [[ ${PHP_VERSION} =~ ^(8.2|8.3)$ ]]; then
+                INVALID_OPTIONS+=("p ${OPTARG}")
+            fi
+            ;;
+        x)
+            PHP_XDEBUG_ON=1
+            ;;
+        y)
+            PHP_XDEBUG_PORT=${OPTARG}
+            ;;
+        n)
+            CGLCHECK_DRY_RUN=1
+            ;;
+        h)
+            loadHelp
+            echo "${HELP}"
+            exit 0
+            ;;
+        u)
+            TEST_SUITE=update
+            ;;
+        \?)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+        :)
+            INVALID_OPTIONS+=("${OPTARG}")
+            ;;
+    esac
+done
+
+# Exit on invalid options
+if [ ${#INVALID_OPTIONS[@]} -ne 0 ]; then
+    echo "Invalid option(s):" >&2
+    for I in "${INVALID_OPTIONS[@]}"; do
+        echo "-"${I} >&2
+    done
+    echo >&2
+    echo "call \".Build/Scripts/runTests.sh -h\" to display help and valid options"
+    exit 1
+fi
+
+COMPOSER_ROOT_VERSION="13.0.x-dev"
+HOST_UID=$(id -u)
+USERSET=""
+if [ $(uname) != "Darwin" ]; then
+    USERSET="--user $HOST_UID"
+fi
+
+# Go to the directory this script is located, so everything else is relative
+# to this dir, no matter from where this script is called, then go up two dirs.
+THIS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+cd "$THIS_SCRIPT_DIR" || exit 1
+cd ../../ || exit 1
+ROOT_DIR="${PWD}"
+
+# Create .cache dir: composer need this.
+mkdir -p .Build/.cache
+mkdir -p .Build/Web/typo3temp/var/tests
+
+IMAGE_PREFIX="docker.io/"
+# Non-CI fetches TYPO3 images (php and nodejs) from ghcr.io
+TYPO3_IMAGE_PREFIX="ghcr.io/typo3/"
+CONTAINER_INTERACTIVE="-it --init"
+
+IS_CORE_CI=0
+# ENV var "CI" is set by gitlab-ci. We use it here to distinct 'local' and 'CI' environment.
+if [ "${CI}" == "true" ]; then
+    IS_CORE_CI=1
+    IMAGE_PREFIX=""
+    CONTAINER_INTERACTIVE=""
+fi
+
+# determine default container binary to use: 1. podman 2. docker
+if [[ -z "${CONTAINER_BIN}" ]]; then
+    if type "podman" >/dev/null 2>&1; then
+        CONTAINER_BIN="podman"
+    elif type "docker" >/dev/null 2>&1; then
+        CONTAINER_BIN="docker"
+    fi
+fi
+
+IMAGE_PHP="${TYPO3_IMAGE_PREFIX}core-testing-$(echo "php${PHP_VERSION}" | sed -e 's/\.//'):latest"
+IMAGE_ALPINE="${IMAGE_PREFIX}alpine:3.8"
+IMAGE_DOCS="ghcr.io/typo3-documentation/render-guides:latest"
+
+# Set $1 to first mass argument, this is the optional test file or test directory to execute
+shift $((OPTIND - 1))
+
+SUFFIX=$(echo $RANDOM)
+NETWORK="t3docsexamples-${SUFFIX}"
+${CONTAINER_BIN} network create ${NETWORK} >/dev/null
+
+if [ ${CONTAINER_BIN} = "docker" ]; then
+    # docker needs the add-host for xdebug remote debugging. podman has host.container.internal built in
+    CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} --rm --network ${NETWORK} --add-host "${CONTAINER_HOST}:host-gateway" ${USERSET} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    CONTAINER_DOCS_PARAMS="${CONTAINER_INTERACTIVE} ${DOCS_PARAMS} --rm --network ${NETWORK} --add-host "${CONTAINER_HOST}:host-gateway" ${USERSET} -v ${ROOT_DIR}:/project"
+else
+    # podman
+    CONTAINER_HOST="host.containers.internal"
+    CONTAINER_COMMON_PARAMS="${CONTAINER_INTERACTIVE} ${CI_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:${ROOT_DIR} -w ${ROOT_DIR}"
+    CONTAINER_DOCS_PARAMS="${CONTAINER_INTERACTIVE} ${DOCS_PARAMS} --rm --network ${NETWORK} -v ${ROOT_DIR}:/project"
+fi
+
+if [ ${PHP_XDEBUG_ON} -eq 0 ]; then
+    XDEBUG_MODE="-e XDEBUG_MODE=off"
+    XDEBUG_CONFIG=" "
+else
+    XDEBUG_MODE="-e XDEBUG_MODE=debug -e XDEBUG_TRIGGER=foo"
+    XDEBUG_CONFIG="client_port=${PHP_XDEBUG_PORT} client_host=host.docker.internal"
+fi
+
+# Suite execution
+case ${TEST_SUITE} in
+    cgl)
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --dry-run --diff --config=Build/.php-cs-fixer.dist.php --using-cache=no"
+        else
+            COMMAND="php -dxdebug.mode=off .Build/bin/php-cs-fixer fix -v --config=Build/.php-cs-fixer.dist.php --using-cache=no"
+        fi
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name cgl-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    clean)
+        cleanCacheFiles
+        cleanRenderedDocumentationFiles
+        ;;
+    cleanCache)
+        cleanCacheFiles
+        ;;
+    cleanRenderedDocumentation)
+        cleanRenderedDocumentationFiles
+        ;;
+    composer)
+        COMMAND=(composer "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerNormalize)
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            COMMAND=(composer normalize -n)
+        else
+            COMMAND=(composer normalize)
+        fi
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    composerUpdate)
+        rm -rf .Build/bin/ .Build/typo3 .Build/vendor .Build/Web ./composer.lock
+        cp ${ROOT_DIR}/composer.json ${ROOT_DIR}/composer.json.orig
+        if [ -f "${ROOT_DIR}/composer.json.testing" ]; then
+            cp ${ROOT_DIR}/composer.json ${ROOT_DIR}/composer.json.orig
+        fi
+        COMMAND=(composer require --no-ansi --no-interaction --no-progress)
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-install-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        cp ${ROOT_DIR}/composer.json ${ROOT_DIR}/composer.json.testing
+        mv ${ROOT_DIR}/composer.json.orig ${ROOT_DIR}/composer.json
+        ;;
+    composerValidate)
+        COMMAND=(composer validate "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    lint)
+        COMMAND="find . -name \\*.php ! -path "./.Build/\\*" -print0 | xargs -0 -n1 -P4 php -dxdebug.mode=off -l >/dev/null"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name composer-command-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstan)
+        COMMAND="php -dxdebug.mode=off .Build/bin/phpstan --configuration=Build/phpstan/phpstan.neon"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    phpstanBaseline)
+        COMMAND="php -dxdebug.mode=off .Build/bin/phpstan --configuration=Build/phpstan/phpstan.neon --generate-baseline=Build/phpstan/phpstan-baseline.neon -v"
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name phpstan-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    rector)
+        if [ "${CGLCHECK_DRY_RUN}" -eq 1 ]; then
+            COMMAND=(php -dxdebug.mode=off .Build/bin/rector -n --config=Build/rector/rector.php --clear-cache "$@")
+        else
+            COMMAND=(php -dxdebug.mode=off .Build/bin/rector --config=Build/rector/rector.php --clear-cache "$@")
+        fi
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name rector-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    renderDocumentation)
+        COMMAND=(--config=Documentation "$@")
+        mkdir -p Documentation-GENERATED-temp
+        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} ${CONTAINER_DOCS_PARAMS} --name render-documentation-${SUFFIX} ${IMAGE_DOCS} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    testRenderDocumentation)
+        COMMAND=(--config=Documentation --no-progress --fail-on-log "$@")
+        mkdir -p Documentation-GENERATED-temp
+        ${CONTAINER_BIN} run ${CONTAINER_INTERACTIVE} ${CONTAINER_DOCS_PARAMS} --name render-documentation-test-${SUFFIX} ${IMAGE_DOCS} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    update)
+        # pull typo3/core-testing-* versions of those ones that exist locally
+        echo "> pull ${TYPO3_IMAGE_PREFIX}core-testing-* versions of those ones that exist locally"
+        ${CONTAINER_BIN} images "${TYPO3_IMAGE_PREFIX}core-testing-*" --format "{{.Repository}}:{{.Tag}}" | xargs -I {} ${CONTAINER_BIN} pull {}
+        echo ""
+        # remove "dangling" typo3/core-testing-* images (those tagged as <none>)
+        echo "> remove \"dangling\" ${TYPO3_IMAGE_PREFIX}/core-testing-* images (those tagged as <none>)"
+        ${CONTAINER_BIN} images --filter "reference=${TYPO3_IMAGE_PREFIX}/core-testing-*" --filter "dangling=true" --format "{{.ID}}" | xargs -I {} ${CONTAINER_BIN} rmi -f {}
+        echo ""
+        ;;
+    yamlLint)
+        COMMAND=(php -dxdebug.mode=off .Build/bin/yaml-lint Documentation/ "$@")
+        ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name yamlLint-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} "${COMMAND[@]}"
+        SUITE_EXIT_CODE=$?
+        ;;
+    *)
+        loadHelp
+        echo "Invalid -s option argument ${TEST_SUITE}" >&2
+        echo >&2
+        echo "${HELP}" >&2
+        exit 1
+        ;;
+esac
+
+cleanUp
+
+# Print summary
+echo "" >&2
+echo "###########################################################################" >&2
+echo "Result of ${TEST_SUITE}" >&2
+echo "Container runtime: ${CONTAINER_BIN}" >&2
+if [[ ${IS_CORE_CI} -eq 1 ]]; then
+    echo "Environment: CI" >&2
+else
+    echo "Environment: local" >&2
+fi
+echo "PHP: ${PHP_VERSION}" >&2
+echo "TYPO3: ${CORE_VERSION}" >&2
+if [[ ${SUITE_EXIT_CODE} -eq 0 ]]; then
+    echo "SUCCESS" >&2
+else
+    echo "FAILURE" >&2
+fi
+echo "###########################################################################" >&2
+echo "" >&2
+
+# Exit with code of test suite - This script return non-zero if the executed test failed.
+exit $SUITE_EXIT_CODE

--- a/Documentation/CodeSnippets/Config/DataProcessing.php
+++ b/Documentation/CodeSnippets/Config/DataProcessing.php
@@ -1,4 +1,5 @@
 <?php
+
 // included in codesnippets.php
 
 return [
@@ -6,132 +7,132 @@ return [
         'action' => 'createCodeSnippet',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/General.typoscript',
         'targetFileName' => 'CodeSnippets/DataProcessing/DataProcessingTemplates.rst.txt',
-        'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/General.typoscript'
+        'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/General.typoscript',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CommaSeparatedValueProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CommaSeparatedValueProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CommaSeparatedValueProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CommaSeparatedValueProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/DatabaseQueryProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/DatabaseQueryProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/DatabaseQueryProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/DatabaseQueryProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CommaSeparatedValueProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CommaSeparatedValueProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CommaSeparatedValueProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CommaSeparatedValueProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/FilesProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/FilesProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/FilesProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/FilesProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/GalleryProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/GalleryProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/GalleryProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/GalleryProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/LanguageMenuProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/LanguageMenuProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/LanguageMenuProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/LanguageMenuProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/MenuProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/MenuProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/MenuProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/MenuProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SiteProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SiteProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SiteProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SiteProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SiteLanguageProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SiteLanguageProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SiteLanguageProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SiteLanguageProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SplitProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/SplitProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SplitProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/SplitProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CustomCategoryProcessor.typoscript',
         'sourceFile' => 'EXT:examples/Configuration/TypoScript/DataProcessors/Processors/CustomCategoryProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CustomCategoryProcessor.rst.txt'
+        'targetFileName' => 'CodeSnippets/DataProcessing/TypoScript/CustomCategoryProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCsv.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCsv.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcCsv.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCsv.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcCsv.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCustom.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCustom.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcCustom.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcCustom.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcCustom.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcDb.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcDb.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcDb.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcDb.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcDb.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcFiles.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcFiles.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcFiles.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcFiles.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcFiles.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcGallery.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcGallery.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcGallery.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcGallery.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcGallery.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcLangMenu.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcLangMenu.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcLangMenu.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcLangMenu.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcLangMenu.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcMenu.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcMenu.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcMenu.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcMenu.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcMenu.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSite.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSite.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSite.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSite.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSite.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSplit.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSplit.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSplit.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSplit.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSplit.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSiteLanguage.html',
-        'sourceFile'=> 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSiteLanguage.html',
-        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSiteLanguage.rst.txt'
+        'sourceFile' => 'EXT:examples/Resources/Private/Templates/ContentElements/DataProcSiteLanguage.html',
+        'targetFileName' => 'CodeSnippets/DataProcessing/Template/DataProcSiteLanguage.rst.txt',
     ],
 ];

--- a/Documentation/CodeSnippets/Config/Menus.php
+++ b/Documentation/CodeSnippets/Config/Menus.php
@@ -1,4 +1,5 @@
 <?php
+
 // included in codesnippets.php
 
 return [
@@ -6,98 +7,98 @@ return [
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript',
-        'sourceFile'=> 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuRecentlyUpdated.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRecentlyUpdated.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuRecentlyUpdated.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRecentlyUpdated.html',
-        'sourceFile'=> 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRecentlyUpdated.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/MenuRecentlyUpdated.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRecentlyUpdated.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/MenuRecentlyUpdated.rst.txt',
     ],
     // special = keywords
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript',
-        'sourceFile'=> 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuRelatedPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuRelatedPages.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuRelatedPages.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRelatedPages.html',
-        'sourceFile'=> 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRelatedPages.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/MenuRelatedPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuRelatedPages.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/MenuRelatedPages.rst.txt',
     ],
     // special = directory
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuSubpages.typoscript',
-        'sourceFile'=> 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuSubpages.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuSubpages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuSubpages.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuSubpages.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuSubpages.html',
-        'sourceFile'=> 'EXT:fluid_styled_content/Resources/Private/Templates/MenuSubpages.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/MenuSubpages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuSubpages.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/MenuSubpages.rst.txt',
     ],
     // special = list
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuPages.typoscript',
-        'sourceFile'=> 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuPages.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuPages.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuPages.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuPages.html',
-        'sourceFile'=> 'EXT:fluid_styled_content/Resources/Private/Templates/MenuPages.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/MenuPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuPages.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/MenuPages.rst.txt',
     ],
     // special = categories
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript',
-        'sourceFile'=> 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuCategorizedPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Configuration/TypoScript/ContentElement/MenuCategorizedPages.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/MenuCategorizedPages.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuCategorizedPages.html',
-        'sourceFile'=> 'EXT:fluid_styled_content/Resources/Private/Templates/MenuCategorizedPages.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/MenuCategorizedPages.rst.txt'
+        'sourceFile' => 'EXT:fluid_styled_content/Resources/Private/Templates/MenuCategorizedPages.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/MenuCategorizedPages.rst.txt',
     ],
     // special = browse
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:site_package/Configuration/TypoScript/Seo/Setup/RelPrevNextMenu.typoscript',
-        'sourceFile'=> 'EXT:site_package/Configuration/TypoScript/Seo/Setup/RelPrevNextMenu.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/RelPrevNextMenu.rst.txt'
+        'sourceFile' => 'EXT:site_package/Configuration/TypoScript/Seo/Setup/RelPrevNextMenu.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/RelPrevNextMenu.rst.txt',
     ],
     // special = rootline
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbLib.typoscript',
-        'sourceFile'=> 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbLib.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/BreadcrumbLib.rst.txt'
+        'sourceFile' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbLib.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/BreadcrumbLib.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbDataProcessor.typoscript',
-        'sourceFile'=> 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbDataProcessor.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/BreadcrumbDataProcessor.rst.txt'
+        'sourceFile' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/BreadcrumbDataProcessor.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/BreadcrumbDataProcessor.rst.txt',
     ],
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:site_package/Resources/Private/Partials/Page/Navigation/Breadcrumb.html',
-        'sourceFile'=> 'EXT:site_package/Resources/Private/Partials/Page/Navigation/Breadcrumb.html',
-        'targetFileName' => 'CodeSnippets/Menu/Template/BreadcrumbDataProcessor.rst.txt'
+        'sourceFile' => 'EXT:site_package/Resources/Private/Partials/Page/Navigation/Breadcrumb.html',
+        'targetFileName' => 'CodeSnippets/Menu/Template/BreadcrumbDataProcessor.rst.txt',
     ],
     // special = language
     [
         'action' => 'createCodeSnippet',
         'caption' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/LanguageMenuLib.typoscript',
-        'sourceFile'=> 'EXT:site_package/Configuration/TypoScript/Menus/Setup/LanguageMenuLib.typoscript',
-        'targetFileName' => 'CodeSnippets/Menu/TypoScript/LanguageMenuLib.rst.txt'
+        'sourceFile' => 'EXT:site_package/Configuration/TypoScript/Menus/Setup/LanguageMenuLib.typoscript',
+        'targetFileName' => 'CodeSnippets/Menu/TypoScript/LanguageMenuLib.rst.txt',
     ],
 ];

--- a/Documentation/codesnippets.php
+++ b/Documentation/codesnippets.php
@@ -1,8 +1,9 @@
 <?php
+
 // https://github.com/TYPO3-Documentation/t3docs-codesnippets
 // ddev exec vendor/bin/typo3  restructured_api_tools:php_domain public/fileadmin/TYPO3CMS-Reference-Typoscript/Documentation
 
 return array_merge(
-    include('CodeSnippets/Config/DataProcessing.php'),
-    include('CodeSnippets/Config/Menus.php'),
+    include ('CodeSnippets/Config/DataProcessing.php'),
+    include ('CodeSnippets/Config/Menus.php'),
 );

--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,21 @@ test-docs: ## Test the documentation rendering
 
 	docker run --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log --output-format=html
 
+.PHONY: test-lint
+test-lint: ## Lint included code snippets
+	Build/Scripts/runTests.sh -s lint
+
+.PHONY: test-cgl
+test-cgl: ## Apply cgl to included code snippets
+	Build/Scripts/runTests.sh -s cgl -n
+
+.PHONY: test-yaml
+test-yaml: ## lint the yaml
+	Build/Scripts/runTests.sh -s yamlLint
+
+.PHONY: test
+test: test-docs test-lint test-cgl test-yaml## Test the documentation rendering
+
+.PHONY: fix
+fix: ## Fix cgl
+	Build/Scripts/runTests.sh -s cgl

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,17 @@
     "config": {
         "allow-plugins": {
             "typo3/cms-composer-installers": true,
-            "typo3/class-alias-loader": true
+            "typo3/class-alias-loader": true,
+            "ergebnis/composer-normalize": true
         },
+        "bin-dir": ".Build/bin",
+        "sort-packages": true,
         "vendor-dir": ".Build/vendor"
     },
     "require-dev": {
+        "ergebnis/composer-normalize": "~2.41.0",
+        "friendsofphp/php-cs-fixer": "^3.46",
+        "symfony/yaml": "^7.0",
         "t3docs/codesnippet": "dev-main",
         "typo3/cms-adminpanel": "^12.4",
         "typo3/cms-backend": "^12.4",


### PR DESCRIPTION
Following the scheme provided by @sbuerk

This change introduces `Build/Scripts/runTests.sh` execution wrapper in line with current TYPO3
Core implementation.

We introduce cgl and linting tests for code includes. And apply cgl.