### PR TITLE
add hint to install extension "setup"

### DIFF
--- a/Documentation/Guide/FirstSteps/Index.rst
+++ b/Documentation/Guide/FirstSteps/Index.rst
@@ -6,7 +6,7 @@
 First steps
 ===========
 
-The system extension "setup - TYPO3 CMS Setup" must be installed.
+The system extension "tstemplate - TYPO3 CMS TypoScript" must be installed.
 
 The basic rendering is defined in the "Setup" field of the main TypoScript record.
 

--- a/Documentation/Guide/FirstSteps/Index.rst
+++ b/Documentation/Guide/FirstSteps/Index.rst
@@ -6,6 +6,8 @@
 First steps
 ===========
 
+The system extension "setup - TYPO3 CMS Setup" must be installed.
+
 The basic rendering is defined in the "Setup" field of the main TypoScript record.
 
 TypoScript essentially consists of objects, which have certain


### PR DESCRIPTION
I have search around without success after I missed the TypoScript module on a TYPO3 website and could not find how to activate it.