### PR TITLE
[TASK] Display data processor aliases more prominent

### DIFF
--- a/Documentation/DataProcessing/CommaSeparatedValueProcessor.rst
+++ b/Documentation/DataProcessing/CommaSeparatedValueProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: comma-separated-value
 ..  include:: /Includes.rst.txt
 ..  _CommaSeparatedValueProcessor:
 
-============================
-CommaSeparatedValueProcessor
-============================
+======================================
+`comma-separated-value` data processor
+======================================
 
-The :php:`CommaSeparatedValueProcessor` allows to split values into a
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`comma-separated-value` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\CommaSeparatedValueProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\CommaSeparatedValueProcessor`,
+alias `comma-separated-value`, allows to split values into a
 two-dimensional array used for :abbr:`CSV (Comma-separated values)` files or
 :sql:`tt_content` records of CType `table`.
 
@@ -134,10 +141,6 @@ We define the :typoscript:`dataProcessing` property to use the
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/CommaSeparatedValueProcessor.rst.txt
 
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`comma-separated-value` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\CommaSeparatedValueProcessor`.
 
 The Fluid template
 ------------------

--- a/Documentation/DataProcessing/CustomDataProcessors.rst
+++ b/Documentation/DataProcessing/CustomDataProcessors.rst
@@ -17,11 +17,6 @@ data processor:
 The available configuration depends on the implementation of the
 specific custom data processor, of course.
 
-..  versionadded:: 12.1
-    One can configure a custom alias in :file:`Configuration/Services.yaml`
-    and use it in TypoScript instead of the fully-qualified class name.
-
-
 Example output
 ==============
 

--- a/Documentation/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/DataProcessing/DatabaseQueryProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: database-query
 ..  include:: /Includes.rst.txt
 ..  _DatabaseQueryProcessor:
 
-======================
-DatabaseQueryProcessor
-======================
+===============================
+`database-query` data processor
+===============================
 
-The :php:`DatabaseQueryProcessor` fetches records from the database, using
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`database-query` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`,
+alias `database-query`, fetches records from the database, using
 standard TypoScript :ref:`select` semantics. The result is then passed to the
 :ref:`cobj-fluidtemplate` as an array.
 
@@ -13,7 +20,7 @@ This way a :ref:`cobj-fluidtemplate` cObject can iterate over the
 array of records.
 
 ..  versionadded:: 13.2
-    The :php:`DatabaseQueryProcessor` can be used in combination with the
+    The :typoscript:`database-query` processor can be used in combination with the
     :ref:`RecordTransformationProcessor` to use additional computed information.
 
 ..  _DatabaseQueryProcessor-options:
@@ -118,10 +125,6 @@ We define the :typoscript:`dataProcessing` property to use the
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/DatabaseQueryProcessor.rst.txt
 
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`database-query` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\DatabaseQueryProcessor`.
 
 
 The Fluid template

--- a/Documentation/DataProcessing/FilesProcessor.rst
+++ b/Documentation/DataProcessing/FilesProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: files
 ..  include:: /Includes.rst.txt
 ..  _FilesProcessor:
 
-==============
-FilesProcessor
-==============
+======================
+`files` data processor
+======================
 
-This data processor can be used for processing file information:
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`files` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\FilesProcessor`.
+
+This data processor :php:`\TYPO3\CMS\Frontend\DataProcessing\FilesProcessor`,
+alias `files`, can be used for processing file information:
 
 *   relations to file records (:sql:`sys_file_reference`)
 *   fetch files records by their uids in table (:sql:`sys_file`)
@@ -224,12 +231,6 @@ TypoScript
 Using the :php:`FilesProcessor` the following scenario is possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/FilesProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`files` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\FilesProcessor`.
-
 
 The Fluid template
 ------------------

--- a/Documentation/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/DataProcessing/FlexFormProcessor.rst
@@ -1,14 +1,21 @@
+:navigation-title: flex-form
 ..  include:: /Includes.rst.txt
 ..  _FlexFormProcessor:
 ..  index:: FlexForm, DataProcessing
 
-=================
-FlexFormProcessor
-=================
+==========================
+`flex-form` data processor
+==========================
+
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`flex-form` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor`.
 
 TYPO3 offers :ref:`FlexForms <t3coreapi:flexforms>` which can be used to store
 data within an XML structure inside a single database column. The data processor
-:php:`\TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor` converts the
+:php:`\TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor`,
+alias `flex-form`, converts the
 FlexForm data of a given field into a Fluid-readable array.
 
 ..  _FlexFormProcessor-options:
@@ -83,11 +90,6 @@ Example of a minimal TypoScript configuration
     # dataProcessing.10 = TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor
     # Since TYPO3 v12.1 one can also use the available alias
     10 = flex-form
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`flex-form` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\FlexFormProcessor`.
 
 The converted array can be accessed within the Fluid template with the
 :html:`{flexFormData}` variable.

--- a/Documentation/DataProcessing/GalleryProcessor.rst
+++ b/Documentation/DataProcessing/GalleryProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: gallery
 ..  include:: /Includes.rst.txt
 ..  _GalleryProcessor:
 
