### PR TITLE
Document dynamic USER to USER_INT conversion

### DIFF
--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -272,104 +272,23 @@ via TypoScript:
 Example 6: Converting a custom (non-Extbase) USER plugin dynamically into a USER_INT
 ------------------------------------------------------------------------------------
 
-An extension plugin can be defined as :typoscript:`USER` or :typoscript:`USER_INT` content
-object (cObject). A big extension will have multiple display modes. Some of the display modes show views
-which should be stored in a cache (:typoscript:`USER`) and others show personal data and must never be
-cached. For this reason it is necessary that the plugin transitions from a :typoscript:`USER` to a
-:typoscript:`USER_INT` cObject dynamically. Calling :php:`convertToUserIntObject()` marks the current object
-as :typoscript:`USER_INT`; TYPO3 Core then substitutes it with a freshly, non-cached rendered version of the
-same plugin in a later rendering pass, so the rest of the page can still be cached.
+An extension plugin can be defined as :typoscript:`USER` or :typoscript:`USER_INT` content object
+(cObject). Sometimes whether a plugin's output is cacheable only becomes clear while it is
+rendering - for example, once it decides to show personal or otherwise uncacheable content -
+so a plugin registered as :typoscript:`USER` needs to transition to :typoscript:`USER_INT`
+dynamically. Calling :php:`convertToUserIntObject()` marks the current object as
+:typoscript:`USER_INT`; TYPO3 Core then substitutes it with a freshly, non-cached rendered
+version of the same plugin in a later rendering pass, so the rest of the page can still be
+cached.
 
-..  code-block:: typoscript
+..  literalinclude:: _ConvertUserToUserInt.typoscript
+    :language: typoscript
     :caption: Configuration/TypoScript/setup.typoscript
-
-    # Define the custom content element / plugin as a standard cached USER object
-    tt_content.my_custom_plugin = USER
-    tt_content.my_custom_plugin {
-        # Route the request to our PSR-11 compliant container service class and method
-        userFunc = MyVendor\MyExtension\UserFunc\PluginRenderer->renderPlugin
-        
-        # Optional settings passed into the $conf array inside PHP
-        settings {
-            activeModes = list_view, live_search
-        }
-    }
 
 This example PHP code executes the dynamic transition from :typoscript:`USER` to :typoscript:`USER_INT`.
 
-..  code-block:: php
+..  literalinclude:: _ConvertUserToUserInt.php
+    :language: php
     :caption: Classes/UserFunc/PluginRenderer.php
-
-    namespace MyVendor\MyExtension\UserFunc;
-
-    use Psr\Http\Message\ServerRequestInterface;
-    use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
-    use TYPO3\CMS\Core\Utility\GeneralUtility;
-    use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-
-    class PluginRenderer
-    {
-        /**
-         * Main entry point called by TypoScript.
-         * TYPO3 v13/v14 automatically passes the ServerRequestInterface as the third argument.
-         *
-         * @param string $content Empty string from TypoScript pipeline
-         * @param array $conf TypoScript configuration array passed to this object
-         * @param ServerRequestInterface $request The modern PSR-7 server request object
-         * @return string The rendered HTML output
-         */
-        #[AsAllowedCallable]
-        public function renderPlugin(string $content, array $conf, ServerRequestInterface $request): string
-        {
-            // TYPO3 v13/v14 Style: Extract the ContentObjectRenderer from the request attributes
-            /** @var ContentObjectRenderer $cObj */
-            $cObj = $request->getAttribute('currentContentObject');
-
-            // Read the active modes from the "settings.activeModes" TypoScript property
-            $activeModes = GeneralUtility::trimExplode(',', $conf['settings.']['activeModes'] ?? '', true);
-
-            // Call the check and transform cache logic using the extracted cObj
-            if ($cObj instanceof ContentObjectRenderer) {
-                $this->checkAndTransformCache($cObj, $activeModes);
-            }
-
-            // Render your custom HTML without Extbase overhead
-            if (in_array('live_search', $activeModes, true)) {
-                return '<div>Live Search Result (Rendered live via USER_INT conversion)</div>';
-            }
-
-            return '<div>Standard List View (Cached via USER)</div>';
-        }
-
-        /**
-         * Internal cache-handling method matching your requested logic
-         */
-        private function checkAndTransformCache(ContentObjectRenderer $cObj, array $selectedModes): bool
-        {
-            // Define modes that strictly require real-time processing (disables caching)
-            $noCacheCodes = ['cart_view', 'checkout', 'user_profile_edit', 'live_search'];
-
-            // Nothing to do if this call is already the non-cached USER_INT re-render
-            if ($cObj->getUserObjectType() !== ContentObjectRenderer::OBJECTTYPE_USER) {
-                return false;
-            }
-
-            $wasConverted = false;
-
-            // Loop through all active modes of the current plugin instance
-            foreach ($selectedModes as $currentCode) {
-                if (in_array($currentCode, $noCacheCodes, true)) {
-
-                    // TYPO3 CORE API: Dynamically upgrades the USER object to a non-cached USER_INT object
-                    $cObj->convertToUserIntObject();
-
-                    $wasConverted = true;
-                    break; // Stop loop immediately since caching is already disabled for this request
-                }
-            }
-
-            return $wasConverted;
-        }
-    }
 
 

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -266,3 +266,101 @@ via TypoScript:
             return 'Something';
         }
     }
