### PR TITLE
Fix "Demonstrates" link

### DIFF
--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -937,7 +937,7 @@ Example: Make a cObject available in JavaScript
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Demonstrates:
-    * :confval:`page.jsFooterInline <page-jsFooterInline>`
+    * :confval:`page.jsInline <page-jsInline>`
 
 ..  code-block:: typoscript
     :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript


### PR DESCRIPTION
The example code uses `jsInline`. Adapt the "Demonstrates" section to jump to `jsInline` too.