-================
-GalleryProcessor
-================
+========================
+`gallery` data processor
+========================
 
-The :php:`GalleryProcessor` provides the logic for working with galleries and
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`gallery` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\GalleryProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\GalleryProcessor`,
+alias `gallery`, provides the logic for working with galleries and
 calculates the maximum asset size. It uses the files already present in
 the `processedData` array for its calculations. The :ref:`FilesProcessor` can
 be used to fetch the files.
@@ -254,10 +261,6 @@ in the :php:`GalleryProcessor` has to be equal to the content of
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/GalleryProcessor.rst.txt
 
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`gallery` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\GalleryProcessor`.
 
 The Fluid template
 ------------------

--- a/Documentation/DataProcessing/Index.rst
+++ b/Documentation/DataProcessing/Index.rst
@@ -3,9 +3,9 @@
 ..  _cobj-fluidtemplate-properties-dataprocessing:
 ..  _dataProcessing:
 
-==============
-dataProcessing
-==============
+===============
+Data processors
+===============
 
 :ref:`dataProcessing <fluidtemplate-dataProcessing>` is a property of
 :ref:`cobj-fluidtemplate` and :ref:`cobj-pageview`.

--- a/Documentation/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/DataProcessing/LanguageMenuProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: language-menu
 ..  include:: /Includes.rst.txt
 ..  _LanguageMenuProcessor:
 
-=====================
-LanguageMenuProcessor
-=====================
+============================
+language-menu data processor
+============================
 
-This menu processor generates a list of language menu items which can be
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`language-menu` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor`.
+
+The processor :php:`\TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor`,
+alias `language-menu`, generates a list of language menu items which can be
 assigned to the :typoscript:`FLUIDTEMPLATE` as a variable.
 
 ..  hint::
@@ -96,11 +103,6 @@ TypoScript
 Using the :php:`LanguageMenuProcessor` the following scenario is possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/LanguageMenuProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`language-menu` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\LanguageMenuProcessor`.
 
 
 The Fluid template

--- a/Documentation/DataProcessing/MenuProcessor.rst
+++ b/Documentation/DataProcessing/MenuProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: menu
 ..  include:: /Includes.rst.txt
 ..  _MenuProcessor:
 
-=============
-MenuProcessor
-=============
+=====================
+`menu` data processor
+=====================
 
-The :php:`MenuProcessor` utilizes :ref:`HMENU <cobj-hmenu>` to generate a list
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`menu` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\MenuProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\MenuProcessor`,
+alias `menu`, utilizes :ref:`HMENU <cobj-hmenu>` to generate a list
 of menu items which can be assigned to :typoscript:`FLUIDTEMPLATE` as a
 variable.
 
@@ -116,11 +123,6 @@ TypoScript
 Using the :php:`MenuProcessor` the following scenario is possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/MenuProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`menu` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\MenuProcessor`.
 
 
 The Fluid template

--- a/Documentation/DataProcessing/PageContentFetchingProcessor.rst
+++ b/Documentation/DataProcessing/PageContentFetchingProcessor.rst
@@ -1,11 +1,15 @@
+:navigation-title: page-content
 ..  include:: /Includes.rst.txt
 ..  _PageContentFetchingProcessor:
 
-============================
-PageContentFetchingProcessor
-============================
+=============================
+`page-content` data processor
+=============================
 
-This Data Processor loads all :sql:`tt_content` records from the current
+..  versionadded:: 13.2
+
+This data processor :php:`\TYPO3\CMS\Frontend\DataProcessing\PageContentFetchingProcessor`,
+alias `page-content`, loads all :sql:`tt_content` records from the current
 :ref:`backend layout <t3coreapi:be-layout>` into
 the template with a given identifier for each :sql:`colPos`, also respecting slideMode or
 collect options based on the page layouts content columns.

--- a/Documentation/DataProcessing/RecordTransformationProcessor.rst
+++ b/Documentation/DataProcessing/RecordTransformationProcessor.rst
@@ -1,15 +1,17 @@
+:navigation-title: record-transformation
 ..  include:: /Includes.rst.txt
 ..  _RecordTransformationProcessor:
 
-=============================
-RecordTransformationProcessor
-=============================
+======================================
+`record-transformation` data processor
+======================================
 
 ..  versionadded:: 13.2
     A new TypoScript data processor for :ref:`FLUIDTEMPLATE <cobj-fluidtemplate>` and
     :typoscript:`PAGEVIEW` has been added.
 
