### PR TITLE
[BUGFIX] Use correct variables and properties in examples

### DIFF
--- a/Documentation/DataProcessing/RecordTransformationProcessor.rst
+++ b/Documentation/DataProcessing/RecordTransformationProcessor.rst
@@ -64,7 +64,7 @@ We are dealing with an object here. You however can access your record
 properties as you are used to with :html:`{record.title}` or
 :html:`{record.uid}`. In addition, you gain special, context-aware properties
 like the language :html:`{record.languageId}` or workspace
-:html:`{data.versionInfo.workspaceId}`.
+:html:`{record.versionInfo.workspaceId}`.
 
 Overview of all possibilities:
 

--- a/Documentation/DataProcessing/_RecordTransformationProcessor/_FluidUsage.html
+++ b/Documentation/DataProcessing/_RecordTransformationProcessor/_FluidUsage.html
@@ -24,26 +24,26 @@
 {record.fullType}
 
 <!-- System related properties -->
-{data.systemProperties.isDeleted}
-{data.systemProperties.isDisabled}
-{data.systemProperties.isLockedForEditing}
-{data.systemProperties.createdAt}
-{data.systemProperties.lastUpdatedAt}
-{data.systemProperties.publishAt}
-{data.systemProperties.publishUntil}
-{data.systemProperties.userGroupRestriction}
-{data.systemProperties.sorting}
-{data.systemProperties.description}
+{record.systemProperties.deleted}
+{record.systemProperties.disabled}
+{record.systemProperties.lockedForEditing}
+{record.systemProperties.createdAt}
+{record.systemProperties.lastUpdatedAt}
+{record.systemProperties.publishAt}
+{record.systemProperties.publishUntil}
+{record.systemProperties.userGroupRestriction}
+{record.systemProperties.sorting}
+{record.systemProperties.description}
 
 <!-- Computed properties depending on the request context -->
-{data.computedProperties.versionedUid}
-{data.computedProperties.localizedUid}
-{data.computedProperties.requestedOverlayLanguageId}
-{data.computedProperties.translationSource} <!-- Only for pages, contains the Page model -->
+{record.computedProperties.versionedUid}
+{record.computedProperties.localizedUid}
+{record.computedProperties.requestedOverlayLanguageId}
+{record.computedProperties.translationSource} <!-- Only for pages, contains the Page model -->
 
 <!-- Workspace related properties -->
-{data.versionInfo.workspaceId}
-{data.versionInfo.liveId}
-{data.versionInfo.state.name}
-{data.versionInfo.state.value}
-{data.versionInfo.stageId}
+{record.versionInfo.workspaceId}
+{record.versionInfo.liveId}
+{record.versionInfo.state.name}
+{record.versionInfo.state.value}
+{record.versionInfo.stageId}


### PR DESCRIPTION
Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/1718
Releases: main, 14.3, 13.4