### PR TITLE
Remove example for "Images in lightbox TopUp"

### DIFF
--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -329,9 +329,8 @@ Example: Use alternative parameters for the a-tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This way it is possible to use a lightbox and to display
-resized images in the frontend. More complete examples are
-:ref:`imageLinkWrap-example-fancybox` and
-:ref:`imageLinkWrap-example-topup`.
+resized images in the frontend. A more complete example is
+:ref:`imageLinkWrap-example-fancybox`.
 
 ..  code-block:: typoscript
 
@@ -525,38 +524,5 @@ and use `fancybox <http://fancybox.net>`_:
        directImageLink = 1
        linkParams.ATagParams {
           dataWrap = class= "lightbox" data-fancybox-group="lightbox{field:uid}"
-       }
-    }
-
-..  _imageLinkWrap-example-topup:
-
-Example: Images in lightbox "TopUp"
------------------------------------
-
-In this `blog post <https://www.interaktionsdesigner.de/2009/typo3-klickvergrossern-durch-eine-jquery-lightbox-ersetzen>`__
-(German) Paul Lunow shows a way to integrate the
-`jQuery <https://jquery.com/>`__
-`TopUp lightbox <https://jquery-plugins.net/topup-jquery-lightbox-pop-up-plugin>`__:
-
-..  code-block:: typoscript
-
-    tt_content.image.20.1.imageLinkWrap >
-    tt_content.image.20.1.imageLinkWrap = 1
-    tt_content.image.20.1.imageLinkWrap {
-       enable = 1
-       typolink {
-          # directly link to the recent image
-          parameter.cObject = IMG_RESOURCE
-          parameter.cObject.file.import.data = TSFE : lastImageInfo | origFile
-          parameter.cObject.file.maxW = {$styles.content.imgtext.maxW}
-          parameter.override.listNum.stdWrap.data = register : IMAGE_NUM_CURRENT
-          title.field = imagecaption // title
-          title.split.token.char = 10
-          title.if.isTrue.field = imagecaption // header
-          title.split.token.char = 10
-          title.split.returnKey.data = register : IMAGE_NUM_CURRENT
-          parameter.cObject = IMG_RESOURCE
-          parameter.cObject.file.import.data = TSFE : lastImageInfo | origFile
-          ATagParams = target="_blank"
        }
     }

--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -326,6 +326,12 @@ linkParams
     Needs :typoscript:`JSwindow = 0`.
 
 Example: Use alternative parameters for the a-tag
+Needs :typoscript:`JSwindow = 0`.
+
+..  _imageLinkWrap-example-topup:
+..  _imageLinkWrap-example:
+
+Example: Use alternative parameters for the a-tag
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This way it is possible to use a lightbox and to display


### PR DESCRIPTION
The example uses "TSFE : lastImageInfo | origFile" which is not available anymore with TYPO3 v14. The example is also rather complex and uses the TopUp lightbox which was last updated 16 years ago (https://github.com/archan937/topup). Therefore, we should remove the whole example. The same feature can be achieved nowadays more easily with Fluid.

Related: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1074
Releases: main, 14.3