### PR TITLE
Remove value on pages for directory menu

### DIFF
--- a/Documentation/CodeSnippets/Menu/TypoScript/MenuSubpages.rst.txt
+++ b/Documentation/CodeSnippets/Menu/TypoScript/MenuSubpages.rst.txt
@@ -16,7 +16,6 @@
             10 = menu
             10 {
                 special = directory
-                special.value.field = pages
                 dataProcessing {
                     10 = files
                     10 {


### PR DESCRIPTION
Hi,

in menu-example we use:

```
special = directory
special.value.field = pages
```

Link: https://docs.typo3.org/m/typo3/reference-typoscript/main/en-us/DataProcessing/MenuProcessor/Directory.html

This does not make sense, as property "field" is page related and table "pages" does NOT have a column "pages". Only tt_content table has a "pages" column.

Luckily TYPO3 hadles this error internally and defaults to an empty value, and on empty value it falls back again to current page UID.

Stefan