### PR TITLE
[TASK] Properly document typolink.userFunc usage

### DIFF
--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -165,7 +165,8 @@ userFunc
     :type: :ref:`data-type-function-name`
 
     This passes the non-tag content to a function of your own choice.
-    Similar to, for example, :ref:`stdwrap-postUserFunc` in :ref:`stdWrap`.
+    Similar to, for example, :ref:`stdwrap-postUserFunc` in :ref:`stdWrap`,
+    or :ref:`typolink.userFunc <typolink-userFunc>`.
 
     Remember the function name must possibly be prepended :php:`user_`.
 

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -561,61 +561,33 @@ userFunc
 
     `$content`
         This contains the object implementing :php:`LinkResultInterface`. Inside your :php:`userFunc()` you
-        can call :php:`$content->getUrl()` to get the URL of a link, or :php:`$content->getLinkText()`
-        to get the title of your link. :php:`$content->getLinkConfiguration()` returns an array
-        with all typolink configuration options, and :php:`$content->getAttributes()`
-        (like :typoscript:`typolink.additionalArguments`) returns current anchor link attributes.
-        :php:`$content->getType()` returns the kind of link that is returned like
-        :php:`LinkService::TYPE_PAGE` (specific pages in your TYPO3 setup) or :php:`LinkService::TYPE_URL`
-        for links to external pages.
+        can call for example:
 
-        See the PHP definition of `LinkResultInterface` for the full list of getters.
+        *  :php:`$content->getUrl()` to get the URL of a link,
+        *  :php:`$content->getLinkText()` to get the title of your link,
+        *  :php:`$content->getLinkConfiguration()` for the array with all typolink configuration options,
+        *  :php:`$content->getAttributes()` returns current anchor link attributes (like :typoscript:`typolink.additionalArguments`),
+        *  :php:`$content->getType()` returns the kind of link that is operated on, like
+           :php:`LinkService::TYPE_PAGE` (specific pages in your TYPO3 setup) or :php:`LinkService::TYPE_URL`
+           for links to external pages.
 
-        Since `LinkResultInterface` is an immutable object, you must use the methods :php:`withLinkText()`
-        and/or :php:`withAttributes()` to return a new object variant, which at the end of your
-        :php:`userFunc` must be returned (see below for an example). In case you do not make any
+        See the PHP definition of :php:`LinkResultInterface` for the full list of getters.
+
+        Since :php:`LinkResultInterface` is an immutable object, you must use the methods :php:`withLinkText()`
+        and/or :php:`withAttributes()` to create a new object variant, which at the end of your
+        :php:`userFunc` must be returned (see below for examples). In case you do not make any
         changes to the object, the function must return the original object.
 
     `$conf`
-        Contains an array of the TypoScript configuration of your :typoScript:`userFunc` parameters.
+        Contains an array of the TypoScript configuration of your :typoscript:`userFunc` parameters.
 
     `$request`
         Contains the PSR-7 request object that allows you to operate on your current frontend
         environment and retrieve things like Site Settings, current Language, current URL,
-        related `ContentObjectRenderer` (`$cObj`) and other aspects,
+        related :php:`ContentObjectRenderer` (:php:`$cObj`) and other aspects,
         see :ref:`TYPO3 request object <t3coreapi:typo3-request>`.
 
-    Give this TypoScript example:
-
-    ..  literalinclude:: _StdWrap/_UserFunc.typoscript
-        :language: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
-
-    This would first create a TypoLink :php:`LinkResultInterface` that would resolve to something like
-    `<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Title</a>`.
-
-    But because `userFunc = MyVendor\SitePackage\UserFunctions\TypoLinkUserFunc->createUserFuncLink`
-    is defined you can now manipulate the generated link to your liking:
-
-    ..  literalinclude:: _StdWrap/_UserFunc.php
-        :language: php
-        :caption: EXT:site_package/Classes/UserFunctions/TypoLinkUserFunc.php
-
-    This class would take the :php:`LinkResultInterface` object, retrieve some data from it,
-    alter it, pass it to a new immutable object and return that. Then this is what finally
-    gets emitted after full processing:
-
-    ..  code-block:: html
-        <a href="/en/pages/4711/event/18"
-           target="_blank"
-           title="Custom: My Link Title"
-           rel="noreferrer">Event Title #18</a>
-
-
-    You can also apply a custom `userFunc` to vital things like the
-    :ref:`lib.parseFunc_RTE.userFunc <t3tsref:parsefunc-userFunc>`
-    routine. This would allow you to modify any kind of link generated from the
-    parsing of the Rich-Text-Editor (RTE).
+    See :ref:`typolink-userfunc-examples` for more details.
 
 ..  index:: typolink; Resource references
 ..  _typolink-resource_references:

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -543,27 +543,66 @@ userFunc
     :name: typolink-userFunc
     :type: :ref:`data-type-function-name`
 
