### PR TITLE
[TASK] Remove 'type' from note about bad parameters

### DIFF
--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -632,7 +632,7 @@ Properties of 'config'
 
         ..  note::
 
-            Do **not** include the `type` and `L` parameter in the linkVars
+            Do **not** include the `L` parameter in the linkVars
             list, as this will result in unexpected behavior.
 
     ..  confval:: message_preview


### PR DESCRIPTION
In previous versions of TYPO3 this might have been true, but I don't see any reason, why `type` shouldn't be used in `config.linkVars`.

This goes probably back to: https://forge.typo3.org/issues/25317

I've tested it with TYPO3 12 and couldn't find any side effects.

Here's my scenario:

```
pageTest = PAGE
pageTest {
    typeNum = 1234

    config.linkVars = type

    10 = TEXT
    10.typolink.parameter = 1
    10.typolink.returnLast = url
    10.noTrimWrap = |Link: |<br>|
}
 ```
