### PR TITLE
[BUGFIX] Align headline and description in example

### DIFF
--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -378,7 +378,7 @@ group
 
 ..  _pagetcemain-permissions-group-example:
 
-Example: Set permission defaults so that the group can do anything but delete a page
+Example: Set permission defaults so that the group can do anything with the new page
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ..  code-block:: typoscript


### PR DESCRIPTION
Headline says that the following example does not allow deletion, desxription says that this code snippet will allow deletion (which is true).