+
+..  _cobj-user-convert-userint-plugin:
+
+Example 6: Converting a custom (non-Extbase) USER plugin dynamically into a USER_INT
+------------------------------------------------------------------------------------
+
+An extension plugin can be defined as USER or USER_INT content object (cObject). A big extension will have multiple
+display modes. Some of the display modes show views which should be stored in a cache (USER) ond other show 
+personal data and must never be cached. For this reason it is necessary that the plugin transitions from a 
+USER to a USER_INT cObject dynamically. The code procedure exits immediately if a display mode must be a USER_INT. 
+TYPO3 Core then restarts the same plugin execution immediately again as a USER_INT cObject. It must be avoided
+to clear the cache of the whole TYPO3 page.
+
+..  code-block:: typoscript
+    :caption: Configuration/TypoScript/setup.typoscript
+
+    # Define the custom content element / plugin as a standard cached USER object
+    tt_content.my_custom_plugin = USER
+    tt_content.my_custom_plugin {
+        # Route the request to our PSR-11 compliant container service class and method
+        userFunc = MyVendor\MyExtension\UserFunc\PluginRenderer->renderPlugin
+        
+        # Optional settings passed into the $conf array inside PHP
+        settings {
+            activeModes = list_view, live_search
+        }
+    }
+
+This example PHP code executes the dynamic transition from USER to USER_INT.
+
+..  code-block:: php
+    :caption: Classes/UserFunc/PluginRenderer.php
+
+    namespace MyVendor\MyExtension\UserFunc;
+    
+    use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+    
+    class PluginRenderer
+    {
+        /**
+         * Main entry point called by TypoScript.
+         * TYPO3 v13/v14 automatically passes the ServerRequestInterface as the third argument.
+         * 
+         * @param string $content Empty string from TypoScript pipeline
+         * @param array $conf TypoScript configuration array passed to this object
+         * @param ServerRequestInterface $request The modern PSR-7 server request object
+         * @return string The rendered HTML output
+         */
+        public function renderPlugin(string $content, array $conf, ServerRequestInterface $request): string
+        {
+            // TYPO3 v13/v14 Style: Extract the ContentObjectRenderer from the request attributes
+            /** @var ContentObjectRenderer $cObj */
+            $cObj = $request->getAttribute('currentContentObject');
+    
+            // Example: Simulating selected modes (usually fetched from request or TypoScript configuration)
+            $activeModes = ['list_view', 'live_search']; 
+    
+            // Call the check and transform cache logic using the extracted cObj
+            if ($cObj instanceof ContentObjectRenderer) {
+                $this->checkAndTransformCache($cObj, $activeModes);
+            }
+    
+            // Render your custom HTML without Extbase overhead
+            if (in_array('live_search', $activeModes, true)) {
+                return '<div>Live Search Result (Rendered live via USER_INT conversion)</div>';
+            }
+    
+            return '<div>Standard List View (Cached via USER)</div>';
+        }
+    
+        /**
+         * Internal cache-handling method matching your requested logic
+         */
+        private function checkAndTransformCache(ContentObjectRenderer $cObj, array $selectedModes): bool
+        {
+            // Define modes that strictly require real-time processing (disables caching)
+            $noCacheCodes = ['cart_view', 'checkout', 'user_profile_edit', 'live_search'];
+            
+            $wasConverted = false;
+    
+            // Loop through all active modes of the current plugin instance
+            foreach ($selectedModes as $currentCode) {
+                if (in_array($currentCode, $noCacheCodes, true)) {
+                    
+                    // TYPO3 CORE API: Dynamically upgrades the USER object to a non-cached USER_INT object
+                    $cObj->convertToUserIntObject();
+                    
+                    $wasConverted = true;
+                    break; // Stop loop immediately since caching is already disabled for this request
+                }
+            }
+    
+            return $wasConverted;
+        }
+    }
+
+

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -269,15 +269,15 @@ via TypoScript:
 
 ..  _cobj-user-convert-userint-plugin:
 
