### PR TITLE
[TASK] Unify extension name in examples

### DIFF
--- a/Documentation/Gifbuilder/ObjectNames/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Index.rst
@@ -42,7 +42,7 @@ different each time!
          off. This is done to make matching easier and avoid problems when font
          files might move to other locations in extensions etc.
 
-         So if you use the font file "EXT:myext/fonts/vera.ttf" or
+         So if you use the font file "EXT:my_extension/fonts/vera.ttf" or
          "typo3/sysext/install/Resources/Private/Font/vera.ttf" both of them will
          match with this configuration.
 

--- a/Documentation/Setup/Config/Index.rst
+++ b/Documentation/Setup/Config/Index.rst
@@ -448,7 +448,7 @@ compressCss
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler'] =
                \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/CssCompressHandler.php:Vendor\MyExt\CssCompressHandler->compressCss';
+               'Classes/CssCompressHandler.php:Vendor\MyExtension\CssCompressHandler->compressCss';
 
    Example
          .. code-block:: typoscript
@@ -497,7 +497,7 @@ compressJs
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['jsCompressHandler'] =
                \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/JsCompressHandler.php:Vendor\MyExt\JsCompressHandler->compressJs';
+               'Classes/JsCompressHandler.php:Vendor\MyExtension\JsCompressHandler->compressJs';
 
    Example
          .. code-block:: typoscript
@@ -538,7 +538,7 @@ concatenateCss
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['cssCompressHandler'] =
                \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/CssCompressHandler.php:Vendor\MyExt\CssCompressHandler->compressCss';
+               'Classes/CssCompressHandler.php:Vendor\MyExtension\CssCompressHandler->compressCss';
 
    Example
          .. code-block:: typoscript
@@ -581,7 +581,7 @@ concatenateJs
 
             $GLOBALS['TYPO3_CONF_VARS']['FE']['jsConcatenateHandler'] =
                \TYPO3\CMS\Core\Extension\ExtensionManager::extPath($_EXTKEY) .
-               'Classes/JsConcatenateHandler.php:Vendor\MyExt\JsConcatenateHandler->concatenateJs';
+               'Classes/JsConcatenateHandler.php:Vendor\MyExtension\JsConcatenateHandler->concatenateJs';
 
    Example
          .. code-block:: typoscript

--- a/Documentation/Setup/Page/Index.rst
+++ b/Documentation/Setup/Page/Index.rst
@@ -831,7 +831,7 @@ inlineLanguageLabelFiles
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
             inlineLanguageLabelFiles {
-                someLabels = EXT:myExt/Resources/Private/Language/locallang.xlf
+                someLabels = EXT:my_extension/Resources/Private/Language/locallang.xlf
                 someLabels.selectionPrefix = idPrefix
                 someLabels.stripFromSelectionName = strip_me
                 someLabels.errorMode = 2

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -10,9 +10,9 @@ plugin
 
 This is used for extensions in TYPO3 set up as frontend plugins.
 Typically you can set configuration properties of the plugin here. Say
-you have an extension with the key "myext" and it has a frontend
-plugin named "tx\_myext\_pi1" then you would find the TypoScript
-configuration at the position :typoscript:`plugin.tx_myext_pi1` in the object
+you have an extension with the key "my_extension" and it has a frontend
+plugin named "tx\_myextension\_pi1" then you would find the TypoScript
+configuration at the position :typoscript:`plugin.tx_myextension_pi1` in the object
 tree!
 
 Most plugins are :ref:`cobj-user` objects
@@ -527,7 +527,7 @@ Format
         ..  code-block:: typoscript
             :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-            plugin.tx_myext_pi1._LOCAL_LANG.de.list_mode_1 = Der erste Modus
+            plugin.tx_myextension_pi1._LOCAL_LANG.de.list_mode_1 = Der erste Modus
 
     All variables, which are used inside an Extbase extension with
     the ViewHelper `<f:translate>` can that way be overwritten with

--- a/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
+++ b/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
@@ -50,7 +50,7 @@ Make TypoScript available for static includes
 
    call_user_func(function()
    {
-      $extensionKey = 'myextension';
+      $extensionKey = 'my_extension';
 
       /**
        * Default TypoScript
@@ -93,12 +93,12 @@ If this is not the case, use the method described in the previous section
 
    call_user_func(function()
    {
-      $extensionKey = 'myextension';
+      $extensionKey = 'my_extension';
 
       \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript(
          $extensionKey,
          'setup',
-         "@import 'EXT:myextension/Configuration/TypoScript/setup.typoscript'"
+         "@import 'EXT:my_extension/Configuration/TypoScript/setup.typoscript'"
       );
    });
 

--- a/Documentation/UsingSetting/TheConstantEditor.rst
+++ b/Documentation/UsingSetting/TheConstantEditor.rst
@@ -117,7 +117,7 @@ has to be added. Example:
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
 
-   # customcategory=mysite=LLL:EXT:myext/locallang.xlf:mysite
+   # customcategory=mysite=LLL:EXT:my_extension/locallang.xlf:mysite
 
 This line defines the new category "mysite" which will be available for any
 constant defined **after** this line. The :typoscript:`LLL:` reference points to the
@@ -196,7 +196,7 @@ using the :typoscript:`customsubcategory` parameter. Example:
 .. code-block:: typoscript
    :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
 
-   # customsubcategory=cache=LLL:EXT:myext/locallang.xlf:cache
+   # customsubcategory=cache=LLL:EXT:my_extension/locallang.xlf:cache
 
 Usage example:
 


### PR DESCRIPTION
Unify the extension name of examples to an identical in all places of documentation.

Follow-up of https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/pull/6110