### PR TITLE
Note on not resolving the recursion for “root”

### DIFF
--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -146,6 +146,8 @@ recursive
 
     Number of recursive levels for the pidInList.
 
+     **Note:** :typoscript:`recursive` is ignored for *special keyword* :typoscript:`pidInList=root`.
+
 
 ..  _select-orderBy:
 

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -146,8 +146,8 @@ recursive
 
     Number of recursive levels for the pidInList.
 
-     **Note:** :typoscript:`recursive` is ignored for *special keyword* :typoscript:`pidInList=root`.
-
+    ..  note::
+        :typoscript:`recursive` is ignored for *special keyword* :typoscript:`pidInList=root`.
 
 ..  _select-orderBy:
 


### PR DESCRIPTION
The new `\TYPO3\CMS\Core\Domain\Repository\PageRepository::getDescendantPageIdsRecursive()` introduced in v12 exits for `$startPageId=0` via early-return without resolving the recursion.