-Example 6: Converting a custom (non-Extbase) USER plugin dynamically into a USER_INT
-------------------------------------------------------------------------------------
+Example 6: Converting a custom (non-Extbase) `USER` plugin dynamically into a `USER_INT`
+----------------------------------------------------------------------------------------
 
 An extension plugin can be defined as :typoscript:`USER` or :typoscript:`USER_INT` content object
-(cObject). Sometimes whether a plugin's output is cacheable only becomes clear while it is
-rendering - for example, once it decides to show personal or otherwise uncacheable content -
-so a plugin registered as :typoscript:`USER` needs to transition to :typoscript:`USER_INT`
+(cObject). Whether a plugin's output is cacheable sometimes only becomes clear while it is
+rendering - for example, once it decides to show personal or otherwise uncacheable content. In
+that case, a plugin registered as :typoscript:`USER` needs to transition to :typoscript:`USER_INT`
 dynamically. Calling :php:`convertToUserIntObject()` marks the current object as
-:typoscript:`USER_INT`; TYPO3 Core then substitutes it with a freshly, non-cached rendered
+:typoscript:`USER_INT`; TYPO3 Core then substitutes it with a freshly rendered, non-cached
 version of the same plugin in a later rendering pass, so the rest of the page can still be
 cached.
 
@@ -285,7 +285,7 @@ cached.
     :language: typoscript
     :caption: Configuration/TypoScript/setup.typoscript
 
-This example PHP code executes the dynamic transition from :typoscript:`USER` to :typoscript:`USER_INT`.
+This PHP class performs the dynamic transition from :typoscript:`USER` to :typoscript:`USER_INT`.
 
 ..  literalinclude:: _ConvertUserToUserInt.php
     :language: php

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -272,12 +272,13 @@ via TypoScript:
 Example 6: Converting a custom (non-Extbase) USER plugin dynamically into a USER_INT
 ------------------------------------------------------------------------------------
 
-An extension plugin can be defined as USER or USER_INT content object (cObject). A big extension will have multiple
-display modes. Some of the display modes show views which should be stored in a cache (USER) and others show
-personal data and must never be cached. For this reason it is necessary that the plugin transitions from a
-USER to a USER_INT cObject dynamically. Calling :php:`convertToUserIntObject()` marks the current object as
-USER_INT; TYPO3 Core then substitutes it with a freshly, non-cached rendered version of the same plugin in a
-later rendering pass, so the rest of the page can still be cached.
+An extension plugin can be defined as :typoscript:`USER` or :typoscript:`USER_INT` content
+object (cObject). A big extension will have multiple display modes. Some of the display modes show views
+which should be stored in a cache (:typoscript:`USER`) and others show personal data and must never be
+cached. For this reason it is necessary that the plugin transitions from a :typoscript:`USER` to a
+:typoscript:`USER_INT` cObject dynamically. Calling :php:`convertToUserIntObject()` marks the current object
+as :typoscript:`USER_INT`; TYPO3 Core then substitutes it with a freshly, non-cached rendered version of the
+same plugin in a later rendering pass, so the rest of the page can still be cached.
 
 ..  code-block:: typoscript
     :caption: Configuration/TypoScript/setup.typoscript
