### PR TITLE
[DOC] Fix incorrect includeCSS usage in TypoScript Page example

### DIFF
--- a/Documentation/Guide/Page/_javascript-loading.typoscript
+++ b/Documentation/Guide/Page/_javascript-loading.typoscript
@@ -8,7 +8,7 @@ page {
       alert("Hello World! ");
     )
   }
-  includeCSS {
-    includeJSFooter = EXT:site_package/Resources/Public/JavaScript/main.js
+  includeJSFooter {
+    main = EXT:site_package/Resources/Public/JavaScript/main.js
   }
 }


### PR DESCRIPTION
The "Loading JavaScript in TypoScript" section incorrectly placed `includeJSFooter` inside `includeCSS`, which is not valid TypoScript. JavaScript includes must be placed under `includeJSFooter`, not `includeCSS`.

This update corrects the example and prevents confusion for integrators.