### PR TITLE
[BUGFIX] Fix `siteLanguage("locale")` TypoScript condition example

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1399,7 +1399,7 @@ siteLanguage()
         Returns the language ID as an integer.
 
     :typoscript:`siteLanguage("locale")`
-        Returns the current locale as a string, for example `en_GB` or `de_DE`.
+        Returns the current locale as a string, for example `en-GB` or `de-DE`.
 
     :typoscript:`siteLanguage("base")`
         Returns the configured base URL as a string.
@@ -1450,8 +1450,8 @@ siteLanguage()
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-        [siteLanguage("locale") == "de_CH"]
-            page.10.value = This site has the locale "de_CH"
+        [siteLanguage("locale") == "de-CH"]
+            page.10.value = This site has the locale "de_CH" or "de_CH.utf8"
         [END]
 
         [siteLanguage("title") == "Italy"]


### PR DESCRIPTION
The current example for the `siteLanguage` condition does not seem to be working. If I understand the code correctly, the locale string will be normalized to use dashes (e.g. `fr-CH`) as separator instead of an underscore (`fr_CH`) (see [Locale.php](https://git.typo3.org/typo3/typo3/-/blob/22b303f63282e422533b37b09c624900c5995c70/typo3/sysext/core/Classes/Localization/Locale.php#L104).

The output of "locale" in `<f:debug>{siteLanguage}</f:debug>` is also a bit misleading as it uses the `posixFormatted` version instead of the one used in the TypoScript condition.

Please check this proposed change carefully, as I may not understand the whole picture and/or some things depend on the actual hosting environment.