### PR TITLE
[TASK] Display page and config on top level of Frontend TypoScript

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -52,8 +52,10 @@ chapter.
     :maxdepth: 1
     :titlesonly:
 
+    TopLevelObjects/Page/Index
     ContentObjects/Index
     DataProcessing/Index
+    TopLevelObjects/Config
     TopLevelObjects/Index
     Functions/Index
     Conditions/Index

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -13,7 +13,7 @@
 `config`: TypoScript configuration
 ==================================
 
-The `config` top-level object does not have to be initialized,  configuration
+The `config` top-level object does not have to be initialized, configuration
 settings can be made like this:
 
 ..  code-block::

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -1,3 +1,5 @@
+:navigation-title: Config
+
 ..  include:: /Includes.rst.txt
 ..  index::
     config
@@ -7,38 +9,23 @@
 ..  _config-datatype:
 ..  _top-level-objects-config:
 
-===============
-CONFIG & config
-===============
+==================================
+`config`: TypoScript configuration
+==================================
+
+The `config` top-level object does not have to be initialized,  configuration
+settings can be made like this:
+
+..  code-block::
+    :caption: config/sites/my_site/setup.typoscript
+
+    # TypoScript
+    config {
+        headerComment = Made with ❤ by your TYPO3 Documentation Team
+    }
 
 ..  contents:: Table of content
     :depth: 1
-
-..  _top-level-objects-config-about:
-
-The 'config' top-level-object
-=============================
-
-Internally TYPO3 always creates an array `config` with various configuration
-values which are evaluated during the rendering process and treated in some
-special, predefined and predictive way. This is what we mean when we say the
-property `config`, actually the array `'config'` is of type CONFIG. It is a
-"top-level-object" because it is not subordinate to any other configuration
-setting.
-
-In PHP you can refer to the array within :file:`typo3/sysext/frontend/Classes/`
-files by writing :php:`$GLOBALS['TSFE']->config['config']`.
-
-This typoscript "top level object" `config` provides access to the internal
-array. This means, that configuration settings can be made easily. For example:
-
-..  code-block::
-
-    # TypoScript
-    config.debug = 1
-
-    # will produce, in php
-    $GLOBALS['TSFE']->config['config']['debug'] // with value 1
 
 ..  _setup-config-xmlprologue:
 ..  _setup-config-typolinklinkaccessrestrictedpages-ATagParams:

--- a/Documentation/TopLevelObjects/Index.rst
+++ b/Documentation/TopLevelObjects/Index.rst
@@ -34,12 +34,10 @@ config                                :ref:`CONFIG <config-datatype>`
 :ref:`sitetitle <tlo-sitetitle>`      readonly
 ===================================== =========================
 
-
 ..  toctree::
     :hidden:
 
-    Config
+    PageAndConfig
     Module
-    Page/Index
     Plugin
     Other

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -1,14 +1,17 @@
+:navigation-title: Page
+
 ..  include:: /Includes.rst.txt
 ..  index::
-   PAGE
-   Top-level objects; page
+    PAGE
+    Top-level objects; page
 ..  _page:
 ..  _page-datatype:
 ..  _object-type-page:
 
-====
-PAGE
-====
+
+================================
+`PAGE` object type in TypoScript
+================================
 
 This defines what is rendered in the frontend.
 

--- a/Documentation/TopLevelObjects/PageAndConfig.rst
+++ b/Documentation/TopLevelObjects/PageAndConfig.rst
@@ -12,7 +12,7 @@ level object called `page`. It is of type
 `PAGE <https://docs.typo3.org/permalink/t3tsref:object-type-page>`_.
 
 The main TypoScript configuration is always done in a top level object called
-`configuration`. It is of type
+`config`. It is of type
 `CONFIG <https://docs.typo3.org/permalink/t3tsref:top-level-objects-config>`_.
 
 ..  contents:: Table of Contents

--- a/Documentation/TopLevelObjects/PageAndConfig.rst
+++ b/Documentation/TopLevelObjects/PageAndConfig.rst
@@ -1,0 +1,52 @@
+:navigation-title: page & config
+
+..  include:: /Includes.rst.txt
+..  _page-config:
+
+===============================================
+`page` and `config` on the TypoScript top level
+===============================================
+
+By convention the main rendering of a page (page type 0) is configured in a top
+level object called `page`. It is of type
+`PAGE <https://docs.typo3.org/permalink/t3tsref:object-type-page>`_.
+
+The main TypoScript configuration is always done in a top level object called
+`configuration`. It is of type
+`CONFIG <https://docs.typo3.org/permalink/t3tsref:top-level-objects-config>`_.
+
+..  contents:: Table of Contents
+
+..  _top-level-objects-page:
+
+The 'page' top-level-object
+=============================
+
+The `page` object should be of type `PAGE <https://docs.typo3.org/permalink/t3tsref:object-type-page>`_
+with property :ref:`typeNum <t3tsref:confval-page-typenum>` (also called page type)
+set to `0`, which is the default.
+
+Some site package authors decide to give the main `PAGE <https://docs.typo3.org/permalink/t3tsref:object-type-page>`_
+object a different top level name like `mypage`, however this can be confusing
+to subsequent integrators and not compatible with extensions that also make
+settings to the `page` top level object.
+
+TYPO3 does not initialize :typoscript:`page` by default. You must initialize this
+explicitly, for example:
+
+..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+
+    page = PAGE
+
+..  _top-level-objects-config-about:
+
+The 'config' top-level-object
+=============================
+
+Internally TYPO3 always creates an array `config` with various configuration
+values which are evaluated during the rendering process and treated in some
+special, predefined and predictive way. This is what we mean when we say the
+property `config`, actually the array `'config'` is of type CONFIG. It is a
+"top-level-object" because it is not subordinate to any other configuration
+setting.


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/5be686da-79bd-4ea4-9310-b58ad2007fd5)


The page is the starting point for whatever rendering is configured via TypoScript. It is hard to find within the "Top level object."

The TypoScript config also has a central and special handling.

Leave hints of how they can be found in the previous place in the Top Level objects

Releases: main, 13.4, 12.4