### PR TITLE
[BUGFIX] Remove unnecessary “data.” in _Default.html

### DIFF
--- a/Documentation/DataProcessing/_PageContentFetchingProcessor/_Default.html
+++ b/Documentation/DataProcessing/_PageContentFetchingProcessor/_Default.html
@@ -1,8 +1,8 @@
 <f:render partial="Jumbotron" arguments="{jumbotronContent: myContent.jumbotron}"/>
 <main>
     <f:for each="{myContent.left.records}" as="contentElement">
-        <h3>{contentElement.data.header}</h3>
-        <p>{contentElement.data.bodytext -> f:format.html()}</p>
+        <h3>{contentElement.header}</h3>
+        <p>{contentElement.bodytext -> f:format.html()}</p>
     </f:for>
 </main>
 <aside>


### PR DESCRIPTION
Accessing the data does not work with contentElement.data.[property], but directly with contentElement.[property] (Tested in TYPO3 version 13.4.0-dev)