-    This passes the link-data compiled by the typolink function to a user-
-    defined function for final manipulation.
+    As `userFunc` is the last property of `typolink`, all previous properties
+    have already been processed into an object of type `LinkResultInterface`,
+    which is passed as the first parameter to the defined `userFunc` for
+    further manipulation.
 
-    The :php:`$content` variable passed to the user-function (first parameter) is
-    an array with the keys "TYPE", "TAG", "url", "targetParams" and
-    "aTagParams".
+    All `typolink` properties are passed as an array as the second parameter.
 
-    TYPE is an indication of link-kind: mailto, url, file, page
+    The current request object incl. current instance of `ContentObjectRenderer`
+    will be passed as third parameter.
 
-    TAG is the full <A>-tag as generated and ready from the typolink
-    function.
+    As the `userFunc` property must also return an object of type
+    `LinkResultInterface`, it makes sense to use this LinkResult object
+    passed and customise it to suit your needs.
 
-    The actual tag value is constructed like this:
+    ..  code-block:: typoscript
+
+        # Register your UserFunc with TypoScript
+        lib.parseFunc_RTE.userFunc = MyVendor\MySitePackage\UserFunc\ModifyTypoLinkUserFunc->modifyTypoLinkResult
+
+    The following PHP example checks whether the object passed contains a link
+    of type `page` (this is the value behind: `LinkService::TYPE_PAGE`). If yes,
+    the link is opened in a new browser tab, the link title is set to the page
+    title and the link text will be wrapped in :html:`<strong>` tags.
 
     ..  code-block:: php
 
-        $contents = '<a href="' . $finalTagParts['url'] . '"'
-                   . $finalTagParts['targetParams']
-                   . $finalTagParts['aTagParams'] . '>';
+        <?php
 
-    The userfunction must return an <A>-tag.
+        declare(strict_types=1);
+
+        namespace MyVendor\MySitePackage\UserFunc;
+
+        use Psr\Http\Message\ServerRequestInterface;
+        use TYPO3\CMS\Core\LinkHandling\LinkService;
+        use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+        use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+
+        class ModifyTypoLinkUserFunc
+        {
+            public function modifyTypoLinkResult(
+                LinkResultInterface $linkResult,
+                array $conf,
+                ServerRequestInterface $request
+            ): LinkResultInterface {
+                if ($linkResult->getType() === LinkService::TYPE_PAGE) {
+                    $cObj = $this->getContentObjectRenderer($request);
+                    return $linkResult
+                        ->withTarget('_blank')
+                        ->withAttribute('title', $cObj->data['title'])
+                        ->withLinkText($cObj->stdWrap_dataWrap('<strong>{FIELD:title}</strong'));
+                }
+
+                return $linkResult;
+            }
+
+            protected function getContentObjectRenderer(ServerRequestInterface $request): ContentObjectRenderer
+            {
+                return $request->getAttribute('currentContentObject');
+            }
+        }
 
 ..  index:: typolink; Resource references
 ..  _typolink-resource_references:

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -553,18 +553,18 @@ userFunc
     The detailed execution steps are:
 
     First, the :typoscript:`typolink` will be created as configured by the specified TypoScript.
-    This will result in an object of Type :php:`LinkResultInterface`. This object receives
+    This will result in an object of Type :php:`LinkResultInterface`. This immutable object receives
     all of the TypoScript :typoscript:`typolink` configuration as properties, and makes them
