### PR TITLE
Add section about Template naming and locations to PAGEVIEW

### DIFF
--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -45,8 +45,8 @@ fallback mechanisms apply:
 
 **Target Path Structure**:
 
-*   The target directory **must contain a folder named `Pages/`**.
-*   This folder must contain Fluid templates in *.html format.
+*   The target directory **must contain a folder named :directory:`Pages/`**.
+*   This folder must contain Fluid templates in :file`*.html` format.
 
 **Template Naming Convention**:
 
@@ -56,11 +56,11 @@ fallback mechanisms apply:
 
 **Fallback Behavior**:
 
-*   If page record does not specify a backend layout, TYPO3 tries to detect
-    next-level backend layouts by travelling up the page rootline.
+*   If the page record does not specify a backend layout, TYPO3 tries to detect
+    next-level backend layouts by traversing up the page rootline.
 *   If still no backend layout could be found, TYPO3 falls back to `Default.html`.
-*   If you explizit set backend layout to `none` a Fluid template
-    with name `None.html` will be used.
+*   If you explicitly set the backend layout to `none`, a Fluid template
+    with name :file:`None.html` will be used.
 
 .. _cobj-pageview-data:
 

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -67,7 +67,7 @@ Template naming convention
 
 ..  _cobj-pageview-template-naming-fallback:
 
-Fallback behavior when not backend layout is defined
+Fallback behavior when no backend layout is defined
 ----------------------------------------------------
 
 *   If the page record does not specify a backend layout, TYPO3 tries to detect

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -40,21 +40,35 @@ Example: Display a page with Fluid templates
     :language: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
+..  _cobj-pageview-template-naming:
+
+Template naming and locations
+=============================
+
 To ensure proper rendering, the following requirements and
 fallback mechanisms apply:
 
-**Target Path Structure**:
+..  _cobj-pageview-template-naming-path:
+
+Target path structure
+---------------------
 
 *   The target directory **must contain a folder named :directory:`Pages/`**.
 *   This folder must contain Fluid templates in :file`*.html` format.
 
-**Template Naming Convention**:
+..  _cobj-pageview-template-naming-cobnventions:
 
-*   The Fluid template file should match the name of the selected backend layout
+Template naming convention
+--------------------------
+
+*   The Fluid template file **must** match the name of the selected backend layout
     of your current page.
 *   The first letter of the Fluid template file must be **uppercase**.
 
-**Fallback Behavior**:
+..  _cobj-pageview-template-naming-fallback:
+
+Fallback behavior when not backend layout is defined
+----------------------------------------------------
 
 *   If the page record does not specify a backend layout, TYPO3 tries to detect
     next-level backend layouts by traversing up the page rootline.

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -56,7 +56,7 @@ Target path structure
 *   The target directory **must contain a folder named :directory:`Pages/`**.
 *   This folder must contain Fluid templates in :file`*.html` format.
 
-..  _cobj-pageview-template-naming-cobnventions:
+..  _cobj-pageview-template-naming-conventions:
 
 Template naming convention
 --------------------------

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -40,6 +40,28 @@ Example: Display a page with Fluid templates
     :language: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
+To ensure proper rendering, the following requirements and
+fallback mechanisms apply:
+
+**Target Path Structure**:
+
+*   The target directory **must contain a folder named `Pages/`**.
+*   This folder must contain Fluid templates in *.html format.
+
+**Template Naming Convention**:
+
+*   The Fluid template file should match the name of the selected backend layout
+    of your current page.
+*   The first letter of the Fluid template file must be **uppercase**.
+
+**Fallback Behavior**:
+
+*   If page record does not specify a backend layout, TYPO3 tries to detect
+    next-level backend layouts by travelling up the page rootline.
+*   If still no backend layout could be found, TYPO3 falls back to `Default.html`.
+*   If you explizit set backend layout to `none` a Fluid template
+    with name `None.html` will be used.
+
 .. _cobj-pageview-data:
 
 Default variables in Fluid templates


### PR DESCRIPTION
I just try to get PAGEVIEW running and get errors like:

Tried resolving a template file for controller action "Default->Pages/Default" in format ".html", but none of the paths contained the expected template file (Default/Pages/Default.html).

That's why I would prefer to provide a running example in first section, before we start explaining the containing variables for Fluid templating.