### PR TITLE
[TASK] Improve resource documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 * In order to make changes on a [rendered page](https://docs.typo3.org/typo3cms/TyposcriptReference/), just click on "Edit me on GitHub".
 * For a step-by-step walkthrough for making a change, see [Contribute to docs.typo3.org](https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/Index.html)
-* For a step-by-step walkthrough of alternative workflow, see [Local Editing and Rendering with Docker](https://docs.typo3.org/typo3cms/HowToDocument/WritingDocsOfficial/LocalEditing.html)
+* For a step-by-step walkthrough of alternative workflow, see [Rendering the Documentation folder locally with Docker](https://docs.typo3.org/permalink/h2document:render-documentation-with-docker)
 
 ## Get help
 

--- a/Documentation/Syntax/StringFormats/Index.rst
+++ b/Documentation/Syntax/StringFormats/Index.rst
@@ -143,13 +143,13 @@ resource
 
         The resource handling has been streamlined, see
         :ref:`System resource API for system file access and public
-        URI generation <changelog:feature-107537-1759136314>` and now
+        URI generation <changelog:feature-107537-1759136314>`. It now
         supports different resource formats.
 
     These types are supported:
 
-    * **package resource** – a file within an extension
-    * **FAL resource** – a file from a :abbr:`FAL (File Abstraction Layer)` storage
+    * **package resource** – a file inside an extension
+    * **FAL resource** – a file from :abbr:`FAL (File Abstraction Layer)` storage
     * **app resource** – a file in the TYPO3 project folder
     * **URI resource** – a URL
 

--- a/Documentation/Syntax/StringFormats/Index.rst
+++ b/Documentation/Syntax/StringFormats/Index.rst
@@ -139,18 +139,44 @@ resource
 ..  confval:: resource
     :name: data-type-resource
 
-    If the value contains a "/", it is expected to be a reference (absolute or
-    relative) to a file in the file system. There is no support for wildcard
-    characters in the name of the reference.
+    ..  versionchanged:: 14.0
 
-    ..  rubric:: Example
+        The resource handling has been streamlined, see
+        :ref:`System resource API for system file access and public
+        URI generation <changelog:feature-107537-1759136314>` and now
+        supports different resource formats.
+
+    These types are supported:
+
+    * **package resource** – a file within an extension
+    * **FAL resource** – a file from a :abbr:`FAL (File Abstraction Layer)` storage
+    * **app resource** – a file in the TYPO3 project folder
+    * **URI resource** – a URL
+
+    ..  rubric:: Examples
 
     Reference to a file in the file system:
 
     ..  code-block:: typoscript
         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
-        page.10.settings.someFile = fileadmin/picture.gif
+        # PKG should be preferred to EXT
+        page.10.settings.someFile = PKG:my-vendor/package-name:Resources/Public/Icons/MyIcon.svg
+
+        # EXT still works
+        page.10.settings.someFile = EXT:ext_name/Resources/Public/Icons/MyIcon.svg
+
+        # App resources (files in the webroot) can be accessed with PKG:typo3/app:
+        page.10.settings.someFile = PKG:typo3/app:public/typo3temp/assets/style.css
+
+        # A FAL resource
+        page.10.settings.someFile = FAL:1:/identifier/of/file.svg
+
+        # External URL
+        page.10.settings.someFile = https://www.example.com/my/image.svg
+
+        # URIs relative to the current host can be prefixed with URI:
+        page.10.settings.someFile = URI:/path/to/my/image.svg
 
 ..  index:: Simple data types; string
 ..  _data-type-string:

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -301,7 +301,7 @@ Properties
         ..  versionchanged:: 14.0
 
             TYPO3 no longer supports frontend asset concatenation or pre-compression
-            in the core. The per-file properties
+            in the core. The per-file properties :typoscript:`external`,
             :typoscript:`disableCompression` and
             :typoscript:`excludeFromConcatenation` are therefore not available in
             TYPO3 v14 and above. See
@@ -326,9 +326,6 @@ Properties
         `alternate`
             If set (boolean) then the rel-attribute will be
             "alternate stylesheet".
-        `external`
-            If set, there is no file existence check. Useful for
-            inclusion of external files.
         `forceOnTop`
             Boolean flag. If set, this file will be added on top
             of all other files.
@@ -355,7 +352,7 @@ Properties
         ..  versionchanged:: 14.0
 
             TYPO3 no longer supports frontend asset concatenation or pre-compression
-            in the core. The per-file properties
+            in the core. The per-file properties :typoscript:`external`,
             :typoscript:`disableCompression` and
             :typoscript:`excludeFromConcatenation` are therefore not available in
             TYPO3 v14 and above. See
@@ -364,8 +361,7 @@ Properties
         Adds CSS library files to head of page.
 
         The file definition must be a valid :ref:`data-type-resource` data type,
-        otherwise nothing is inserted. This means that remote files cannot be referenced
-        (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
+        otherwise nothing is inserted.
 
         Each file has *optional properties*:
 
@@ -378,9 +374,6 @@ Properties
         `alternate`
             If set (boolean) then the rel-attribute will be
             "alternate stylesheet".
-        `external`
-            If set, there is no file existence check. Useful for
-            inclusion of external files.
         `forceOnTop`
             Boolean flag. If set, this file will be added on top
             of all other files.
@@ -404,7 +397,7 @@ Properties
         ..  versionchanged:: 14.0
 
             TYPO3 no longer supports frontend asset concatenation or pre-compression
-            in the core. The per-file properties
+            in the core. The per-file properties :typoscript:`external`,
             :typoscript:`disableCompression` and
             :typoscript:`excludeFromConcatenation` are therefore not available in
             TYPO3 v14 and above. See
@@ -414,8 +407,7 @@ Properties
         With :ref:`setup-config-movejsfromheadertofooter` set to TRUE all files
         will be moved to the footer.
         The file definition must be a valid :ref:`data-type-resource` data type,
-        otherwise nothing is inserted. This means that remote files cannot be referenced
-        (i.e. using :samp:`https://...`), except by using the :typoscript:`.external` property.
+        otherwise nothing is inserted.
 
         Each file has *optional properties*:
 
@@ -437,10 +429,6 @@ Properties
 
         `defer`
             Allows to set the HTML5 attribute :html:`defer`.
-
-        `external`
-            If set, there is no file existence check. Useful for
-            inclusion of external files.
 
         `forceOnTop`
             Boolean flag. If set, this file will be added on top
@@ -810,7 +798,6 @@ Demonstrates:
         ie6.allWrap = <!--[if lte IE 7]>|<![endif]-->
 
         example = https://example.org/some_external_styles.css
-        example.external = 1
     }
 
 
@@ -830,7 +817,6 @@ Demonstrates:
 
     page.includeCSSLibs {
         bootstrap = https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css
-        bootstrap.external = 1
 
         additional = EXT:site_package/Resources/Public/Css/additional_styles.css
         additional.data-foo = bar
@@ -870,7 +856,6 @@ Demonstrates:
         consent.data.other-attribute = value
 
         jquery = https://code.jquery.com/jquery-3.4.1.min.js
-        jquery.external = 1
         jquery.integrity = sha384-vk5WoKIaW/vJyUAd9n/wmopsmNhiy+L2Z+SBxGYnUkunIxVxAv/UtMOhba/xskxh
     }
 

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -301,7 +301,7 @@ Properties
         ..  versionchanged:: 14.0
 
             TYPO3 no longer supports frontend asset concatenation or pre-compression
-            in the core. The per-file properties :typoscript:`external`,
+            in the core. The file properties :typoscript:`external`,
             :typoscript:`disableCompression` and
             :typoscript:`excludeFromConcatenation` are therefore not available in
             TYPO3 v14 and above. See
@@ -352,7 +352,7 @@ Properties
         ..  versionchanged:: 14.0
 
             TYPO3 no longer supports frontend asset concatenation or pre-compression
-            in the core. The per-file properties :typoscript:`external`,
+            in the core. The file properties :typoscript:`external`,
             :typoscript:`disableCompression` and
             :typoscript:`excludeFromConcatenation` are therefore not available in
             TYPO3 v14 and above. See


### PR DESCRIPTION
The resource handling has been streamlined in TYPO3 14, see:
https://docs.typo3.org/permalink/changelog:feature-107537-1759136314
https://review.typo3.org/c/Packages/TYPO3.CMS/+/91562

The documentation for the resource string format is adjusted accordingly and a hint about the change is added.

The external property no longer exists for includeCSS / includeJS page config and is removed.

Also: the link to the local rendering docs in CONTRIBUTING.md is fixed.

Releases: main, 14.3