### PR TITLE
[BUGFIX] use spamProtectEmailAddresses_atSubst

### DIFF
--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -1518,8 +1518,9 @@ Spam protect email addresses automatically
 ------------------------------------------
 
 Demonstrates:
+
     * :confval:`config.spamProtectEmailAddresses <config-spamProtectEmailAddresses>`
-    * :confval:`config.spamProtectEmailAddresses_lastDotSubst <config-spamProtectEmailAddresses_lastDotSubst>`
+    * :confval:`config.spamProtectEmailAddresses_atSubst <config-spamProtectEmailAddresses_atSubst>`
     * :confval:`config.spamProtectEmailAddresses_lastDotSubst <config-spamProtectEmailAddresses_lastDotSubst>`
 
 ..  code-block:: typoscript
@@ -1527,7 +1528,7 @@ Demonstrates:
 
     config {
         spamProtectEmailAddresses = -2
-        spamProtectEmailAddresses_lastDotSubst = (at)
+        spamProtectEmailAddresses_atSubst = (at)
         spamProtectEmailAddresses_lastDotSubst = (dot)
     }
 


### PR DESCRIPTION
Thanks @agriaIT for catching this!

Next time you can also try to use the "Edit on GitHub" button and propose the change directly, see https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/Howto/EditOnGithub.html

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/1315
Releases: main, 12.4