-The :typoscript:`record-transformation` Data Processor can typically be used in
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\RecordTransformationProcessor`,
+alias `record-transformation`, can typically be used in
 conjunction with the DatabaseQuery Data Processor. The DatabaseQuery Data
 Processor typically fetches records from the database, and the
 :typoscript:`record-transformation` will take the result, and transforms
@@ -25,12 +27,6 @@ addressed in a unified way.
 
 The `type` property contains the database table name and the actual type based
 on the record, such `tt_content.textmedia` for Content Elements.
-
-..  note::
-
-    The Record object is available but details are still to be finalized in
-    the API until TYPO3 v13 LTS. Right now only the usage in Fluid is public
-    API.
 
 ..  _RecordTransformationProcessor-databasequeryprocessor-example:
 

--- a/Documentation/DataProcessing/SiteLanguageProcessor.rst
+++ b/Documentation/DataProcessing/SiteLanguageProcessor.rst
@@ -1,13 +1,18 @@
+:navigation-title: site-language
 ..  include:: /Includes.rst.txt
 ..  _SiteLanguageProcessor:
 
-=====================
-SiteLanguageProcessor
-=====================
+==============================
+`site-language` data processor
+==============================
 
-..  versionadded:: 12.0
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`site-language` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteLanguageProcessor`.
 
-The :php:`SiteLanguageProcessor` fetches language-related data from the
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteLanguageProcessor`,
+alias `site-language`, fetches language-related data from the
 :ref:`site configuration<t3coreapi:sitehandling>`.
 
 ..  _SiteLanguageProcessor-options:
@@ -42,11 +47,6 @@ TypoScript
 Using the :php:`SiteLanguageProcessor` the following scenario is possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/SiteLanguageProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`site-language` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteLanguageProcessor`.
 
 
 The Fluid template

--- a/Documentation/DataProcessing/SiteProcessor.rst
+++ b/Documentation/DataProcessing/SiteProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: site
 ..  include:: /Includes.rst.txt
 ..  _SiteProcessor:
 
-=============
-SiteProcessor
-=============
+=====================
+`site` data processor
+=====================
 
-The :php:`SiteProcessor` fetches data from the :ref:`site configuration
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`site` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteProcessor`,
+alias `site`, fetches data from the :ref:`site configuration
 <t3coreapi:sitehandling>`.
 
 
@@ -41,11 +48,6 @@ TypoScript
 Using the :php:`SiteProcessor` the following scenario is possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/SiteProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`site` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\SiteProcessor`.
 
 
 The Fluid template

--- a/Documentation/DataProcessing/SplitProcessor.rst
+++ b/Documentation/DataProcessing/SplitProcessor.rst
@@ -1,11 +1,18 @@
+:navigation-title: split
 ..  include:: /Includes.rst.txt
 ..  _splitProcessor:
 
-==============
-SplitProcessor
-==============
+======================
+`split` data processor
+======================
 
-The :php:`SplitProcessor` allows to split values separated with a delimiter
+..  versionadded:: 12.1
+    One can use the alias :typoscript:`split` instead
+    of the fully-qualified class name
+    :php:`\TYPO3\CMS\Frontend\DataProcessing\SplitProcessor`.
+
+The :php:`\TYPO3\CMS\Frontend\DataProcessing\SplitProcessor`,
+alias `split`, allows to split values separated with a delimiter
 from a single database field. The result is an array that can be iterated over.
 Whitespaces are automatically trimmed.
 
@@ -130,12 +137,6 @@ With the help of the :php:`SplitProcessor` the following scenario is
 possible:
 
 ..  include:: /CodeSnippets/DataProcessing/TypoScript/SplitProcessor.rst.txt
-
-..  versionadded:: 12.1
-    One can use the alias :typoscript:`split` instead
-    of the fully-qualified class name
-    :php:`\TYPO3\CMS\Frontend\DataProcessing\SplitProcessor`.
-
 The Fluid template
 ------------------
 

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -885,6 +885,38 @@ Properties of 'config'
          both browser- and reverse-proxy caches and even make TYPO3 regenerate
          the page. Teach them that trick!
 
+    ..  confval:: sendCacheHeadersForSharedCaches
+        :name: config-sendCacheHeadersForSharedCaches
+        :type: `auto`, `force`, or empty
+
+        ..  versionadded:: 13.3
+
+        When working with proxies, it is much helpful to take load
+        off of TYPO3 / the webserver by keeping a cached version for a period of
+        time and answering requests from the client, while still telling the
+        client to not cache the response inside the browser cache.
+
+        This is achieved by setting
+        :typoscript:`config.sendCacheHeadersForSharedCaches = auto`.
+
+        With this option enabled, TYPO3 evaluates if the current TYPO3 Frontend
+        request is executed behind a reverse proxy, and if so, TYPO3 sends the following
+        HTTP Response Headers at a cached response:
+
+        ..  code-block:: plaintext
+
+            Expires: Thu, 26 Aug 2024 08:52:00 GMT
+            ETag: "d41d8cd98f00b204ecs00998ecf8427e"
+            Cache-Control: max-age=0, s-maxage=86400
+            Pragma: public
+
+        With :typoscript:`config.sendCacheHeadersForSharedCaches = force` the reverse
+        proxy evaluation can be omitted, which can be used for local webserver internal
+        caches.
+
+        See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
+        for details and if your reverse proxy supports this directive.
+
     ..  confval:: showWebsiteTitle
         :name: config-showWebsiteTitle
         :type: :ref:`data-type-boolean`


### PR DESCRIPTION
* Move versionadded directive for alias to top. Will be removed from main and 13.4 in a follow up.
* Mention FQN when introducing the data processor
* Restructure menu and headlines for easier readability

Releases: main, 13.4, 12.4