### PR TITLE
[TASK] Deprecate GeneralUtility::getIndpEnv()

### DIFF
--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -74,9 +74,10 @@ Properties
 
 ..  note::
 
-    The :php:`$request` object should be used to access request related variables instead of directly accessing
-    the superglobal variables like :php:`$_GET` / :php:`$_POST` / :php:`$_SERVER`, or TYPO3’s API methods :php:`GeneralUtility::_GP()`
-    and :php:`GeneralUtility::getIndpEnv()`.
+    The :php:`$request` object should be used to access request related
+    variables instead of directly accessing the superglobal variables like
+    :php:`$_GET` / :php:`$_POST` / :php:`$_SERVER`, or TYPO3’s API method
+    :php:`GeneralUtility::_GP()`.
 
 ..  _cobj-user-defined-properties:
 

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -451,8 +451,7 @@ getIndpEnv
     Returns the value of a *System Environment Variable* denoted by
     *name* regardless of server OS, CGI/MODULE version, etc. The result is
     usually identical to the :php:`$_SERVER` variable. This method is more reliable
-    then *getEnv*. Internal processing is handled by
-    :php:`TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv()`
+    then :ref:`getEnv <data-type-gettext-getenv>`.
 
     Available names:
 


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1715
Resolves: https://github.com/TYPO3-Documentation/Changelog-To-Doc/issues/1697
Releases: main, 14.3