### PR TITLE
Remove the section for the TLO “temp.” as no unset() is executed anymore

### DIFF
--- a/Documentation/TopLevelObjects/Index.rst
+++ b/Documentation/TopLevelObjects/Index.rst
@@ -27,7 +27,6 @@ page | ...                            :ref:`PAGE <page-datatype>`
 config                                :ref:`CONFIG <config-datatype>`
 :ref:`plugin`
 :ref:`tlo-module`
-:ref:`temp <tlo-temp>`
 :ref:`styles <tlo-styles>`
 :ref:`lib <tlo-lib>`
 :ref:`tt_* <tlo-tt>`

--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -25,10 +25,8 @@ lib
     TypoScript code.
 
     This top-level object is available after the template is cached,
-    objects in it can therefore be referenced by using the
+    objects in it can therefore be referenced and copied by using the
     :ref:`reference operator <typoscript-syntax-syntax-object-referencing>` :typoscript:`=<`.
-    Just like with a :confval:`tlo-temp` object copying is
-    also possible.
 
 ..  code-block:: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript

--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -8,45 +8,6 @@ Reserved top-level objects
 ..  contents:: List of the reserved top-level objects
     :depth: 1
 
-..  index:: Top-level objects; temp
-
-..  _top-level-objects-temp:
-..  _tlo-temp:
-
-temp
-====
-
-..  confval:: temp
-    :name: tlo-temp
-
-    This top-level object name is reserved.
-
-    The top-level object :typoscript:`temp` is used to store and copy
-    TypoScript code during parse time.
-
-    :typoscript:`temp` is unset before the template is cached, objects in it
-    can therefore not be referenced. Use :confval:`tlo-lib` for that purpose.
-
-Example: Use the top-level object `temp` to copy code
------------------------------------------------------
-
-..  code-block:: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
-
-    temp.some_content = TEXT
-    temp.some_content.value = Hello World!
-
-    // Output
-    // <h1>Hello World!</h1><p>Hello World!</p>
-    page = PAGE
-    page {
-        10 < temp.some_content
-        10.wrap = <h1>|</h1>
-
-        20 < temp.some_content
-        20.wrap = <p>|</p>
-    }
-
 ..  index:: Top-level objects; lib
 
 ..  _top-level-objects-lib:


### PR DESCRIPTION
Since TYPO3 v12, no unset() is executed when "temp." is parsed. So there is no longer any difference between addressing "temp." by reference or by copy.