@@ -294,7 +295,7 @@ later rendering pass, so the rest of the page can still be cached.
         }
     }
 
-This example PHP code executes the dynamic transition from USER to USER_INT.
+This example PHP code executes the dynamic transition from :typoscript:`USER` to :typoscript:`USER_INT`.
 
 ..  code-block:: php
     :caption: Classes/UserFunc/PluginRenderer.php

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -302,6 +302,7 @@ This example PHP code executes the dynamic transition from USER to USER_INT.
     namespace MyVendor\MyExtension\UserFunc;
     
     use Psr\Http\Message\ServerRequestInterface;
+    use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
     use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
     
     class PluginRenderer
@@ -315,6 +316,7 @@ This example PHP code executes the dynamic transition from USER to USER_INT.
          * @param ServerRequestInterface $request The modern PSR-7 server request object
          * @return string The rendered HTML output
          */
+        #[AsAllowedCallable]
         public function renderPlugin(string $content, array $conf, ServerRequestInterface $request): string
         {
             // TYPO3 v13/v14 Style: Extract the ContentObjectRenderer from the request attributes

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -273,11 +273,11 @@ Example 6: Converting a custom (non-Extbase) USER plugin dynamically into a USER
 ------------------------------------------------------------------------------------
 
 An extension plugin can be defined as USER or USER_INT content object (cObject). A big extension will have multiple
-display modes. Some of the display modes show views which should be stored in a cache (USER) ond other show 
-personal data and must never be cached. For this reason it is necessary that the plugin transitions from a 
-USER to a USER_INT cObject dynamically. The code procedure exits immediately if a display mode must be a USER_INT. 
-TYPO3 Core then restarts the same plugin execution immediately again as a USER_INT cObject. It must be avoided
-to clear the cache of the whole TYPO3 page.
+display modes. Some of the display modes show views which should be stored in a cache (USER) and others show
+personal data and must never be cached. For this reason it is necessary that the plugin transitions from a
+USER to a USER_INT cObject dynamically. Calling :php:`convertToUserIntObject()` marks the current object as
+USER_INT; TYPO3 Core then substitutes it with a freshly, non-cached rendered version of the same plugin in a
+later rendering pass, so the rest of the page can still be cached.
 
 ..  code-block:: typoscript
     :caption: Configuration/TypoScript/setup.typoscript
@@ -300,17 +300,18 @@ This example PHP code executes the dynamic transition from USER to USER_INT.
     :caption: Classes/UserFunc/PluginRenderer.php
 
     namespace MyVendor\MyExtension\UserFunc;
-    
+
     use Psr\Http\Message\ServerRequestInterface;
     use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
+    use TYPO3\CMS\Core\Utility\GeneralUtility;
     use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
-    
+
     class PluginRenderer
     {
         /**
          * Main entry point called by TypoScript.
          * TYPO3 v13/v14 automatically passes the ServerRequestInterface as the third argument.
-         * 
+         *
          * @param string $content Empty string from TypoScript pipeline
          * @param array $conf TypoScript configuration array passed to this object
          * @param ServerRequestInterface $request The modern PSR-7 server request object
@@ -322,23 +323,23 @@ This example PHP code executes the dynamic transition from USER to USER_INT.
             // TYPO3 v13/v14 Style: Extract the ContentObjectRenderer from the request attributes
             /** @var ContentObjectRenderer $cObj */
             $cObj = $request->getAttribute('currentContentObject');
-    
-            // Example: Simulating selected modes (usually fetched from request or TypoScript configuration)
-            $activeModes = ['list_view', 'live_search']; 
-    
+
+            // Read the active modes from the "settings.activeModes" TypoScript property
+            $activeModes = GeneralUtility::trimExplode(',', $conf['settings.']['activeModes'] ?? '', true);
+
             // Call the check and transform cache logic using the extracted cObj
             if ($cObj instanceof ContentObjectRenderer) {
                 $this->checkAndTransformCache($cObj, $activeModes);
             }
-    
+
             // Render your custom HTML without Extbase overhead
             if (in_array('live_search', $activeModes, true)) {
                 return '<div>Live Search Result (Rendered live via USER_INT conversion)</div>';
             }
-    
+
             return '<div>Standard List View (Cached via USER)</div>';
         }
-    
+
         /**
          * Internal cache-handling method matching your requested logic
          */
@@ -346,21 +347,26 @@ This example PHP code executes the dynamic transition from USER to USER_INT.
         {
             // Define modes that strictly require real-time processing (disables caching)
             $noCacheCodes = ['cart_view', 'checkout', 'user_profile_edit', 'live_search'];
-            
+
+            // Nothing to do if this call is already the non-cached USER_INT re-render
+            if ($cObj->getUserObjectType() !== ContentObjectRenderer::OBJECTTYPE_USER) {
+                return false;
+            }
+
             $wasConverted = false;
-    
+
             // Loop through all active modes of the current plugin instance
             foreach ($selectedModes as $currentCode) {
                 if (in_array($currentCode, $noCacheCodes, true)) {
-                    
+
                     // TYPO3 CORE API: Dynamically upgrades the USER object to a non-cached USER_INT object
                     $cObj->convertToUserIntObject();
-                    
+
                     $wasConverted = true;
                     break; // Stop loop immediately since caching is already disabled for this request
                 }
             }
-    
+
             return $wasConverted;
         }
     }

