### PR TITLE
[TASK] Clarify constants do not work in constant conditions

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1234,10 +1234,9 @@ site()
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
  
-        my.constant = myValue
+        my.constant = my global value
         [traverse(site('configuration'), 'settings/some/setting') == 'someValue']
-          # This works but is rather ugly to rely on
-          other.constant = otherValue
+          my.constant = another value, if condition matches
         [global]
 
 ..  index:: Conditions; siteLanguage

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1363,7 +1363,7 @@ TypoScript constants can be used in conditions with the
     but not in Frontend TypoScript *constants* conditions. At the time of
     evaluation the constants are not yet available in constants conditions.
 
-    It is, however, possible to use :confval:`site setttings <condition-site>`
+    It is, however, possible to use :confval:`site settings <condition-site>`
     in constant conditions.
 
 ..  _condition-examples-constant-strict-types:

--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1229,6 +1229,16 @@ site()
             # ...
         [END]
 
+    Site settings can also be used in the conditions in TypoScript constants:
+
+    ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
+ 
+        my.constant = myValue
+        [traverse(site('configuration'), 'settings/some/setting') == 'someValue']
+          # This works but is rather ugly to rely on
+          other.constant = otherValue
+        [global]
 
 ..  index:: Conditions; siteLanguage
 ..  _condition-functions-in-frontend-context-function-siteLanguage:
@@ -1347,6 +1357,14 @@ TypoScript constants can be used in conditions with the
     [ELSE]
         page.10.value = The feature 1 of my_extension is not enabled.
     [END]
+
+..  note::
+    TypoScript constants can be used in frontend TypoScript *setup* conditions,
+    but not in Frontend TypoScript *constants* conditions. At the time of
+    evaluation the constants are not yet available in constants conditions.
+
+    It is, however, possible to use :confval:`site setttings <condition-site>`
+    in constant conditions.
 
 ..  _condition-examples-constant-strict-types:
 


### PR DESCRIPTION
releases: main, 12.4
resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/925