-    available via corresponding getters and setters.
-    Then your custom :typoscript:`userFunc` is executed and receives the following arguments
-    (delivered via :php:`$contentObjectRenderer->callUserFunction()`):
+    available via corresponding getters. Then your custom :typoscript:`userFunc` is executed
+    and receives the following arguments (delivered via :php:`$contentObjectRenderer->callUserFunction()`):
 
     `$content`
         This contains the object implementing :php:`LinkResultInterface`. Inside your :php:`userFunc()` you
         can call for example:
 
         *  :php:`$content->getUrl()` to get the URL of a link,
-        *  :php:`$content->getLinkText()` to get the title of your link,
+        *  :php:`$content->getLinkText()` to get the text of your link
+           (everything with the :html:`<a>...</a>` tag),
         *  :php:`$content->getLinkConfiguration()` for the array with all typolink configuration options,
         *  :php:`$content->getAttributes()` returns current anchor link attributes (like :typoscript:`typolink.additionalArguments`),
         *  :php:`$content->getType()` returns the kind of link that is operated on, like

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -614,7 +614,7 @@ userFunc
 
     You can also apply a custom `userFunc` to vital things like the
     :ref:`lib.parseFunc_RTE.userFunc <t3tsref:parsefunc-userFunc>`
-    routine. This would allowyou to modify any kind of link generated from the
+    routine. This would allow you to modify any kind of link generated from the
     parsing of the Rich-Text-Editor (RTE).
 
 ..  index:: typolink; Resource references

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -543,66 +543,79 @@ userFunc
     :name: typolink-userFunc
     :type: :ref:`data-type-function-name`
 
-    As `userFunc` is the last property of `typolink`, all previous properties
-    have already been processed into an object of type `LinkResultInterface`,
-    which is passed as the first parameter to the defined `userFunc` for
-    further manipulation.
+    All of the :typoscript:`typolink` TypoScript configuration will be parsed and evaluated
+    by the TYPO3 Core's :php:`LinkFactory->create()` method, and then passed on
+    to the defined :typoscript:`userFunc` for further manipulation. The :typoscript:`userFunc` needs to
+    return an object implementing the :php:`LinkResultInterface`. The currently calculated
+    typolink is passed as an argument to the :php:`userFunc` as an object of the same type. This allows
+    to return either an enriched link, or a completely new one.
 
-    All `typolink` properties are passed as an array as the second parameter.
+    The detailed execution steps are:
 
-    The current request object incl. current instance of `ContentObjectRenderer`
-    will be passed as third parameter.
+    First, the :typoscript:`typolink` will be created as configured by the specified TypoScript.
+    This will result in an object of Type :php:`LinkResultInterface`. This object receives
+    all of the TypoScript :typoscript:`typolink` configuration as properties, and makes them
+    available via corresponding getters and setters.
+    Then your custom :typoscript:`userFunc` is executed and receives the following arguments
+    (delivered via :php:`$contentObjectRenderer->callUserFunction()`):
 
-    As the `userFunc` property must also return an object of type
-    `LinkResultInterface`, it makes sense to use this LinkResult object
-    passed and customise it to suit your needs.
+    `$content`
+        This contains the object implementing :php:`LinkResultInterface`. Inside your :php:`userFunc()` you
+        can call :php:`$content->getUrl()` to get the URL of a link, or :php:`$content->getLinkText()`
+        to get the title of your link. :php:`$content->getLinkConfiguration()` returns an array
+        with all typolink configuration options, and :php:`$content->getAttributes()`
+        (like :typoscript:`typolink.additionalArguments`) returns current anchor link attributes.
+        :php:`$content->getType()` returns the kind of link that is returned like
+        :php:`LinkService::TYPE_PAGE` (specific pages in your TYPO3 setup) or :php:`LinkService::TYPE_URL`
+        for links to external pages.
 
-    ..  code-block:: typoscript
+        See the PHP definition of `LinkResultInterface` for the full list of getters.
 
-        # Register your UserFunc with TypoScript
-        lib.parseFunc_RTE.userFunc = MyVendor\MySitePackage\UserFunc\ModifyTypoLinkUserFunc->modifyTypoLinkResult
+        Since `LinkResultInterface` is an immutable object, you must use the methods :php:`withLinkText()`
+        and/or :php:`withAttributes()` to return a new object variant, which at the end of your
+        :php:`userFunc` must be returned (see below for an example). In case you do not make any
+        changes to the object, the function must return the original object.
 
