### PR TITLE
[DEPRECATION] Obsolete $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLine…

### DIFF
--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -606,7 +606,7 @@ Get the value of the user-defined field :sql:`tx_myextension_myfield` in the roo
     To stay compatible with both TYPO3 v12 and v13, add the following to your
     extensions :file:`ext_localconf.php`:
 
-    ..  code-block:: _Data/_addRootlineFields_ext_localconf.php
+    ..  literalinclude:: _Data/_addRootlineFields_ext_localconf.php
         :caption: EXT:my_extension/ext_localconf.php
 
 ..  _data-type-gettext-levelmedia:

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -597,16 +597,17 @@ Get the value of the user-defined field :sql:`tx_myextension_myfield` in the roo
 
     lib.foo.data = levelfield : -1, tx_myextension_myfield, slide
 
-Requires additional configuration in
-:ref:`$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] <t3coreapi:typo3ConfVars_fe_addRootLineFields>` to include
-field. In order that you can use this function, your field name
-:sql:`tx_myextension_myfield` needs be included in the comma
-separated list of ['addRootLineFields']:
+..  versionchanged:: 13.2
 
-..  code-block:: php
-    :caption: EXT:my_extension/ext_localconf.php
+    Until TYPO3 v13 it was required to do additional configuration in
+    :ref:`$GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] <t3coreapi:typo3ConfVars_fe_addRootLineFields>` to
+    use custom fields.
 
-    $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',tx_myextension_myfield';
+    To stay compatible with both TYPO3 v12 and v13, add the following to your
+    extensions :file:`ext_localconf.php`:
+
+    ..  code-block:: _Data/_addRootlineFields_ext_localconf.php
+        :caption: EXT:my_extension/ext_localconf.php
 
 ..  _data-type-gettext-levelmedia:
 

--- a/Documentation/Functions/_Data/_addRootlineFields_ext_localconf.php
+++ b/Documentation/Functions/_Data/_addRootlineFields_ext_localconf.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+defined('TYPO3') or die();
+
+$versionInformation = GeneralUtility::makeInstance(Typo3Version::class);
+// TODO: Remove when dropping TYPO3 v12 support
+if ($versionInformation->getMajorVersion() < 13) {
+    $GLOBALS['TYPO3_CONF_VARS']['FE']['addRootLineFields'] .= ',tx_myextension_myfield';
+}


### PR DESCRIPTION
…Fields']

references: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/910
releases: main