### PR TITLE
[BUGFIX] Adjust default value for typolink extTarget

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -36,7 +36,7 @@ extTarget
 ..  confval:: extTarget
     :name: typolink-extTarget
     :type: :ref:`data-type-target` / :ref:`stdwrap`
-    :Default: `_top`
+    :Default: "" (no target set)
 
     Target used for external links
 


### PR DESCRIPTION
Tested with this snippet in main and v12:

    page.20 = TEXT
    page.20.value = link to example.com
    page.20.typolink.parameter = https://example.com/

Releases: main, 12.4