-    The following PHP example checks whether the object passed contains a link
-    of type `page` (this is the value behind: `LinkService::TYPE_PAGE`). If yes,
-    the link is opened in a new browser tab, the link title is set to the page
-    title and the link text will be wrapped in :html:`<strong>` tags.
+    `$conf`
+        Contains an array of the TypoScript configuration of your :typoScript:`userFunc` parameters.
 
-    ..  code-block:: php
+    `$request`
+        Contains the PSR-7 request object that allows you to operate on your current frontend
+        environment and retrieve things like Site Settings, current Language, current URL,
+        related `ContentObjectRenderer` (`$cObj`) and other aspects,
+        see :ref:`TYPO3 request object <t3coreapi:typo3-request>`.
 
-        <?php
+    Give this TypoScript example:
 
-        declare(strict_types=1);
+    ..  literalinclude:: _StdWrap/_UserFunc.typoscript
+        :language: typoscript
+        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-        namespace MyVendor\MySitePackage\UserFunc;
+    This would first create a TypoLink :php:`LinkResultInterface` that would resolve to something like
+    `<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Title</a>`.
 
-        use Psr\Http\Message\ServerRequestInterface;
-        use TYPO3\CMS\Core\LinkHandling\LinkService;
-        use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-        use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+    But because `userFunc = MyVendor\SitePackage\UserFunctions\TypoLinkUserFunc->createUserFuncLink`
+    is defined you can now manipulate the generated link to your liking:
 
-        class ModifyTypoLinkUserFunc
-        {
-            public function modifyTypoLinkResult(
-                LinkResultInterface $linkResult,
-                array $conf,
-                ServerRequestInterface $request
-            ): LinkResultInterface {
-                if ($linkResult->getType() === LinkService::TYPE_PAGE) {
-                    $cObj = $this->getContentObjectRenderer($request);
-                    return $linkResult
-                        ->withTarget('_blank')
-                        ->withAttribute('title', $cObj->data['title'])
-                        ->withLinkText($cObj->stdWrap_dataWrap('<strong>{FIELD:title}</strong'));
-                }
+    ..  literalinclude:: _StdWrap/_UserFunc.php
+        :language: php
+        :caption: EXT:site_package/Classes/UserFunctions/TypoLinkUserFunc.php
 
-                return $linkResult;
-            }
+    This class would take the :php:`LinkResultInterface` object, retrieve some data from it,
+    alter it, pass it to a new immutable object and return that. Then this is what finally
+    gets emitted after full processing:
 
-            protected function getContentObjectRenderer(ServerRequestInterface $request): ContentObjectRenderer
-            {
-                return $request->getAttribute('currentContentObject');
-            }
-        }
+    ..  code-block:: html
+        <a href="/en/pages/4711/event/18"
+           target="_blank"
+           title="Custom: My Link Title"
+           rel="noreferrer">Event Title #18</a>
+
+
+    You can also apply a custom `userFunc` to vital things like the
+    :ref:`lib.parseFunc_RTE.userFunc <t3tsref:parsefunc-userFunc>`
+    routine. This would allowyou to modify any kind of link generated from the
+    parsing of the Rich-Text-Editor (RTE).
 
 ..  index:: typolink; Resource references
 ..  _typolink-resource_references:

--- a/Documentation/Functions/_Examples/Typolink-Example.rst
+++ b/Documentation/Functions/_Examples/Typolink-Example.rst
@@ -17,7 +17,7 @@ Given this TypoScript example:
     :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
 This would first create a TypoLink :php:`LinkResultInterface` that would resolve to something like
-:html:`<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Title</a>`.
+:html:`<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Text</a>`.
 
 But because :typoscript:`userFunc = MyVendor\SitePackage\UserFunctions\TypoLinkUserFunc->createUserFuncLink`
 is defined you can now manipulate the generated link to your liking.
@@ -53,7 +53,7 @@ gets emitted after full processing:
 ..  code-block:: html
     <a href="/en/pages/4711/event/18"
        target="_blank"
