### PR TITLE
[TASK] Fix headline level for prefixLocalAnchors

### DIFF
--- a/Documentation/Functions/HtmlparserTags.rst
+++ b/Documentation/Functions/HtmlparserTags.rst
@@ -228,7 +228,7 @@ fixAttrib.[attribute].casesensitiveComp
 .. _htmlparser-tags-fixattrib-attribute-prefixlocalanchors:
 
 fixAttrib.[attribute].prefixLocalAnchors
-========================================
+----------------------------------------
 
 :aspect:`Property`
    fixAttrib.[attribute].prefixLocalAnchors


### PR DESCRIPTION
This fix is only necessary for the 11.5 branch.
In newer branches `prefixLocalAnchors` isn't present anymore and in older branches, everything is fine.