### PR TITLE
Remove mention of TSFE in LOAD_REGISTER

### DIFF
--- a/Documentation/ContentObjects/LoadRegister/Index.rst
+++ b/Documentation/ContentObjects/LoadRegister/Index.rst
@@ -8,9 +8,6 @@
 LOAD\_REGISTER
 ==============
 
-This provides a way to load the array :php:`$GLOBALS['TSFE']->register[]`
-with values. It does not return anything!
-
 The register is working like a stack: With each call new content can be
 put on top of the stack. :ref:`RESTORE_REGISTER <cobj-restore-register>`
 can be used to remove the element at the topmost position again.

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -809,7 +809,7 @@ register
 
 ..  confval:: register
     :name: data-register
-    :Syntax: register: [field name from the :php:`$GLOBALS['TSFE']->register`]
+    :Syntax: register: [field name from the register stack]
 
     See :ref:`LOAD_REGISTER <cobj-load-register>`.
 

--- a/Documentation/Guide/TypoScriptObjects/FurtherObjects/Index.rst
+++ b/Documentation/Guide/TypoScriptObjects/FurtherObjects/Index.rst
@@ -19,7 +19,7 @@ Further objects
 
 *   :ref:`LOAD\_REGISTER <cobj-load-register>` /
     :ref:`RESTORE\_REGISTER <cobj-restore-register>` objects allow us to
-    fill the global array `$GLOBALS['TSFE']->register[]` with content.
+    fill the register stack with content.
     These objects return nothing. Single values and complete TypoScript
     objects can be used. In doing so, the register works as a stack: With
     every call, a further element is stacked. With


### PR DESCRIPTION
Actually, the LoadRegisterContentObject is responsible for handling LOAD_REGISTER nowadays. The internal RegisterStack is stored in the internal frontend.register.stack request attribute. The sentence is therefore removed completely, as the handling is an internal implementation detail and should not matter to the user.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 14.3