-       title="Custom: My Link Title"
+       title="Custom: My Link Text"
        rel="noreferrer">Event Title #18</a>
 
 

--- a/Documentation/Functions/_Examples/Typolink-Example.rst
+++ b/Documentation/Functions/_Examples/Typolink-Example.rst
@@ -1,0 +1,65 @@
+:orphan:
+..  include:: /Includes.rst.txt
+..  index::
+    Functions; typolink
+    typolink
+
+..  _typolink-userfunc-examples:
+
+================================
+Examples for `typolink.userFunc`
+================================
+
+Given this TypoScript example:
+
+..  literalinclude:: ../_StdWrap/_UserFunc.typoscript
+    :language: typoscript
+    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+This would first create a TypoLink :php:`LinkResultInterface` that would resolve to something like
+:html:`<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Title</a>`.
+
+But because :typoscript:`userFunc = MyVendor\SitePackage\UserFunctions\TypoLinkUserFunc->createUserFuncLink`
+is defined you can now manipulate the generated link to your liking.
+
+The usual case would be to enrich the link with any kind of attributes, or also
+to change existing ones:
+
+..  literalinclude:: ../_StdWrap/_UserFuncSimple.php
+    :language: php
+    :caption: EXT:site_package/Classes/UserFunctions/TypoLinkUserFunc.php
+
+This class would take the :php:`LinkResultInterface` object, enrich it with
+attributes, pass it to a new immutable object and return that. Then this is what finally
+gets emitted after full processing:
+
+..  code-block:: html
+    <a href="/en/pages/4711"
+       target="_blank"
+       title="Custom Title"
+       rel="noreferrer">A replaced link</a>
+
+Here is another example which uses more complex operations and also operates on the
+linked URL:
+
+..  literalinclude:: ../_StdWrap/_UserFunc.php
+    :language: php
+    :caption: EXT:site_package/Classes/UserFunctions/TypoLinkUserFunc.php
+
+This class would take the :php:`LinkResultInterface` object, retrieve some data from it,
+alter it, pass it to a new immutable object and return that. Then this is what finally
+gets emitted after full processing:
+
+..  code-block:: html
+    <a href="/en/pages/4711/event/18"
+       target="_blank"
+       title="Custom: My Link Title"
+       rel="noreferrer">Event Title #18</a>
+
+
+You can also apply a custom :typoscript:`userFunc` to vital objects like the
+:ref:`lib.parseFunc_RTE.userFunc <t3tsref:parsefunc-userFunc>`
+routine. This would allow you to modify any kind of link generated from the
+parsing of the Rich-Text-Editor (RTE), usually by adding CSS classes to it,
+adjusting :html:`rel` attributes or attaching :html:`data-XXX` attributes.
+

--- a/Documentation/Functions/_StdWrap/_UserFunc.php
+++ b/Documentation/Functions/_StdWrap/_UserFunc.php
@@ -31,8 +31,9 @@ class TypoLinkUserFunc
                 $url = $content->getAttribute('href')
                        . '/event/' . (int)$conf['eventUid.']['data'];
                 // Here you could do database lookups for example
-                // to add for example extbase routing URIs and retrieve
-                // fields.
+                // to add extbase routing URIs and retrieve
+                // fields. This is just an example, proper link building
+                // needs to be performed here, also considering cHash.
                 $linkText = 'Event Title #18';
             } else {
                 // Use currently defined URL
@@ -67,8 +68,7 @@ class TypoLinkUserFunc
                 ->withLinkText('I am an internal link');
         }
 
-        // If the condition does not match, return the unmodified
-        // link.
+        // If the condition does not match, return the unmodified link.
         return $content;
     }
 

