### PR TITLE
Link examples to cache configuration from text

### DIFF
--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -165,7 +165,7 @@ Properties of 'config'
             config.cache.<page-id> = <table name>:<storage-pid>
 
         Multiple record sources can be added as comma-separated list, see the
-        examples.
+        :ref:`examples <setup-config-cache>`.
 
         You can use the keyword "all" instead of a <page-id> to consider
         records for the cache lifetime of all pages.


### PR DESCRIPTION
Although the link is given directly in the confval it is easier for users to just click on the link instead scrolling up and click (if you know already that there is a link above).