### PR TITLE
[BUGFIX] Use correct property `fieldName`

### DIFF
--- a/Documentation/DataProcessing/_FilesProcessorFlexForm.typoscript
+++ b/Documentation/DataProcessing/_FilesProcessorFlexForm.typoscript
@@ -2,7 +2,7 @@ page.10.dataProcessing {
     10 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
     10 {
         references.table = tt_content
-        references.field = settings.myImage
+        references.fieldName = settings.myImage
         as = myImageFromFlexForm
     }
 }


### PR DESCRIPTION
`field` would be a property of stdWrap, but not an subproperty of `references`, which is needed in this snippet.

https://docs.typo3.org/permalink/t3tsref:confval-filesprocessor-references-fieldname