--- a/Documentation/ContentObjects/UserAndUserInt/_ConvertUserToUserInt.php
+++ b/Documentation/ContentObjects/UserAndUserInt/_ConvertUserToUserInt.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyVendor\MyExtension\UserFunc;
+
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+
+final class PluginRenderer
+{
+    /**
+     * @param string $content Empty string from the TypoScript pipeline
+     * @param array $conf TypoScript configuration array passed to this object
+     * @param ServerRequestInterface $request The PSR-7 server request object
+     */
+    #[AsAllowedCallable]
+    public function renderPlugin(string $content, array $conf, ServerRequestInterface $request): string
+    {
+        /** @var ContentObjectRenderer $cObj */
+        $cObj = $request->getAttribute('currentContentObject');
+        $showLiveSearch = (bool)($conf['settings.']['showLiveSearch'] ?? false);
+
+        if (!$showLiveSearch) {
+            return '<div>Standard list view (cached)</div>';
+        }
+
+        // Live search results are personal and must never be cached: promote this
+        // cObject to USER_INT, unless this call is already the non-cached re-render.
+        if ($cObj->getUserObjectType() === ContentObjectRenderer::OBJECTTYPE_USER) {
+            $cObj->convertToUserIntObject();
+        }
+
+        return '<div>Live search result</div>';
+    }
+}

--- a/Documentation/ContentObjects/UserAndUserInt/_ConvertUserToUserInt.typoscript
+++ b/Documentation/ContentObjects/UserAndUserInt/_ConvertUserToUserInt.typoscript
@@ -1,0 +1,11 @@
+# Define the custom content element / plugin as a standard cached USER object
+tt_content.my_custom_plugin = USER
+tt_content.my_custom_plugin {
+    # Route the request to our PSR-11 compliant container service class and method
+    userFunc = MyVendor\MyExtension\UserFunc\PluginRenderer->renderPlugin
+
+    # Personalized output (for example a live search) must never be cached
+    settings {
+        showLiveSearch = 1
+    }
+}


### PR DESCRIPTION
Added example of converting a USER plugin to USER_INT dynamically in TYPO3. This is crucial information  for big extensions still missing at TYPO3 documentation.