### PR TITLE
[TASK] Lower case template path names have been removed

### DIFF
--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -171,11 +171,10 @@ Properties
         :file:`EXT:my_extension/Resources/Private/Templates/` or a folder below that
         path like :file:`EXT:my_extension/Resources/Private/Templates/MyPages`.
 
-        The templates are expected in a subfolder :path:`Pages` or
-        :path:`pages`.
+        The templates are expected in a subfolder :path:`Pages`.
 
-        Fluid partials are looked up in a sub-directory called :path:`Partials` or
-        :path:`partials`, layouts in :path:`Layouts` or :path:`layouts`.
+        Fluid partials are looked up in a sub-directory called :path:`Partials`,
+        layouts in :path:`Layouts`.
 
         The name of the used page layout (:ref:`Backend layout <t3coreapi:be-layout>`)
         is resolved automatically.


### PR DESCRIPTION
This change changed https://docs.typo3.org/c/typo3/cms-core/main/en-us/Changelog/13.1/Feature-103504-NewContentObjectPageView.html

to remove the support for lowercase template path names.

References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/904 
References:https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1005 
Releases: main