### PR TITLE
[TASK] Add hint to concatenate/compress options

### DIFF
--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -222,6 +222,8 @@ Properties of 'config'
         related compressionLevel options in :file:`.htaccess`, as otherwise the
         compressed files will not be readable by the user agent.
 
+        ..  include:: _includes/_concat-compress.rst.txt
+
         TYPO3 comes with a built-in compression handler, but you can
         also register your own one using
         :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler']`.
@@ -244,13 +246,12 @@ Properties of 'config'
         the like using GZIP compression. Does not work on files, which are
         referenced in :typoscript:`page.headerData`.
 
-        This can significantly reduce file sizes of linked JavaScript files
-        and thus decrease loading times.
-
         Please note that this requires :file:`.htaccess` to be adjusted, as otherwise
         the files will not be readable by the user agent. Please see the
         description of :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['compressionLevel']` in the
         Install Tool.
+
+        ..  include:: _includes/_concat-compress.rst.txt
 
         TYPO3 comes with a built-in compression handler, but you can
         also register your own one using
@@ -274,6 +275,8 @@ Properties of 'config'
         for several files. Does not work on files, which are referenced in
         :typoscript:`page.headerData`.
 
+        ..  include:: _includes/_concat-compress.rst.txt
+
         TYPO3 comes with a built-in concatenation handler, but you
         can also register your own one using
         :php:`$GLOBALS['TYPO3_CONF_VARS']['FE']['cssConcatenateHandler']`.
@@ -295,6 +298,8 @@ Properties of 'config'
         on files, which are referenced in :typoscript:`page.headerData`.
 
         If all files to be concatenated are marked with the async flag, the async attribute is assigned to the script tag.
+
+        ..  include:: _includes/_concat-compress.rst.txt
 
         TYPO3 comes with a built-in concatenation handler, but you
         can also register your own one using

--- a/Documentation/TopLevelObjects/_includes/_concat-compress.rst.txt
+++ b/Documentation/TopLevelObjects/_includes/_concat-compress.rst.txt
@@ -5,9 +5,9 @@
     uncached pages. For optimal performance, you should prefer
     to pre-bundle as many CSS/JS assets as possible via a frontend
     buildchain. Also, you can try to utilize HTTP/2 multiplexing on your
-    webserver, which performs  much better than HTTP/1 for requesting multiple 
+    webserver, which performs much better than HTTP/1 for requesting multiple 
     small files. It also leverages distinct cacheability of these CSS/JS assets.
 
     Most servers can be configured to dynamically compress specific
-    file types on-the-fly, which is preferrable to using application-level
+    file types on-the-fly, which is preferable to using application-level
     compression.

--- a/Documentation/TopLevelObjects/_includes/_concat-compress.rst.txt
+++ b/Documentation/TopLevelObjects/_includes/_concat-compress.rst.txt
@@ -1,0 +1,13 @@
+..  hint::
+
+    Enabling concatenation and/or compression requires several filesystem operations
+    and can considerably impact frontend request time performance, especially for
+    uncached pages. For optimal performance, you should prefer
+    to pre-bundle as many CSS/JS assets as possible via a frontend
+    buildchain. Also, you can try to utilize HTTP/2 multiplexing on your
+    webserver, which performs  much better than HTTP/1 for requesting multiple 
+    small files. It also leverages distinct cacheability of these CSS/JS assets.
+
+    Most servers can be configured to dynamically compress specific
+    file types on-the-fly, which is preferrable to using application-level
+    compression.


### PR DESCRIPTION
The internal TYPO3 concatenation and compression comes with some drawbacks, also mentioned in https://forge.typo3.org/issues/75127.

This patch adds a "hint" to the four options to describe also disadvantages of using the options.