### PR TITLE
[FEATURE] Use translation domain mappings over LLL as simplified labels

### DIFF
--- a/Documentation/DataProcessing/_FlexFormWithFal.xml
+++ b/Documentation/DataProcessing/_FlexFormWithFal.xml
@@ -1,5 +1,5 @@
 <my_flex_form_group.my_flex_form_field>
-    <label>LLL:EXT:sitepackage/Resources/Private/Language/locallang_be.xlf:my_flex_form_field</label>
+    <label>LLL:my_sitepackage.backend:my_flex_form_field</label>
     <config>
         <type>file</type>
         <maxitems>9</maxitems>
@@ -14,12 +14,12 @@
         <foreign_types type="array">
             <numIndex index="0">
                 <showitem>
-                    --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
+                    --palette--;LLL:core.tca:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
                 </showitem>
             </numIndex>
             <numIndex index="1">
                 <showitem>
-                    --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
+                    --palette--;LLL:core.tca:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
                 </showitem>
             </numIndex>
         </foreign_types>
@@ -37,7 +37,7 @@
                 <localize>1</localize>
             </enabledControls>
             <createNewRelationLinkTitle>
-                LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:images.addFileReference
+                LLL:frontend.ttc:images.addFileReference
             </createNewRelationLinkTitle>
         </appearance>
         <behaviour>
@@ -48,7 +48,7 @@
             <types type="array">
                 <numIndex index="2">
                     <showitem>
-                        --palette--;LLL:EXT:lang/locallang_tca.xlf:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
+                        --palette--;LLL:core.tca:sys_file_reference.imageoverlayPalette;imageoverlayPalette,--palette--;;filePalette
                     </showitem>
                 </numIndex>
             </types>

--- a/Documentation/Guide/TypoScriptFunctions/GetText/Index.rst
+++ b/Documentation/Guide/TypoScriptFunctions/GetText/Index.rst
@@ -41,7 +41,7 @@ current branch, i.e. the website root for that branch:
 ..  code-block:: typoscript
 
     10 = TEXT
-    10.data = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:siteTitle
+    10.data = LLL:my_extension.messages:siteTitle
 
 Creates a text object that contains the value of the "siteTitle" string in the
 given localization, appropriately translated for the current language.

--- a/Documentation/PageTsconfig/Mod/WebInfo.rst
+++ b/Documentation/PageTsconfig/Mod/WebInfo.rst
@@ -55,17 +55,17 @@ Example: Override the field definitions in the info module
     mod.web_info.fieldDefinitions {
         0 {
             # Basic settings
-            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_0
+            label = LLL:info.webinfo:pages_0
             fields = title,uid,slug,alias,starttime,endtime,fe_group,target,url,shortcut,shortcut_mode
         }
         1 {
             # Record overview
-            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_1
+            label = LLL:info.webinfo:pages_1
             fields = title,uid,###ALL_TABLES###
         }
         2 {
             # Cache and age
-            label = LLL:EXT:info/Resources/Private/Language/locallang_webinfo.xlf:pages_2
+            label = LLL:info.webinfo:pages_2
             fields = title,uid,table_tt_content,table_fe_users
         }
     }

