### PR TITLE
[TASK] Modernize cObject "USER" examples

### DIFF
--- a/Documentation/ContentObjects/UserAndUserInt/_ExampleListRecords.php
+++ b/Documentation/ContentObjects/UserAndUserInt/_ExampleListRecords.php
@@ -5,15 +5,24 @@ declare(strict_types=1);
 namespace MyVendor\SitePackage\UserFunctions;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autoconfigure;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Example of a method in a PHP class to be called from TypoScript
+ *
+ * The class is defined as public as we use dependency injection in
+ * this example. If you do not need dependency injection, the
+ * "Autoconfigure" attribute should be omitted!
  */
+#[Autoconfigure(public: true)]
 final class ExampleListRecords
 {
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+    ) {}
+
     /**
      * Reference to the parent (calling) cObject set from TypoScript
      */
@@ -27,17 +36,21 @@ final class ExampleListRecords
     /**
      * List the headers of the content elements on the page
      *
-     * @param  string Empty string (no content to process)
-     * @param  array  TypoScript configuration
+     * @param string Empty string (no content to process)
+     * @param array TypoScript configuration
+     * @param ServerRequestInterface The current PSR-7 request object
      * @return string HTML output, showing content elements (in reverse order, if configured)
      */
     public function listContentRecordsOnPage(string $content, array $conf, ServerRequestInterface $request): string
     {
-        $connection = GeneralUtility::makeInstance(ConnectionPool::class)->getConnectionForTable('tt_content');
+        $connection = $this->connectionPool->getConnectionForTable('tt_content');
         $result = $connection->select(
             ['header'],
             'tt_content',
-            ['pid' => (int)$GLOBALS['TSFE']->id],
+            // The request attribute 'frontend.page.information' has been introduced
+            // with TYPO3 v13. For compatibility with older TYPO3 versions use the
+            // version switch on the top of the page.
+            ['pid' => $request->getAttribute('frontend.page.information')->getId()],
             [],
             ['sorting' => $conf['reverseOrder'] ? 'DESC' : 'ASC'],
         );
@@ -45,6 +58,6 @@ final class ExampleListRecords
         foreach ($result as $row) {
             $output[] = $row['header'];
         }
-        return implode('<br />', $output);
+        return implode('<br>', $output);
     }
 }

--- a/Documentation/ContentObjects/UserAndUserInt/_ExampleTime.php
+++ b/Documentation/ContentObjects/UserAndUserInt/_ExampleTime.php
@@ -13,7 +13,7 @@ final class ExampleTime
      *
      * @param string Empty string (no content to process)
      * @param array TypoScript configuration
-     * @param ServerRequestInterface $request
+     * @param ServerRequestInterface $request The current PSR-7 request object
      * @return string HTML output, showing the current server time.
      */
     public function printTime(string $content, array $conf, ServerRequestInterface $request): string

--- a/Documentation/ContentObjects/UserAndUserInt/_Hostname.php
+++ b/Documentation/ContentObjects/UserAndUserInt/_Hostname.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Vendor\SitePackage\UserFunctions;
+namespace MyVendor\SitePackage\UserFunctions;
+
+use Psr\Http\Message\ServerRequestInterface;
 
 final class Hostname
 {
@@ -11,9 +13,10 @@ final class Hostname
      *
      * @param  string Empty string (no content to process)
      * @param  array  TypoScript configuration
+     * @param ServerRequestInterface $request The current PSR-7 request object
      * @return string HTML result
      */
-    public function getHostname(string $content, array $conf): string
+    public function getHostname(string $content, array $conf, ServerRequestInterface $request): string
     {
         return gethostname() ?: '';
     }

--- a/Documentation/ContentObjects/UserAndUserInt/_Hostname.php
+++ b/Documentation/ContentObjects/UserAndUserInt/_Hostname.php
@@ -11,8 +11,8 @@ final class Hostname
     /**
      * Return standard host name for the local machine
      *
-     * @param  string Empty string (no content to process)
-     * @param  array  TypoScript configuration
+     * @param string Empty string (no content to process)
+     * @param array TypoScript configuration
      * @param ServerRequestInterface $request The current PSR-7 request object
      * @return string HTML result
      */


### PR DESCRIPTION
- Avoid GeneralUtility::makeInstance(), use DI instead (class has to be set public therefore)
- Use newly introduced request attribute to retrieve current page ID as best practise
- Add request where missing as argument and improve docblock
- Streamline namespace to be in line with other examples

Releases: main