### PR TITLE
[BUGFIX] Avoid hint to temp. in styles. TLO

### DIFF
--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -97,8 +97,7 @@ styles
 ..  confval:: styles
     :name: tlo-styles
 
-    This top-level object name is reserved. It works just like :confval:`tlo-temp`.
-    It is preserved for historic reasons, use :confval:`tlo-temp` instead.
+    This top-level object name is reserved.
 
 ..  index:: Top-level objects; tt_content
 ..  _tlo-tt:


### PR DESCRIPTION
styles. is not unset after parsing since v7:
https://review.typo3.org/c/Packages/TYPO3.CMS/+/31814