### PR TITLE
Do not escape backslashes in TypoScript

### DIFF
--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -114,7 +114,7 @@ Previously, TypoScript code for Extbase plugins looked like this:
 
     page.10 = USER
     page.10 {
-        userFunc = TYPO3\\CMS\\Extbase\\Core\\Bootstrap->run
+        userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
         extensionName = MyExtension
         pluginName = MyPlugin
     }


### PR DESCRIPTION
.. it does not with with double backslashes in TYPO3v11