### PR TITLE
typo in TypoScript

### DIFF
--- a/Documentation/ContentObjects/Pageview/_includes/_PageWithConstant.html
+++ b/Documentation/ContentObjects/Pageview/_includes/_PageWithConstant.html
@@ -4,6 +4,6 @@
         <p>...</p>
     </main>
     <footer>
-        See also our <f:page pageUid="{settings.page.uid.dataPrivacy}">data privacy policy</f:page>
+        See also our <f:page pageUid="{settings.page.uids.dataPrivacy}">data privacy policy</f:page>
     </footer>
 </f:section>


### PR DESCRIPTION
With the example above, it should be uids
https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/ContentObjects/Pageview/Index.html#cobj-pageview-data-settings-example