### PR TITLE
[PREPORT] Remove outdated paragraph

### DIFF
--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -167,9 +167,6 @@ userFunc
     Similar to, for example, :ref:`stdwrap-postUserFunc` in :ref:`stdWrap`,
     or :ref:`typolink.userFunc <typolink-userFunc>`.
 
-    Remember the function name must possibly be prepended :php:`user_`.
-
-
 ..  _parsefunc-nonTypoTagStdWrap:
 
 nonTypoTagStdWrap


### PR DESCRIPTION
There is no necessity anymore for user functions to be prepended with `user_` anymore, so that confusing and vague sentence can be removed.

Preport of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/1581