### PR TITLE
[FEATURE] Rename top-level module "file" to "media"

### DIFF
--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -768,7 +768,7 @@ file.identifier
     ..  attention::
         :typoscript:`file` cannot resolve links to files in extensions.
         The files must lie in a storage and be accessible via the backend module
-        :guilabel:`File > Filelist`.
+        :guilabel:`Media > Filelist`.
 
 
 ..  index:: Link handler; folder

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -262,7 +262,7 @@ Properties
         values are therefore `list` and `tiles`, e.g.:
 
         The listing of resources in the TYPO3 Backend, e.g. in the
-        :guilabel:`File > Filelist` module or the `FileBrowser` can be changed
+        :guilabel:`Media > Filelist` module or the `FileBrowser` can be changed
         between `list` and `tiles`. TYPO3 serves by default `tiles`, if the user
         has not already made a choice.
 

--- a/Documentation/UserTsconfig/Setup.rst
+++ b/Documentation/UserTsconfig/Setup.rst
@@ -159,7 +159,8 @@ Properties
         :name: user-setup-showHiddenFilesAndFolders
         :type: boolean
 
-        If set, hidden files and folders will be shown in the filelist.
+        If set, hidden files and folders will be shown in the
+        :guilabel:`Media > Filelist`.
 
     ..  _user-setup-startModule:
 


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1378
Releases: main