--- a/Documentation/PageTsconfig/Mod/WebLayout/_backendLayouts-example.tsconfig
+++ b/Documentation/PageTsconfig/Mod/WebLayout/_backendLayouts-example.tsconfig
@@ -10,7 +10,7 @@ mod.web_layout.BackendLayouts {
                     1 {
                         columns {
                             1 {
-                                name = LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:colPos.I.3
+                                name = LLL:frontend.ttc:colPos.I.3
                                 colPos = 3
                                 colspan = 1
                             }

--- a/Documentation/PageTsconfig/Mod/WebList.rst
+++ b/Documentation/PageTsconfig/Mod/WebList.rst
@@ -719,12 +719,12 @@ searchLevel.items
         :caption: EXT:site_package/Configuration/page.tsconfig
 
         mod.web_list.searchLevel.items {
-            -1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.infinite
-            0 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.0
-            1 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.1
-            2 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.2
-            3 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.3
-            4 = EXT:core/Resources/Private/Language/locallang_core.xlf:labels.searchLevel.4
+            -1 = LLL:core.core:labels.searchLevel.infinite
+            0 = LLL:core.core:labels.searchLevel.0
+            1 = LLL:core.core:labels.searchLevel.1
+            2 = LLL:core.core:labels.searchLevel.2
+            3 = LLL:core.core:labels.searchLevel.3
+            4 = LLL:core.core:labels.searchLevel.4
         }
 
 ..  index::

--- a/Documentation/PageTsconfig/Mod/WebView.rst
+++ b/Documentation/PageTsconfig/Mod/WebView.rst
@@ -55,7 +55,7 @@ loaded from an xlf file and the category 'desktop'.
     :caption: EXT:site_package/Configuration/page.tsconfig
 
     mod.web_view.previewFrameWidths {
-        1024.label = LLL:EXT:viewpage/Resources/Private/Language/locallang.xlf:computer
+        1024.label = LLL:viewpage.messages:computer
         1024.type = desktop
         1024.width = 1024
         1024.height = 768

--- a/Documentation/PageTsconfig/Mod/_WebList/_downloadPresets.tsconfig
+++ b/Documentation/PageTsconfig/Mod/_WebList/_downloadPresets.tsconfig
@@ -7,7 +7,7 @@ mod.web_list.downloadPresets {
 
         fullExport {
             identifier = uid-title
-            label = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:preset2.label
+            label = LLL:my_extension.messages:preset2.label
             columns = uid, title
         }
     }

--- a/Documentation/PageTsconfig/Mod/_newContentElementWizardGroup.tsconfig
+++ b/Documentation/PageTsconfig/Mod/_newContentElementWizardGroup.tsconfig
@@ -1,6 +1,6 @@
 # Create a new group and add a (pre-filled) element to it
 mod.wizards.newContentElement.wizardItems.myGroup {
-    header = LLL:EXT:cms/layout/locallang.xlf:advancedFunctions
+    header = LLL:my_extension.backend:advancedFunctions
     elements.customText {
         iconIdentifier = content-text
         title = Introductory text for national startpage

--- a/Documentation/PageTsconfig/TceForm.rst
+++ b/Documentation/PageTsconfig/TceForm.rst
@@ -126,8 +126,8 @@ Example: Add header layout option
         # Add another header_layout option:
         addItems.1525215969 = Another header layout
         # Add another one with localized label, icon and group
-        addItems.1525216023 = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:header_layout
-        addItems.1525216023.icon = EXT:my_ext/icon.png
+        addItems.1525216023 = LLL:my_extension.messages:header_layout
+        addItems.1525216023.icon = EXT:my_extension/Resources/Public/Icons/icon.png
         addItems.1525216023.group = special
     }
 
@@ -177,7 +177,7 @@ Example: Override labels for document types
         altLabels.1 = STANDARD Page Type
         altLabels.254 = Folder (for various elements)
         # Sets the default label for Recycler via "locallang":
-        altLabels.255 = LLL:EXT:my_ext/Resources/Private/Language/locallang_tca.xlf:recycler
+        altLabels.255 = LLL:my_extension.tca:recycler
     }
 
 ..  figure:: /Images/ManualScreenshots/List/PagesDoktypeDifferentLabels.png
@@ -503,7 +503,7 @@ description
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/page.tsconfig
 
-        TCEFORM.tt_content.header.description = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:override_description
+        TCEFORM.tt_content.header.description = LLL:my_extension.messages:override_description
 
 ..  index::
     Records; field disabled
@@ -772,7 +772,7 @@ Example: Override the label of a field
     :caption: EXT:site_package/Configuration/page.tsconfig
 
     TCEFORM.pages.title {
-        label = LLL:EXT:my_ext/Resources/Private/Language/locallang.xlf:table.column
+        label = LLL:my_extension.messages:table.column
         label.default = New Label
         label.de = Neuer Feldname
     }
@@ -937,7 +937,7 @@ Example: Rename the first tab of the FlexForm plugin
 
     TCEFORM.tt_content.pi_flexform.myext_pi1.sDEF {
         # Rename the first tab of the FlexForm plug-in configuration
-        sheetTitle = LLL:my_ext/Resource/Private/Language/locallang.xlf:tt_content.pi_flexform.myext_pi1.sDEF
+        sheetTitle = LLL:my_extension.messages:tt_content.pi_flexform.myext_pi1.sDEF
     }
 
 ..  index::

--- a/Documentation/PageTsconfig/TceMain.rst
+++ b/Documentation/PageTsconfig/TceMain.rst
@@ -260,7 +260,7 @@ frontend you need to define the same key in the TypoScript setup
 
     TCEMAIN.linkHandler.my_content {
         handler = TYPO3\CMS\Backend\LinkHandler\RecordLinkHandler
-        label = LLL:EXT:my_extension/Resources/Private/Language/locallang.xlf:link.customTab
+        label = LLL:my_extension.messages:link.customTab
         configuration {
             table = tx_myextension_content
         }

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -103,7 +103,7 @@ Properties
             :caption: EXT:site_package/Configuration/user.tsconfig
 
             bookmarkGroups {
-              2 = LLL:EXT:sitepackage/Resources/Private/Language/locallang_be.xlf:bookmarkGroups.2
+              2 = LLL:my_sitepackage.backend:bookmarkGroups.2
             }
 
     ..  _useroptions-clearCache:

--- a/Documentation/UsingSettingTSconfig/_PageTSconfig/_pages_localized.php
+++ b/Documentation/UsingSettingTSconfig/_PageTSconfig/_pages_localized.php
@@ -2,6 +2,6 @@
 
 $GLOBALS['TCA']['pages']['columns']['tsconfig_includes']['config']['items'][] =
     [
-        'LLL:EXT:my_sitepackage/Resources/Private/Language/locallang_db.xlf:pages.pageTSconfig.my_ext_be_layouts',
+        'LLL:my_sitepackage.db:pages.pageTSconfig.my_ext_be_layouts',
         'EXT:my_sitepackage/Configuration/TsConfig/Page/myPageTSconfigFile.tsconfig',
     ];


### PR DESCRIPTION
References: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1370
Releases: main