### PR TITLE
[BUGFIX] Do not pretend to be a cObject

### DIFF
--- a/Documentation/ContentObjects/Fluidtemplate/_includes/_templateNameAutomatic.typoscript
+++ b/Documentation/ContentObjects/Fluidtemplate/_includes/_templateNameAutomatic.typoscript
@@ -1,6 +1,6 @@
 lib.stdContent = FLUIDTEMPLATE
 lib.stdContent {
-    templateName.stdWrap {
+    templateName {
         cObject = TEXT
         cObject {
             data = levelfield:-2,backend_layout_next_level,slide

--- a/Documentation/ContentObjects/Fluidtemplate/_includes/_templateNameAutomatic.typoscript
+++ b/Documentation/ContentObjects/Fluidtemplate/_includes/_templateNameAutomatic.typoscript
@@ -1,6 +1,5 @@
 lib.stdContent = FLUIDTEMPLATE
 lib.stdContent {
-    templateName = TEXT
     templateName.stdWrap {
         cObject = TEXT
         cObject {


### PR DESCRIPTION
`templateName` is of type string/stdWrap.
However, the snippet gives the impression that it is a cObject due to `templateName = TEXT`.

Working:
```
templateName = Default
```

Working
```
templateName.stdWrap.cObject = TEXT
templateName.stdWrap.cObject.value = Default
```

*Not* working
```
templateName= TEXT
templateName.value = Default
```