### PR TITLE
[TASK] Describe htmlTag_stdWrap for hreflang usage

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1233,7 +1233,7 @@ site()
 
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
- 
+
         my.constant = my global value
         [traverse(site('configuration'), 'settings/some/setting') == 'someValue']
           my.constant = another value, if condition matches
@@ -1287,6 +1287,8 @@ siteLanguage()
             fallback.
 
         Returns the language information for the hreflang tag as a string.
+        If needed, you can use this attribute for the :html:`<html lang="...">`
+        attribute, see :confval:`htmlTag_stdWrap <config-htmltag-stdwrap>`.
 
     :typoscript:`siteLanguage("fallbackType")`
         Returns the language fallback mode as a string, one of `fallback`,

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -1000,7 +1000,9 @@ siteLanguage
             fallback.
 
         The language tag for this language defined by RFC 1766 / 3066 for
-        :html:`hreflang` attributes
+        :html:`hreflang` attributes. If needed, you can use this attribute
+        for the :html:`<html lang="...">` attribute, see
+        :confval:`htmlTag_stdWrap <config-htmltag-stdwrap>`.
 
     :typoscript:`languageId`
         The language mapped to the ID of the site language.

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -557,7 +557,7 @@ Properties of 'config'
         For example it can be used to distinctly set a :html:`lang` attribute,
         that may diverge from the automatically created attribute using the site
         language settings. Normally, :html:`lang` is set to something like `en`
-        or `en`, only indicating the primary language. You may want to use the
+        or `de`, only indicating the primary language. You may want to use the
         :html:`hreflang` site language attribute instead (containing for example
         `en-US`, `en-GB` or `de-AT`), which you can achieve via:
 

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -554,6 +554,19 @@ Properties of 'config'
         Modify the whole :html:`<html>` tag with stdWrap functionality. This can be
         used to extend or override this tag.
 
+        For example it can be used to distinctly set a :html:`lang` attribute,
+        that may diverge from the automatically created attribute using the site
+        language settings. Normally, :html:`lang` is set to something like `en`
+        or `en`, only indicating the primary language. You may want to use the
+        :html:`hreflang` site language attribute instead (containing for example
+        `en-US`, `en-GB` or `de-AT`), which you can achieve via:
+
+        ..  code-block:: typoscript
+            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+            config.htmlTag_stdWrap.override = <html lang="{siteLanguage:hreflang}">
+            config.htmlTag_stdWrap.override.insertData = 1
+
     ..  confval:: index_descrLgd
         :name: config-index-descrLgd
         :type: :ref:`data-type-integer`


### PR DESCRIPTION
See https://review.typo3.org/c/Packages/TYPO3.CMS/+/85049

This documentation should help to allow people to use other custom `<html lang="...">` attribution, which was not clearly enough phrased. We would need a proper documentation entry to properly close the underlying issue.

Releases: main, 12.4