### PR TITLE
[TASK] Always use default language binding in page module 1248

### DIFF
--- a/Documentation/PageTsconfig/Mod/WebLayout.rst
+++ b/Documentation/PageTsconfig/Mod/WebLayout.rst
@@ -110,7 +110,7 @@ defLangBinding
 ..  confval:: defLangBinding
     :name: mod-web-layout-defLangBinding
     :type: boolean
-    :Default: 0
+    :Default: 1
 
     ..  versionchanged:: 14.0
         Is not evaluated anymore. Editors will now always see the content


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1248
Releases: main