--- a/Documentation/Functions/_StdWrap/_UserFunc.php
+++ b/Documentation/Functions/_StdWrap/_UserFunc.php
@@ -6,7 +6,6 @@ namespace MyVendor\MySitePackage\UserFunctions;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 use TYPO3\CMS\Frontend\Typolink\LinkResult;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
@@ -16,7 +15,7 @@ class TypoLinkUserFunc
     public function createUserFuncLink(
         LinkResultInterface $content,
         array $conf,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): LinkResultInterface {
 
         // First check what kind of link this is.
@@ -49,12 +48,16 @@ class TypoLinkUserFunc
                 ->withAttribute('href', $url)
                 ->withAttribute('title', 'Custom: ' . $cObj->data['title'])
                 ->withLinkText($linkText);
-        } else if ($conf['freshExternalLink'] ?? false) {
+        }
+
+        if ($conf['freshExternalLink'] ?? false) {
             // Depending on conditions, you could also return a completely new object
             // for an external link:
             return (new LinkResult(LinkService::TYPE_URL, 'https://example.com'))
                     ->withLinkText('I am an external link');
-        } else if ($conf['freshInternalLink'] ?? false) {
+        }
+
+        if ($conf['freshInternalLink'] ?? false) {
             // ... or an internal link (UID in $conf['freshInternalPageUid']):
             // NOTE: You might want to use the PageLinkBuilder to achieve this;
             //       (this is not yet documented)

--- a/Documentation/Functions/_StdWrap/_UserFunc.php
+++ b/Documentation/Functions/_StdWrap/_UserFunc.php
@@ -46,20 +46,22 @@ class TypoLinkUserFunc
 
             return $content
                 ->withTarget('_blank')
-                #->withUrl($url)
+                ->withAttribute('href', $url)
                 ->withAttribute('title', 'Custom: ' . $cObj->data['title'])
                 ->withLinkText($linkText);
         } else if ($conf['freshExternalLink'] ?? false) {
             // Depending on conditions, you could also return a completely new object
             // for an external link:
             return (new LinkResult(LinkService::TYPE_URL, 'https://example.com'))
-                    ->withLinkText('I am a link');
+                    ->withLinkText('I am an external link');
         } else if ($conf['freshInternalLink'] ?? false) {
             // ... or an internal link (UID in $conf['freshInternalPageUid']):
+            // NOTE: You might want to use the PageLinkBuilder to achieve this;
+            //       (this is not yet documented)
             $cObj = $this->getContentObjectRenderer($request);
             $frontendUrl = $cObj->typoLink_URL(['parameter' => $conf['freshInternalPageUid'] ?? 1]);
             return (new LinkResult(LinkService::TYPE_PAGE, $frontendUrl))
-                ->withLinkText('I am a link');
+                ->withLinkText('I am an internal link');
         }
 
         // If the condition does not match, return the unmodified

--- a/Documentation/Functions/_StdWrap/_UserFunc.php
+++ b/Documentation/Functions/_StdWrap/_UserFunc.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MySitePackage\UserFunctions;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Typolink\LinkResult;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+
+class TypoLinkUserFunc
+{
+    public function createUserFuncLink(
+        LinkResultInterface $content,
+        array $conf,
+        ServerRequestInterface $request
+    ): LinkResultInterface {
+
+        // First check what kind of link this is.
+        // This example only operates on TYPE_PAGE for internal
+        // links; the userFunc can of course also react to
+        // types like TYPE_URL (external pages)
+        if ($content->getType() === LinkService::TYPE_PAGE) {
+            $cObj = $this->getContentObjectRenderer($request);
+
+            // Check if typolink.userFunc additional data is set
+            // and act on it
+            if ($conf['eventUid.']['data'] ?? null) {
+                $url = $content->getAttribute('href')
+                       . '/event/' . (int)$conf['eventUid.']['data'];
+                // Here you could do database lookups for example
+                // to add for example extbase routing URIs and retrieve
+                // fields.
+                $linkText = 'Event Title #18';
+            } else {
+                // Use currently defined URL
+                $url = $content->getUrl();
+                // Example how to utilize the cObj and it's wrapping so
+                // that `<a href=...><strong>(TITLE!)</strong></a>`
+                // would be returned.
+                $linkText = $cObj->stdWrap_dataWrap('<strong>{FIELD:title}</strong');
+            }
+
+            return $content
+                ->withTarget('_blank')
+                #->withUrl($url)
+                ->withAttribute('title', 'Custom: ' . $cObj->data['title'])
+                ->withLinkText($linkText);
+        } else if ($conf['freshExternalLink'] ?? false) {
+            // Depending on conditions, you could also return a completely new object
+            // for an external link:
+            return (new LinkResult(LinkService::TYPE_URL, 'https://example.com'))
+                    ->withLinkText('I am a link');
+        } else if ($conf['freshInternalLink'] ?? false) {
+            // ... or an internal link (UID in $conf['freshInternalPageUid']):
+            $cObj = $this->getContentObjectRenderer($request);
+            $frontendUrl = $cObj->typoLink_URL(['parameter' => $conf['freshInternalPageUid'] ?? 1]);
+            return (new LinkResult(LinkService::TYPE_PAGE, $frontendUrl))
+                ->withLinkText('I am a link');
+        }
+
+        // If the condition does not match, return the unmodified
+        // link.
+        return $content;
+    }
+
+    protected function getContentObjectRenderer(ServerRequestInterface $request): ContentObjectRenderer
+    {
+        return $request->getAttribute('currentContentObject');
+    }
+}

