### PR TITLE
Fixed wrong TSconfig syntax (#1610)

### DIFF
--- a/Documentation/Functions/Htmlparser.rst
+++ b/Documentation/Functions/Htmlparser.rst
@@ -147,7 +147,7 @@ removeTags
 
         RTE.default.proc {
           HTMLparser_db {
-            removeTags: link, meta, o:p, sdfield, style, title
+            removeTags = link, meta, o:p, sdfield, style, title
           }
         }
 


### PR DESCRIPTION
Preport of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/pull/1610