--- a/Documentation/Functions/_StdWrap/_UserFunc.typoscript
+++ b/Documentation/Functions/_StdWrap/_UserFunc.typoscript
@@ -1,0 +1,16 @@
+registration {
+    value = My Link Title
+    typolink {
+        parameter = 4711
+        additionalParams = &someKey=someValue
+        language = 3
+        ATagParams = rel="noreferrer"
+        title = My Link Title
+        userFunc = MyVendor\MySitePackage\UserFunctions\TypoLinkUserFunc->createUserFuncLink
+        userFunc {
+            eventUid = TEXT
+            eventUid.data = field:eventUid
+            someFuncParam = someFuncValue
+        }
+    }
+}

--- a/Documentation/Functions/_StdWrap/_UserFuncSimple.php
+++ b/Documentation/Functions/_StdWrap/_UserFuncSimple.php
@@ -15,7 +15,6 @@ class TypoLinkUserFunc
         array $conf,
         ServerRequestInterface $request,
     ): LinkResultInterface {
-
         // First check what kind of link this is.
         // This example only operates on TYPE_PAGE for internal
         // links; the userFunc can of course also react to

--- a/Documentation/Functions/_StdWrap/_UserFuncSimple.php
+++ b/Documentation/Functions/_StdWrap/_UserFuncSimple.php
@@ -6,9 +6,6 @@ namespace MyVendor\MySitePackage\UserFunctions;
 
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\LinkHandling\LinkService;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-use TYPO3\CMS\Frontend\Typolink\LinkResult;
 use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
 
 class TypoLinkUserFunc
@@ -16,7 +13,7 @@ class TypoLinkUserFunc
     public function createUserFuncLink(
         LinkResultInterface $content,
         array $conf,
-        ServerRequestInterface $request
+        ServerRequestInterface $request,
     ): LinkResultInterface {
 
         // First check what kind of link this is.

--- a/Documentation/Functions/_StdWrap/_UserFuncSimple.php
+++ b/Documentation/Functions/_StdWrap/_UserFuncSimple.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MySitePackage\UserFunctions;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\LinkHandling\LinkService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Typolink\LinkResult;
+use TYPO3\CMS\Frontend\Typolink\LinkResultInterface;
+
+class TypoLinkUserFunc
+{
+    public function createUserFuncLink(
+        LinkResultInterface $content,
+        array $conf,
+        ServerRequestInterface $request
+    ): LinkResultInterface {
+
+        // First check what kind of link this is.
+        // This example only operates on TYPE_PAGE for internal
+        // links; the userFunc can of course also react to
+        // types like TYPE_URL (external pages)
+        if ($content->getType() === LinkService::TYPE_PAGE) {
+            // Add (or replace) a custom "title" link attribute and
+            // add "target=_blank" to it, and adjust the link text:
+
+            return $content
+                ->withTarget('_blank')
+                ->withAttribute('title', 'Custom Title')
+                ->withLinkText('A replaced link');
+        }
+
+        // If the condition does not match, return the unmodified
+        // link.
+        return $content;
+    }
+}


### PR DESCRIPTION
According to  https://review.typo3.org/c/Packages/TYPO3.CMS/+/72999 the userFunc now must return an instance of `LinkResultInterface`.

(drive-by fix of a few wrong formattings)

Releases: main, 12.4
Closes #1275

