### PR TITLE
[Backport 13.4] adjust headlines preceeding confval blocks

### DIFF
--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -37,6 +37,9 @@ Properties
 
 ..  _cobj-case-array-of-cObjects:
 
+array of cObjects
+-----------------
+
 ..  confval:: array of cObjects
     :name: case-array
     :type: :ref:`cObject <data-type-cobject>`
@@ -48,14 +51,19 @@ Properties
 
 ..  _cobj-case-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: case-cache
     :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
-
 ..  _cobj-case-default:
+
+default
+-------
 
 ..  confval:: default
     :name: case-default
@@ -66,8 +74,10 @@ Properties
     default cObject is defined, an empty string will be returned for
     the default case.
 
-
 ..  _cobj-case-if:
+
+if
+--
 
 ..  confval:: if
     :name: case-if
@@ -75,8 +85,10 @@ Properties
 
     If :ref:`if <if>` returns false, nothing is returned.
 
-
 ..  _cobj-case-key:
+
+key
+---
 
 ..  confval:: key
     :name: case-key
@@ -95,8 +107,10 @@ Properties
     dynamic value from some specific source, typically a field of the
     current record. See the :ref:`example below <cobj-case-examples>`.
 
-
 ..  _cobj-case-setCurrent:
+
+setCurrent
+----------
 
 ..  confval:: setCurrent
     :name: case-setCurrent
@@ -104,8 +118,10 @@ Properties
 
     Sets the "current" value.
 
-
 ..  _cobj-case-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: case-stdWrap

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -39,6 +39,9 @@ Properties
 
 ..  _cobj-coa-index:
 
+1,2,3,4...
+----------
+
 ..  confval:: 1,2,3,4...
     :name: coa-array
     :type: :ref:`cObject <data-type-cobject>`
@@ -46,8 +49,10 @@ Properties
     Numbered properties to define the different cObjects, which should be
     rendered.
 
-
 ..  _cobj-coa-cache:
+
+cache
+-----
 
 ..  confval:: cache
     :name: coa-cache
@@ -55,8 +60,10 @@ Properties
 
     See :ref:`cache function description <cache>` for details.
 
-
 ..  _cobj-coa-if:
+
+if
+--
 
 ..  confval:: if
     :name: coa-if
@@ -64,8 +71,10 @@ Properties
 
     If `if` returns false, the COA is **not** rendered.
 
-
 ..  _cobj-coa-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: coa-stdWrap
@@ -73,8 +82,10 @@ Properties
 
     Executed on all rendered cObjects after property :ref:`cobj-coa-wrap`.
 
-
 ..  _cobj-coa-wrap:
+
+wrap
+----
 
 ..  confval:: wrap
     :name: coa-wrap

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -35,14 +35,19 @@ Properties
 
 ..  _cobj-content-if:
 
+if
+--
+
 ..  confval:: if
     :name: content-if
     :type: :ref:`->if <if>`
 
     If "if" returns false, the content is not generated.
 
-
 ..  _cobj-content-select:
+
+select
+------
 
 ..  confval:: select
     :name: content-select
@@ -51,8 +56,10 @@ Properties
     The SQL-statement, a :sql:`SELECT` query, is set here,
     including automatic visibility control.
 
-
 ..  _cobj-content-table:
+
+table
+-----
 
 ..  confval:: table
     :name: content-table
@@ -63,8 +70,10 @@ Properties
 
     In standard configuration this will be :sql:`tt_content`.
 
-
 .. _cobj-content-renderObj:
+
+renderObj
+---------
 
 ..  confval:: renderObj
     :name: content-renderObj
@@ -81,8 +90,10 @@ Properties
 
     See the notes on the example below.
 
-
 ..  _cobj-content-slide:
+
+slide
+-----
 
 ..  confval:: slide
     :name: content-slide
@@ -106,6 +117,9 @@ Properties
 
 ..  _cobj-content-slide-collect:
 
+slide.collect
+-------------
+
 ..  confval:: slide.collect
     :name: content-slide-collect
     :type: :ref:`data-type-integer` / :ref:`stdWrap`
@@ -115,8 +129,10 @@ Properties
     value to the amount of levels to collect on, or use :typoscript:`-1`
     to collect up to the site root.
 
-
 ..  _cobj-content-slide-collectFuzzy:
+
+slide.collectFuzzy
+------------------
 
 ..  confval:: slide.collectFuzzy
     :name: content-slide-collectFuzzy
@@ -126,8 +142,10 @@ Properties
     elements have been found for the specified depth in collect mode, traverse
     further until at least one match has occurred.
 
-
 ..  _cobj-content-slide-collectReverse:
+
+slide.collectReverse
+--------------------
 
 ..  confval:: slide.collectReverse
     :name: content-slide-collectReverse
@@ -138,6 +156,9 @@ Properties
 
 ..  _cobj-content-wrap:
 
+wrap
+----
+
 ..  confval:: wrap
     :name: content-wrap
     :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
@@ -146,14 +167,19 @@ Properties
 
 ..  _cobj-content-stdWrap:
 
+stdWrap
+-------
+
 ..  confval:: stdWrap
     :name: content-stdWrap
     :type: :ref:`stdWrap`
 
     Apply `stdWrap` functionality.
 
-
 ..  _cobj-content-cache:
+
+cache
+-----
 
 ..  confval:: cache
     :name: content-cache

--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -24,14 +24,19 @@ Properties
 
 ..  _cobj-extbaseplugin-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: extbaseplugin-cache
     :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
-
 ..  _cobj-extbaseplugin-extensionName:
+
+extensionName
+-------------
 
 ..  confval:: extensionName
     :name: extbaseplugin-extensionName
@@ -39,8 +44,10 @@ Properties
 
     The :ref:`extension name <t3coreapi:extension-naming-extensionName>`.
 
-
 ..  _cobj-extbaseplugin-pluginName:
+
+pluginName
+----------
 
 ..  confval:: pluginName
     :name: extbaseplugin-pluginName

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -25,14 +25,19 @@ Properties
 
 ..  _cobj-files-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: files-cache
     :type: :ref:`cache <cache>`
 
     See :ref:`cache function description <cache>` for details.
 
-
 .. _cobj-files-files:
+
+files
+-----
 
 ..  confval:: files
     :name: files-files
@@ -48,8 +53,10 @@ Properties
         page.10 = FILES
         page.10.files = 12,15,16
 
-
 .. _cobj-files-references:
+
+references
+----------
 
 ..  confval:: references
     :name: files-references
@@ -93,8 +100,10 @@ Properties
 
     This will fetch all items related to the page.media field.
 
-
 .. _cobj-files-collections:
+
+collections
+-----------
 
 ..  confval:: collections
     :name: files-collections
@@ -103,8 +112,10 @@ Properties
     Comma-separated list of :sql:`sys_file_collection` UIDs, which
     are loaded into the :typoscript:`FILES` object.
 
-
 .. _cobj-files-folders:
+
+folders
+-------
 
 ..  confval:: folders
     :name: files-folders
@@ -146,8 +157,10 @@ Properties
            }
         }
 
-
 .. _cobj-files-sorting:
+
+sorting
+-------
 
 ..  confval:: sorting
     :name: files-sorting
@@ -155,8 +168,10 @@ Properties
 
     Name of the field, which should be used to sort the files.
 
-
 .. _cobj-files-sorting-direction:
+
+sorting.direction
+-----------------
 
 ..  confval:: sorting.direction
     :name: files-sorting-direction
@@ -169,6 +184,9 @@ Properties
 
 .. _cobj-files-begin:
 
+begin
+-----
+
 ..  confval:: begin
     :name: files-begin
     :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -176,8 +194,10 @@ Properties
     The first item to return. If not set (default), items beginning
     with the first one are returned.
 
-
 .. _cobj-files-maxItems:
+
+maxItems
+--------
 
 ..  confval:: maxItems
     :name: files-maxItems
@@ -188,8 +208,10 @@ Properties
     together exceed the number of available items, no items beyond the
     last available item will be returned.
 
-
 .. _cobj-files-renderObj:
+
+renderObj
+---------
 
 ..  confval:: renderObj
     :name: files-renderObj
@@ -213,8 +235,10 @@ Properties
 
     This returns the size of the current file.
 
-
 .. _cobj-files-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: files-stdWrap
@@ -224,10 +248,10 @@ Properties
 .. index:: FILES; references
 .. _cobj-files-references-sub:
 
+.. _cobj-files-references-table:
+
 Special key: "references"
 =========================
-
-.. _cobj-files-references-table:
 
 ..  confval:: references.table
     :name: files-references-table
@@ -235,8 +259,10 @@ Special key: "references"
 
     The table name of the table having the file field.
 
-
 .. _cobj-files-references-uid:
+
+references.uid
+--------------
 
 ..  confval:: references.uid
     :name: files-references-uid
@@ -244,8 +270,10 @@ Special key: "references"
 
     The UID of the record from which to fetch the referenced files.
 
-
 .. _cobj-files-references-fieldName:
+
+references.fieldName
+--------------------
 
 ..  confval:: references.fieldName
     :name: files-references-fieldName
@@ -257,7 +285,6 @@ Special key: "references"
 
 Examples
 =========
-
 
 .. _cobj-files-examples-files:
 

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -78,6 +78,9 @@ Properties
 
 ..  _cobj-_fluidtemplate-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: _fluidtemplate-cache
     :type: :ref:`cache <cache>`
@@ -85,6 +88,9 @@ Properties
     See :ref:`cache function description <cache>` for details.
 
 ..  _fluidtemplate-dataProcessing:
+
+dataProcessing
+--------------
 
 ..  confval:: dataProcessing
     :name: fluidtemplate-dataProcessing
@@ -101,6 +107,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-extbase-controlleractionname:
 
+extbase.controllerActionName
+----------------------------
+
 ..  confval:: extbase.controllerActionName
     :name: fluidtemplate-extbase-controlleractionname
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
@@ -108,6 +117,9 @@ Properties
     Sets the name of the action.
 
 ..  _cobj-fluidtemplate-properties-extbase-controllerextensionname:
+
+extbase.controllerExtensionName
+-------------------------------
 
 ..  confval:: extbase.controllerExtensionName
     :name: fluidtemplate-extbase-controllerextensionname
@@ -117,6 +129,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-extbase-controllername:
 
+extbase.controllerName
+----------------------
+
 ..  confval:: extbase.controllerName
     :name: fluidtemplate-extbase-controllername
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
@@ -125,6 +140,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-extbase-pluginname:
 
+extbase.pluginName
+------------------
+
 ..  confval:: extbase.pluginName
     :name: fluidtemplate-extbase-pluginname
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
@@ -132,6 +150,9 @@ Properties
     Sets variables for initializing extbase.
 
 ..  _cobj-fluidtemplate-properties-file:
+
+file
+----
 
 ..  confval:: file
     :name: fluidtemplate-file
@@ -147,6 +168,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-format:
 
+format
+------
+
 ..  confval:: format
     :name: fluidtemplate-format
     :type: keyword / :ref:`stdWrap <stdwrap>`
@@ -156,6 +180,9 @@ Properties
     like "html", "xml", "png", "json" or even "rss.xml" or something similar.
 
 ..  _cobj-fluidtemplate-properties-layoutrootpath:
+
+layoutRootPath
+--------------
 
 ..  confval:: layoutRootPath
     :name: fluidtemplate-layoutrootpath
@@ -172,6 +199,9 @@ Properties
         sitepackage.
 
 ..  _cobj-fluidtemplate-properties-layoutrootpaths:
+
+layoutRootPaths
+---------------
 
 ..  confval:: layoutRootPaths
     :name: fluidtemplate-layoutrootpaths
@@ -200,6 +230,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-partialrootpath:
 
+partialRootPath
+---------------
+
 ..  confval:: partialRootPath
     :name: fluidtemplate-partialrootpath
     :type: :ref:`data-type-path` / :ref:`stdWrap <stdwrap>`
@@ -215,6 +248,9 @@ Properties
         by the sitepackage.
 
 ..  _cobj-fluidtemplate-properties-partialrootpaths:
+
+partialRootPaths
+----------------
 
 ..  confval:: partialRootPaths
     :name: fluidtemplate-partialrootpaths
@@ -234,6 +270,9 @@ Properties
     for more details.
 
 ..  _cobj-fluidtemplate-properties-settings:
+
+settings
+--------
 
 ..  confval:: settings
     :name: fluidtemplate-settings
@@ -258,6 +297,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-stdwrap:
 
+stdWrap
+-------
+
 ..  confval:: stdWrap
     :name: fluidtemplate-stdwrap
     :type: :ref:`->stdWrap <stdwrap>`
@@ -265,6 +307,9 @@ Properties
     Provides the usual stdWrap functionality.
 
 ..  _cobj-fluidtemplate-properties-template:
+
+template
+--------
 
 ..  confval:: template
     :name: fluidtemplate-template
@@ -275,6 +320,9 @@ Properties
     takes precedence.
 
 ..  _cobj-fluidtemplate-properties-templatename:
+
+templateName
+------------
 
 ..  confval:: templateName
     :name: fluidtemplate-templatename
@@ -297,6 +345,9 @@ Properties
 
 ..  _cobj-fluidtemplate-properties-templaterootpath:
 
+templateRootPath
+----------------
+
 ..  confval:: templateRootPath
     :name: fluidtemplate-templaterootpath
     :type: file path /:ref:`stdWrap <stdwrap>`
@@ -312,6 +363,9 @@ Properties
         by the sitepackage.
 
 ..  _cobj-fluidtemplate-properties-templaterootpaths:
+
+templateRootPaths
+-----------------
 
 ..  confval:: templateRootPaths
     :name: fluidtemplate-templaterootpaths
@@ -337,6 +391,9 @@ Properties
         :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
 
 ..  _cobj-fluidtemplate-properties-variables:
+
+variables
+---------
 
 ..  confval:: variables
     :name: fluidtemplate-variables

--- a/Documentation/ContentObjects/Hmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Index.rst
@@ -41,6 +41,8 @@ Properties
 
     ..  _hmenu-number:
 
+    ..  rubric:: 1, 2, 3, ...
+
     ..  confval:: 1, 2, 3, ...
         :name: hmenu-array
         :type: :ref:`menu object <data-type-menuobj>`
@@ -60,6 +62,8 @@ Properties
 
     ..  _hmenu-cache-period:
 
+    ..  rubric:: cache_period
+
     ..  confval:: cache_period
         :name: hmenu-cache-period
         :type: :ref:`data-type-integer`
@@ -75,6 +79,8 @@ Properties
 
     ..  _hmenu-cache:
 
+    ..  rubric:: cache
+
     ..  confval:: cache
         :name: hmenu-cache
         :type: :ref:`cache <cache>`
@@ -82,6 +88,8 @@ Properties
         See :ref:`cache function description <cache>` for details.
 
     ..  _hmenu-entrylevel:
+
+    ..  rubric:: entryLevel
 
     ..  confval:: entryLevel
         :name: hmenu-entryLevel
@@ -92,6 +100,8 @@ Properties
 
     ..  _hmenu-special:
     ..  _hmenu-special-property:
+
+    ..  rubric:: special
 
     ..  confval:: special
         :name: hmenu-special
@@ -104,6 +114,8 @@ Properties
 
     ..  _hmenu-special-value:
 
+    ..  rubric:: special.value
+
     ..  confval:: special.value
         :name: hmenu-special-value
         :type: *list of page-uid's* / :ref:`stdWrap <stdwrap>`
@@ -113,6 +125,8 @@ Properties
         section about the :ref:`.special property <hmenu-special-property>`!
 
     ..  _hmenu-minitems:
+
+    ..  rubric:: minItems
 
     ..  confval:: minItems
         :name: hmenu-minItems
@@ -128,6 +142,8 @@ Properties
 
     ..  _hmenu-maxitems:
 
+    ..  rubric:: maxItems
+
     ..  confval:: maxItems
         :name: hmenu-maxItems
         :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -140,6 +156,8 @@ Properties
 
     ..  _hmenu-begin:
 
+    ..  rubric:: begin
+
     ..  confval:: begin
         :name: hmenu-begin
         :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
@@ -151,6 +169,8 @@ Properties
 
     ..  _hmenu-excludeuidlist:
 
+    ..  rubric:: excludeUidList
+
     ..  confval:: excludeUidList
         :name: hmenu-excludeUidList
         :type: list of :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -158,6 +178,8 @@ Properties
         See :confval:`MenuProcessor-excludeUidList`.
 
     ..  _hmenu-excludedoktypes:
+
+    ..  rubric:: excludeDoktypes
 
     ..  confval:: excludeDoktypes
         :name: hmenu-excludeDoktypes
@@ -168,6 +190,8 @@ Properties
 
     .. _hmenu-includenotinmenu:
 
+    ..  rubric:: includeNotInMenu
+
     ..  confval:: includeNotInMenu
         :name: hmenu-includeNotInMenu
         :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
@@ -175,6 +199,8 @@ Properties
         See :confval:`MenuProcessor-includeNotInMenu`
 
     .. _hmenu-alwaysactivepidlist:
+
+    ..  rubric:: alwaysActivePIDlist
 
     ..  confval:: alwaysActivePIDlist
         :name: hmenu-alwaysActivePIDlist
@@ -184,6 +210,8 @@ Properties
 
     ..  _hmenu-protectlvar:
 
+    ..  rubric:: protectLvar
+
     ..  confval:: protectLvar
         :name: hmenu-protectlvar
         :type: :ref:`data-type-boolean` / keyword
@@ -192,12 +220,17 @@ Properties
 
     ..  _hmenu-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: hmenu-if
         :type: :ref:`->if <if>`
 
         If "if" returns false, the menu is not generated.
+
     ..  _hmenu-wrap:
+
+    ..  rubric:: wrap
 
     ..  confval:: wrap
         :name: hmenu-wrap
@@ -206,6 +239,8 @@ Properties
         Wrap for the HMENU.
 
     ..  _hmenu-stdwrap:
+
+    ..  rubric:: stdWrap
 
     ..  confval:: stdWrap
         :name: hmenu-stdWrap

--- a/Documentation/ContentObjects/Hmenu/Tmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Tmenu/Index.rst
@@ -59,6 +59,8 @@ The following Item states are listed from the least to the highest priority:
     :type:
     :Default:
 
+    ..  rubric:: NO
+
     ..  confval:: NO
         :name: tmenu-common-property-no
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
@@ -68,6 +70,8 @@ The following Item states are listed from the least to the highest priority:
         The default "Normal" state rendering of Item. This is required for all
         menus.
 
+    ..  rubric:: IFSUB
+
     ..  confval:: IFSUB
         :name: tmenu-common-property-ifsub
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
@@ -75,12 +79,16 @@ The following Item states are listed from the least to the highest priority:
 
         Enable/Configuration for menu items which has subpages.
 
+    ..  rubric:: ACT
+
     ..  confval:: ACT
         :name: tmenu-common-property-act
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
         :Default: 0
 
         Enable/Configuration for menu items which are found in the rootLine.
+
+    ..  rubric:: ACTIFSUB
 
     ..  confval:: ACTIFSUB
         :name: tmenu-common-property-actifsub
@@ -90,12 +98,16 @@ The following Item states are listed from the least to the highest priority:
         Enable/Configuration for menu items which are found in the rootLine
         and have subpages.
 
+    ..  rubric:: CUR
+
     ..  confval:: CUR
         :name: tmenu-common-property-cur
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
         :Default: 0
 
         Enable/Configuration for a menu item if the item is the current page.
+
+    ..  rubric:: CURIFSUB
 
     ..  confval:: CURIFSUB
         :name: tmenu-common-property-curifsub
@@ -105,6 +117,8 @@ The following Item states are listed from the least to the highest priority:
         Enable/Configuration for a menu item if the item is the current page
         and has subpages.
 
+    ..  rubric:: USR
+
     ..  confval:: USR
         :name: tmenu-common-property-usr
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
@@ -112,6 +126,8 @@ The following Item states are listed from the least to the highest priority:
 
         Enable/Configuration for menu items which are access restricted pages
         that a user has access to.
+
+    ..  rubric:: SPC
 
     ..  confval:: SPC
         :name: tmenu-common-property-spc
@@ -123,6 +139,8 @@ The following Item states are listed from the least to the highest priority:
         Spacers are pages of the doktype "Spacer". These are not viewable
         pages but "placeholders" which can be used to divide menu items.
 
+    ..  rubric:: USERDEF1
+
     ..  confval:: USERDEF1
         :name: tmenu-common-property-userdef1
         :type: :ref:`data-type-boolean` / :ref:`tmenuitem`
@@ -133,6 +151,8 @@ The following Item states are listed from the least to the highest priority:
         You can set the ITEM\_STATE values USERDEF1 and USERDEF2 (+...RO) from
         a script/user function processing the menu item array. See the property
         :confval:`menu-common-properties-itemArrayProcFunc` of the menu objects.
+
+    ..  rubric:: USERDEF2
 
     ..  confval:: USERDEF2
         :name: tmenu-common-property-userdef2
@@ -155,6 +175,8 @@ Properties
     :type:
     :Default:
 
+    ..  rubric:: expAll
+
     ..  confval:: expAll
         :name: menu-common-properties-expAll
         :type: :ref:`data-type-boolean` / :ref:`stdWrap <stdwrap>`
@@ -163,6 +185,8 @@ Properties
         underneath the menu item. This corresponds to a situation where a user
         has clicked a menu item and the menu folds out the next level. This
         can enable that to happen on all items as default.
+
+    ..  rubric:: sectionIndex
 
     ..  confval:: sectionIndex
         :name: menu-common-properties-sectionIndex
@@ -180,6 +204,8 @@ Properties
         This corresponds to the "Menu/Sitemap" content element when "Section
         index" is selected as type.
 
+        ..  rubric:: sectionIndex.type
+
         ..  confval:: sectionIndex.type
             :name: menu-common-properties-sectionIndex-type
             :type: :ref:`data-type-string` ("all" / "header")
@@ -194,7 +220,7 @@ Properties
                 header layout of an element is set to "Hidden" then the
                 page will not appear in the menu.
 
-
+        ..  rubric:: sectionIndex.includeHiddenHeaders
 
         ..  confval:: sectionIndex.includeHiddenHeaders
             :name: menu-common-properties-sectionIndex-includeHiddenHeaders
@@ -204,7 +230,7 @@ Properties
              also elements with a header layout set to "Hidden" will appear
              in the menu.
 
-
+        ..  rubric:: sectionIndex.useColPos
 
         ..  confval:: sectionIndex.useColPos
             :name: menu-common-properties-sectionIndex-useColPos
@@ -223,12 +249,16 @@ Properties
 
                 tt_content.menu.20.3.1.sectionIndex.useColPos = -1
 
+    ..  rubric:: target
+
     ..  confval:: target
         :name: menu-common-properties-target
         :type: string
         :Default: self
 
         Target of the menu links
+
+    ..  rubric:: forceTypeValue
 
     ..  confval:: forceTypeValue
         :name: menu-common-properties-forceTypeValue
@@ -237,6 +267,7 @@ Properties
         If set, the `&type` parameter of the link is forced to this value
         regardless of target.
 
+    ..  rubric:: stdWrap
 
     ..  confval:: stdWrap
         :name: menu-common-properties-stdWrap
@@ -245,11 +276,15 @@ Properties
 
         Wraps the whole block of sub items.
 
+    ..  rubric:: wrap
+
     ..  confval:: wrap
         :name: menu-common-properties-wrap
         :type: :ref:`wrap <data-type-wrap>`
 
         Wraps the whole block of sub items, but only if there were items in the menu!
+
+    ..  rubric:: IProcFunc
 
     ..  confval:: IProcFunc
         :name: menu-common-properties-IProcFunc
@@ -259,6 +294,8 @@ Properties
         returned as well. Subsequent to this function call the menu item is
         compiled by implode()'ing the array $I[parts] in the passed array.
         Thus you may modify this if you need to.
+
+    ..  rubric:: alternativeSortingField
 
     ..  confval:: alternativeSortingField
         :name: menu-common-properties-alternativeSortingField
@@ -274,6 +311,8 @@ Properties
         This property works with normal menus, sectionsIndex menus and
         special-menus of type "directory".
 
+    ..  rubric:: minItems
+
     ..  confval:: minItems
         :name: menu-common-properties-minItems
         :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -284,6 +323,8 @@ Properties
 
         Takes precedence over HMENU property :ref:`hmenu-minitems`.
 
+    ..  rubric:: maxItems
+
     ..  confval:: maxItems
         :name: menu-common-properties-maxItems
         :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -292,11 +333,15 @@ Properties
 
         Takes precedence over HMENU property :ref:`hmenu-maxitems`.
 
+    ..  rubric:: begin
+
     ..  confval:: begin
         :name: menu-common-properties-begin
         :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>` :ref:`+calc <objects-calc>`
 
         The first item in the menu.
+
+    ..  rubric:: debugItemConf
 
     ..  confval:: debugItemConf
         :name: menu-common-properties-debugItemConf
@@ -304,6 +349,8 @@ Properties
 
         Outputs (by the :php:`debug()` function) the configuration arrays for each
         menu item. Useful to debug :ref:`optionsplit` things and such...
+
+    ..  rubric:: overrideId
 
     ..  confval:: overrideId
         :name: menu-common-properties-overrideId
@@ -316,6 +363,8 @@ Properties
         else, perhaps a shared menu, but wants the menu items to call the same
         page, which then generates a proper output based on the real\_uid.
 
+    ..  rubric:: addParams
+
     ..  confval:: addParams
         :name: menu-common-properties-addParams
         :type: :ref:`data-type-string`
@@ -323,6 +372,8 @@ Properties
         Additional parameter for the menu links.
 
         Must be rawurlencoded.
+
+    ..  rubric:: showAccessRestrictedPages
 
     ..  confval:: showAccessRestrictedPages
         :name: menu-common-properties-showaccessrestrictedpages
@@ -351,12 +402,16 @@ Properties
 
         **.ATagParams**: Add custom attributes to the anchor tag.
 
+    ..  rubric:: additionalWhere
+
     ..  confval:: additionalWhere
         :name: menu-common-properties-additionalWhere
         :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
         Adds an additional part to the WHERE clause for this menu.
         Make sure to start the part with "AND "!
+
+    ..  rubric:: itemArrayProcFunc
 
     ..  confval:: itemArrayProcFunc
         :name: menu-common-properties-itemArrayProcFunc
@@ -379,6 +434,8 @@ Properties
 
         You can override element states like SPC, IFSUB, ACT, CUR or USR by
         setting the key ITEM\_STATE in the page records.
+
+    ..  rubric:: submenuObjSuffixes
 
     ..  confval:: submenuObjSuffixes
         :name: menu-common-properties-submenuObjSuffixes

--- a/Documentation/ContentObjects/Hmenu/Tmenu/Tmenuitem.rst
+++ b/Documentation/ContentObjects/Hmenu/Tmenu/Tmenuitem.rst
@@ -31,14 +31,19 @@ Properties
 
 ..  _tmenuitem-allWrap:
 
+allWrap
+-------
+
 ..  confval:: allWrap
     :name: tmenuitem-allWrap
     :type: :ref:`data-type-wrap` / :ref:`stdWrap <stdwrap>`
 
     Wraps the whole item.
 
-
 ..  _tmenuitem-wrapItemAndSub:
+
+wrapItemAndSub
+--------------
 
 ..  confval:: wrapItemAndSub
     :name: tmenuitem-wrapItemAndSub
@@ -46,8 +51,10 @@ Properties
 
     Wraps the whole item and any submenu concatenated to it.
 
-
 ..  _tmenuitem-subst-elementUid:
+
+subst_elementUid
+----------------
 
 ..  confval:: subst_elementUid
     :name: tmenuitem-subst-elementUid
@@ -61,15 +68,19 @@ Properties
     This is useful, if you want to insert an identification code in the
     HTML in order to manipulate properties with JavaScript.
 
-
 ..  _tmenuitem-before:
+
+before
+------
 
 ..  confval:: before
     :name: tmenuitem-before
     :type: HTML / :ref:`stdWrap <stdwrap>`
 
-
 ..  _tmenuitem-beforeWrap:
+
+beforeWrap
+----------
 
 ..  confval:: beforeWrap
     :name: tmenuitem-beforeWrap
@@ -77,15 +88,19 @@ Properties
 
     Wrap around the :ref:`.before <tmenuitem-before>` code.
 
-
 ..  _tmenuitem-after:
+
+after
+-----
 
 ..  confval:: after
     :name: tmenuitem-after
     :type: HTML / :ref:`stdWrap <stdwrap>`
 
-
 ..  _tmenuitem-afterWrap:
+
+afterWrap
+---------
 
 ..  confval:: afterWrap
     :name: tmenuitem-afterWrap
@@ -93,15 +108,19 @@ Properties
 
     Wrap around the :ref:`.after <tmenuitem-after>` code.
 
-
 ..  _tmenuitem-linkWrap:
+
+linkWrap
+--------
 
 ..  confval:: linkWrap
     :name: tmenuitem-linkWrap
     :type: :ref:`data-type-wrap`
 
-
 ..  _tmenuitem-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: tmenuitem-stdWrap
@@ -109,8 +128,10 @@ Properties
 
     stdWrap to the link text.
 
-
 ..  _tmenuitem-ATagBeforeWrap:
+
+ATagBeforeWrap
+--------------
 
 ..  confval:: ATagBeforeWrap
     :name: tmenuitem-ATagBeforeWrap
@@ -120,8 +141,10 @@ Properties
     If set, the link is first wrapped with :ref:`*.linkWrap* <tmenuitem-linkWrap>`
     and then the :html:`<a>` tag.
 
-
 ..  _tmenuitem-ATagParams:
+
+ATagParams
+----------
 
 ..  confval:: ATagParams
     :name: tmenuitem-ATagParams
@@ -129,8 +152,10 @@ Properties
 
     Additional parameters
 
-
 ..  _tmenuitem-ATagTitle:
+
+ATagTitle
+---------
 
 ..  confval:: ATagTitle
     :name: tmenuitem-ATagTitle
@@ -139,8 +164,10 @@ Properties
     Allows you to specify the "title" attribute of the :html:`<a>` tag around
     the menu item.
 
-
 ..  _tmenuitem-additionalParams:
+
+additionalParams
+----------------
 
 ..  confval:: additionalParams
     :name: tmenuitem-additionalParams
@@ -151,8 +178,10 @@ Properties
 
     For details, see :ref:`typolink->additionalParams <typolink-additionalParams>`.
 
-
 ..  _tmenuitem-doNotLinkIt:
+
+doNotLinkIt
+-----------
 
 ..  confval:: doNotLinkIt
     :name: tmenuitem-doNotLinkIt
@@ -161,8 +190,10 @@ Properties
 
     If set, the link texts are not linked at all.
 
-
 ..  _tmenuitem-doNotShowLink:
+
+doNotShowLink
+-------------
 
 ..  confval:: doNotShowLink
     :name: tmenuitem-doNotShowLink
@@ -171,8 +202,10 @@ Properties
 
     If set, the text will not be shown at all (smart with spacers).
 
-
 ..  _tmenuitem-stdWrap2:
+
+stdWrap2
+--------
 
 ..  confval:: stdWrap2
     :name: tmenuitem-stdWrap2
@@ -182,8 +215,10 @@ Properties
     stdWrap to the total link text and :html:`<a>` tag. (Notice that the plain
     default value passed to the stdWrap function is "\|".)
 
-
 ..  _tmenuitem-altTarget:
+
+altTarget
+---------
 
 ..  confval:: altTarget
     :name: tmenuitem-altTarget
@@ -192,8 +227,10 @@ Properties
     Alternative target overriding the target property of the
     ref:`TMENU <tmenu>`, if set.
 
-
 ..  _tmenuitem-allStdWrap:
+
+allStdWrap
+----------
 
 ..  confval:: allStdWrap
     :name: tmenuitem-allStdWrap

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -37,6 +37,9 @@ Properties
 
 ..  _cobj-image-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: image-cache
     :type: :ref:`cache <cache>`
@@ -45,21 +48,28 @@ Properties
 
 ..  _cobj-image-if:
 
+if
+--
+
 ..  confval:: if
     :name: image-if
     :type: :ref:`->if <if>`
 
     If "if" returns false, the image is not shown!
 
-
 ..  _cobj-image-file:
+
+file
+----
 
 ..  confval:: file
     :name: image-file
     :type: :ref:`->imgResource <imgresource>`
 
-
 ..  _cobj-image-params:
+
+params
+------
 
 ..  confval:: params
     :name: image-params
@@ -67,8 +77,10 @@ Properties
 
     HTML <IMG> parameters
 
-
 ..  _cobj-image-altText:
+
+altText
+-------
 
 ..  confval:: altText
     :name: image-altText
@@ -78,12 +90,17 @@ Properties
 
 ..  _cobj-image-titleText:
 
+titleText
+---------
+
 ..  confval:: titleText
     :name: image-titleText
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
-
 ..  _cobj-image-emptyTitleHandling:
+
+emptyTitleHandling
+------------------
 
 ..  confval:: emptyTitleHandling
     :name: image-emptyTitleHandling
@@ -94,7 +111,11 @@ Properties
     "useAlt" to use the alt attribute instead.
 
 .. index:: IMAGE; layoutKey
+
 .. _cobj-image-layoutkey:
+
+layoutKey
+---------
 
 ..  confval:: layoutKey
     :name: image-layoutKey
@@ -148,7 +169,11 @@ Properties
                  data-###DATAKEY###="###SRC###" ###PARAMS### ###ALTPARAMS######SELFCLOSINGTAGSLASH###>
 
 .. index:: IMAGE; layout
+
 .. _cobj-image-layout:
+
+layout
+------
 
 ..  confval:: layout
     :name: image-layout
@@ -158,7 +183,11 @@ Properties
 
 
 .. index:: IMAGE; layout.layoutKey
+
 .. _cobj-image-layout-layoutkey:
+
+layout.layoutKey
+----------------
 
 ..  confval:: layout.layoutKey
     :name: image-layout-layoutkey
@@ -178,6 +207,10 @@ Properties
           element = <picture>###SOURCECOLLECTION###<img src="###SRC###" ###PARAMS### ###ALTPARAMS### ###SELFCLOSINGTAGSLASH###></picture>
           source = <source srcset="###SRC###" media="###MEDIAQUERY###" ###SELFCLOSINGTAGSLASH###>
         }
+
+layout.layoutKey.element
+------------------------
+
 
 ..  index:: IMAGE; layout.layoutKey.element
 ..  _cobj-image-layout-layoutkey-element:
@@ -212,6 +245,10 @@ Properties
        definition of the sources is declared inside
        :ref:`layout.layoutKey.source <cobj-image-layout-layoutkey-source>`
 
+layout.layoutKey.source
+-----------------------
+
+
 
 ..  index:: IMAGE; layout.layoutKey.source
 ..  _cobj-image-layout-layoutkey-source:
@@ -243,6 +280,10 @@ Properties
     ###SRCSETCANDIDATE###, ###MEDIAQUERY###, ###DATAKEY### are already defined
     as additional datakeys in the out of the box typoscript. Thus can be
     overwritten by your typoscript.
+
+sourceCollection
+----------------
+
 
 
 ..  index:: IMAGE; sourceCollection
@@ -290,6 +331,10 @@ Properties
           }
         }
 
+sourceCollection.dataKey
+------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey
 ..  _cobj-image-datakey:
@@ -301,6 +346,10 @@ Properties
     Definition of your image size definition depending on your responsive
     layout, breakpoints and display density.
 
+sourceCollection.dataKey.if
+---------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey.if
 ..  _cobj-image-datakey-if:
@@ -311,6 +360,10 @@ Properties
 
     Renders only if the condition is met, this is evaluated before any
     execution of code.
+
+sourceCollection.dataKey.pixelDensity
+-------------------------------------
+
 
 
 ..  index:: IMAGE; sourceCollection.dataKey.pixelDensity
@@ -327,6 +380,10 @@ Properties
     200 the generated image file will have a width of 400 but will be
     treated inside the html code as 200 pixels.
 
+sourceCollection.dataKey.width
+------------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey.width
 ..  _cobj-image-datakey-width:
@@ -338,6 +395,10 @@ Properties
          Defines the width for the html code of the image defined in this
          source collection. For the image file itself the width will be multiplied by
          :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
+
+sourceCollection.dataKey.height
+-------------------------------
+
 
 
 ..  index:: IMAGE; sourceCollection.dataKey.height
@@ -351,6 +412,10 @@ Properties
     source collection. For the image file itself the height will be multiplied by
     :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
 
+sourceCollection.dataKey.maxW
+-----------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey.maxW
 ..  _cobj-image-datakey-maxW:
@@ -362,6 +427,10 @@ Properties
     Defines the maxW for the html code of the image defined in this
     source collection. For the image file itself the maxW will be multiplied by
     :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
+
+sourceCollection.dataKey.maxH
+-----------------------------
+
 
 
 ..  index:: IMAGE; sourceCollection.dataKey.maxH
@@ -375,6 +444,10 @@ Properties
     source collection. For the image file itself the maxH will be multiplied by
     :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
 
+sourceCollection.dataKey.minW
+-----------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey.minW
 ..  _cobj-image-datakey-minW:
@@ -386,6 +459,10 @@ Properties
     Defines the minW for the html code of the image defined in this
     source collection. For the image file itself the minW will be multiplied by
     :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
+
+sourceCollection.dataKey.minH
+-----------------------------
+
 
 
 ..  index:: IMAGE; sourceCollection.dataKey.minH
@@ -399,6 +476,10 @@ Properties
     source collection. For the image file itself the minH will be multiplied by
     :ref:`dataKey.pixelDensity <cobj-image-datakey-pixeldensity>`.
 
+sourceCollection.dataKey.quality
+--------------------------------
+
+
 
 ..  index:: IMAGE; sourceCollection.dataKey.quality
 ..  _cobj-image-datakey-quality:
@@ -408,6 +489,10 @@ Properties
     :type: :ref:`data-type-integer`
 
     Defines the quality of the rendered images on a scale from 1-100.
+
+sourceCollection.dataKey.*
+--------------------------
+
 
 
 ..  index:: IMAGE; sourceCollection.dataKey.*
@@ -421,8 +506,10 @@ Properties
     setting the image size, but will be available as additional markers for
     the image template. See the example mediaquery.
 
-
 ..  _cobj-image-linkWrap:
+
+linkWrap
+--------
 
 ..  confval:: linkWrap
     :name: image-linkWrap
@@ -430,8 +517,10 @@ Properties
 
     (before ".wrap")
 
-
 ..  _cobj-image-imageLinkWrap:
+
+imageLinkWrap
+-------------
 
 ..  confval:: imageLinkWrap
     :name: image-imageLinkWrap
@@ -443,6 +532,9 @@ Properties
 
 ..  _cobj-image-wrap:
 
+wrap
+----
+
 ..  confval:: wrap
     :name: image-wrap
     :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap <stdwrap>`
@@ -450,6 +542,9 @@ Properties
     Wrap for the image tag.
 
 ..  _cobj-image-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: image-stdWrap

--- a/Documentation/ContentObjects/ImgResource/Index.rst
+++ b/Documentation/ContentObjects/ImgResource/Index.rst
@@ -27,6 +27,9 @@ Properties
 
 ..  _cobj-img-resource-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: img-resource-cache
     :type: :ref:`cache <cache>`
@@ -35,12 +38,17 @@ Properties
 
 ..  _cobj-img-resource-file:
 
+file
+----
+
 ..  confval:: file
     :name: img-resource-file
     :type: :ref:`->imgResource <imgresource>`
 
-
 ..  _cobj-img-resource-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: img-resource-stdWrap

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -92,6 +92,8 @@ Additional variables can be defined with property
     :display: table
     :type:
 
+    ..  rubric:: language
+
     ..  confval:: language
         :name: pageview-data-language
         :type: :php:`\TYPO3\CMS\Core\Site\Entity\SiteLanguage`
@@ -100,6 +102,8 @@ Additional variables can be defined with property
         The current :php:`SiteLanguage` object, see also
         :ref:`the SiteLanguage object <t3coreapi:sitehandling-sitelanguage-object>`.
 
+    ..  rubric:: page
+
     ..  confval:: page
         :name: pageview-data-page
         :type: :php:`TYPO3\CMS\Frontend\Page\PageInformation`
@@ -107,6 +111,8 @@ Additional variables can be defined with property
 
         The current `PageInformation` as object. See also
         :ref:`Frontend page information <t3coreapi:typo3-request-attribute-frontend-page-information>`.
+
+    ..  rubric:: settings
 
     ..  confval:: settings
         :name: pageview-data-settings
@@ -117,6 +123,8 @@ Additional variables can be defined with property
         :ref:`constants <typoscript-syntax-constants>` that are set on the current
         page. Settings from the site can be accessed via the :confval:`pageview-data-site` with
         :fluid:`{site.settings}`
+
+    ..  rubric:: site
 
     ..  confval:: site
         :name: pageview-data-site
@@ -184,11 +192,15 @@ Properties
     :display: table
     :type:
 
+    ..  rubric:: cache
+
     ..  confval:: cache
         :name: pageview-cache
         :type: :ref:`cache <cache>`
 
         See :ref:`cache function description <cache>` for details.
+
+    ..  rubric:: dataProcessing.[key]
 
     ..  confval:: dataProcessing.[key]
         :name: pageview-dataProcessing
@@ -202,6 +214,8 @@ Properties
         It is recommended to use the  :ref:`PageContentFetchingProcessor <PageContentFetchingProcessor>`
         to fetch the content elements from the page, respecting the
         :ref:`backend layout <t3coreapi:be-layout>`.
+
+    ..  rubric:: paths.[priority]
 
     ..  confval:: paths.[priority]
         :name: pageview-paths
@@ -222,6 +236,8 @@ Properties
         is resolved automatically.
 
         The paths are evaluated from highest to lowest priority.
+
+    ..  rubric:: variables.[variable_name]
 
     ..  confval:: variables.[variable_name]
         :name: pageview-variables

--- a/Documentation/ContentObjects/Records/Index.rst
+++ b/Documentation/ContentObjects/Records/Index.rst
@@ -37,6 +37,10 @@ Properties
     :display: table
     :type:
 
+source
+------
+
+
 ..  index:: RECORDS; source
 ..  _cobj-records-properties-source:
 
@@ -54,7 +58,11 @@ Properties
 
 
 .. index:: RECORDS; categories
+
 .. _cobj-records-properties-categories:
+
+categories
+----------
 
 ..  confval:: categories
     :name: records-categories
@@ -75,6 +83,9 @@ Properties
 
 ..  _cobj-records-categories-relation:
 
+categories.relation
+-------------------
+
 ..  confval:: categories.relation
     :name: records-categories-relation
 
@@ -84,7 +95,11 @@ Properties
 
 
 .. index:: RECORDS; tables
+
 .. _cobj-records-properties-tables:
+
+tables
+------
 
 ..  confval:: tables
     :name: records-tables
@@ -111,7 +126,11 @@ Properties
 
 
 .. index:: RECORDS; conf
+
 .. _cobj-records-properties-conf:
+
+conf.[*table name*]
+-------------------
 
 ..  confval:: conf.[*table name*]
     :name: records-conf
@@ -126,7 +145,11 @@ Properties
 
 
 .. index:: RECORDS; dontCheckPid
+
 .. _cobj-records-properties-dontcheckpid:
+
+dontCheckPid
+------------
 
 ..  confval:: dontCheckPid
     :name: records-dontCheckPid
@@ -136,8 +159,10 @@ Properties
     Normally a record cannot be selected, if its parent page (pid) is not
     accessible for the website user. This option disables that check.
 
-
 .. _cobj-records-properties-wrap:
+
+wrap
+----
 
 ..  confval:: wrap
     :name: records-wrap
@@ -145,8 +170,10 @@ Properties
 
     Wraps the output. Executed before :ref:`stdWrap <cobj-records-properties-stdwrap>`.
 
-
 .. _cobj-records-properties-stdwrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: records-stdWrap
@@ -154,8 +181,10 @@ Properties
 
     Executed after :ref:`wrap <cobj-records-properties-wrap>`.
 
-
 .. _cobj-records-properties-cache:
+
+cache
+-----
 
 ..  confval:: cache
     :name: records-cache

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -24,6 +24,9 @@ Properties
 
 ..  _cobj-svg-cache:
 
+cache
+-----
+
 ..  confval:: cache
     :name: svg-cache
     :type: :ref:`cache <cache>`
@@ -32,6 +35,9 @@ Properties
 
 ..  _cobj-svg-width:
 
+width
+-----
+
 ..  confval:: width
     :name: svg-width
     :type: :ref:`data-type-integer` / :ref:`stdWrap <stdwrap>`
@@ -39,8 +45,10 @@ Properties
 
     Width of the SVG.
 
-
 ..  _cobj-svg-height:
+
+height
+------
 
 ..  confval:: height
     :name: svg-height
@@ -49,8 +57,10 @@ Properties
 
     Height of the SVG.
 
-
 ..  _cobj-svg-src:
+
+src
+---
 
 ..  confval:: src
     :name: svg-src
@@ -66,8 +76,10 @@ Properties
 
         src = fileadmin/svg/tiger.svg
 
-
 ..  _cobj-svg-renderMode:
+
+renderMode
+----------
 
 ..  confval:: renderMode
     :name: svg-renderMode
@@ -75,8 +87,10 @@ Properties
 
     Setting `renderMode` to inline will render an inline version of the SVG.
 
-
 ..  _cobj-svg-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: svg-stdWrap

--- a/Documentation/ContentObjects/Text/Index.rst
+++ b/Documentation/ContentObjects/Text/Index.rst
@@ -31,14 +31,19 @@ Properties
 
 ..  _cobj-text-value:
 
+value
+-----
+
 ..  confval:: value
     :name: text-value
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
 
     Text, which you want to output.
 
-
 ..  _cobj-text-stdWrap:
+
+stdWrap
+-------
 
 ..  confval:: stdWrap
     :name: text-stdWrap
@@ -49,8 +54,10 @@ Properties
     properties consistently to those of the other cObjects by
     accessing them through the property "stdWrap".
 
-
 ..  _cobj-text-cache:
+
+cache
+-----
 
 ..  confval:: cache
     :name: text-cache

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -45,6 +45,9 @@ Properties
 
 ..  _cobj-user-userFunc:
 
+userFunc
+--------
+
 ..  confval:: userFunc
     :name: user-userFunc
     :type: :ref:`data-type-function-name`
@@ -68,6 +71,9 @@ Properties
 
 ..  _cobj-user-defined-properties:
 
+(properties you define)
+-----------------------
+
 ..  confval:: (properties you define)
     :name: user-defined-properties
     :type: (the data type you want)
@@ -81,11 +87,17 @@ Properties
 
 ..  _cobj-user-stdWrap:
 
+stdWrap
+-------
+
 ..  confval:: stdWrap
     :name: user-stdWrap
     :type: :ref:`stdWrap`.
 
 ..  _cobj-user-cache:
+
+cache
+-----
 
 ..  confval:: cache
     :name: user-cache

--- a/Documentation/DataProcessing/CommaSeparatedValueProcessor.rst
+++ b/Documentation/DataProcessing/CommaSeparatedValueProcessor.rst
@@ -28,6 +28,8 @@ Options:
 
     ..  _CommaSeparatedValueProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: CommaSeparatedValueProcessor-if
         :Required: false
@@ -38,6 +40,8 @@ Options:
 
     ..  _CommaSeparatedValueProcessor-fieldName:
 
+    ..  rubric:: fieldName
+
     ..  confval:: fieldName
         :name: CommaSeparatedValueProcessor-fieldName
         :Required: true
@@ -46,8 +50,9 @@ Options:
 
         Name of the field in the processed ContentObjectRenderer.
 
-
     ..  _CommaSeparatedValueProcessor-as:
+
+    ..  rubric:: as
 
     ..  confval:: as
         :name: CommaSeparatedValueProcessor-as
@@ -58,6 +63,8 @@ Options:
         The variable's name to be used in the Fluid template.
 
     ..  _CommaSeparatedValueProcessor-maximumColumns:
+
+    ..  rubric:: maximumColumns
 
     ..  confval:: maximumColumns
         :name: CommaSeparatedValueProcessor-maximumColumns
@@ -71,6 +78,8 @@ Options:
 
     ..  _CommaSeparatedValueProcessor-fieldDelimiter:
 
+    ..  rubric:: fieldDelimiter
+
     ..  confval:: fieldDelimiter
         :name: CommaSeparatedValueProcessor-fieldDelimiter
         :Required:  false
@@ -79,8 +88,9 @@ Options:
 
         The field delimiter, a character separating the values.
 
-
     ..  _CommaSeparatedValueProcessor-fieldEnclosure:
+
+    ..  rubric:: fieldEnclosure
 
     ..  confval:: fieldEnclosure
         :name: CommaSeparatedValueProcessor-fieldEnclosure

--- a/Documentation/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/DataProcessing/DatabaseQueryProcessor.rst
@@ -32,6 +32,8 @@ Options:
 
     ..  _DatabaseQueryProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: DatabaseQueryProcessor-if
         :Required: false
@@ -40,8 +42,9 @@ Options:
 
         Only if the condition is met the data processor is executed.
 
-
     ..  _DatabaseQueryProcessor-table:
+
+    ..  rubric:: table
 
     ..  confval:: table
         :name: DatabaseQueryProcessor-table
@@ -53,6 +56,8 @@ Options:
 
     ..  _DatabaseQueryProcessor-as:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: DatabaseQueryProcessor-as
         :Required: false
@@ -62,6 +67,8 @@ Options:
         The variable's name to be used in the Fluid template.
 
     ..  _DatabaseQueryProcessor-dataProcessing:
+
+    ..  rubric:: dataProcessing
 
     ..  confval:: dataProcessing
         :name: DatabaseQueryProcessor-dataProcessing

--- a/Documentation/DataProcessing/FilesProcessor.rst
+++ b/Documentation/DataProcessing/FilesProcessor.rst
@@ -31,6 +31,8 @@ Options:
 
     ..  _FilesProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: FilesProcessor-if
         :Required: false
@@ -40,6 +42,8 @@ Options:
         Only, if the condition is met the data processor is executed.
 
     ..  _FilesProcessor-references:
+
+    ..  rubric:: references
 
     ..  confval:: references
         :name: FilesProcessor-references
@@ -58,6 +62,8 @@ Options:
 
     ..  _FilesProcessor-references-fieldName:
 
+    ..  rubric:: references.fieldName
+
     ..  confval:: references.fieldName
         :name: FilesProcessor-references-fieldName
         :Required: false
@@ -72,6 +78,8 @@ Options:
 
     ..  _FilesProcessor-references-table:
 
+    ..  rubric:: references.table
+
     ..  confval:: references.table
         :name: FilesProcessor-references.table
         :Required: false
@@ -85,6 +93,8 @@ Options:
 
     ..  _FilesProcessor-files:
 
+    ..  rubric:: files
+
     ..  confval:: files
         :name: FilesProcessor-files
         :Required: false
@@ -96,6 +106,8 @@ Options:
         these are treated as uids of files (:sql:`sys_file`).
 
     ..  _FilesProcessor-collections:
+
+    ..  rubric:: collections
 
     ..  confval:: collections
         :name: FilesProcessor-collections
@@ -109,6 +121,8 @@ Options:
         collection are then being added to the output array.
 
     ..  _FilesProcessor-folders:
+
+    ..  rubric:: folders
 
     ..  confval:: folders
         :name: FilesProcessor-folders
@@ -132,6 +146,8 @@ Options:
 
     ..  _FilesProcessor-folders-recursive:
 
+    ..  rubric:: folders.recursive
+
     ..  confval:: folders.recursive
         :name: FilesProcessor-folders-recursive
         :Required: false
@@ -143,6 +159,8 @@ Options:
         recursively.
 
     ..  _FilesProcessor-sorting:
+
+    ..  rubric:: sorting
 
     ..  confval:: sorting
         :name: FilesProcessor-sorting
@@ -156,6 +174,8 @@ Options:
 
     ..  _FilesProcessor-sorting-direction:
 
+    ..  rubric:: sorting.direction
+
     ..  confval:: sorting.direction
         :name: FilesProcessor-sorting-direction
         :Required: false
@@ -166,6 +186,8 @@ Options:
         The sorting direction (:typoscript:`ascending` or :typoscript:`descending`).
 
     ..  _FilesProcessor-as:
+
+    ..  rubric:: as
 
     ..  confval:: as
         :name: FilesProcessor-as

--- a/Documentation/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/DataProcessing/FlexFormProcessor.rst
@@ -27,6 +27,8 @@ Options
 
     ..  _FlexFormProcessor-fieldname:
 
+    ..  rubric:: fieldName
+
     ..  confval:: fieldName
         :name: FlexFormProcessor-fieldname
         :Required: false
@@ -35,8 +37,9 @@ Options
 
         Field name of the column the FlexForm data is stored in.
 
-
     ..  _FlexFormProcessor-references:
+
+    ..  rubric:: references
 
     ..  confval:: references
         :name: FlexFormProcessor-references
@@ -55,8 +58,9 @@ Options
 
         See :ref:`FlexFormProcessor-resolving-fal`.
 
-
     ..  _FlexFormProcessor-as:
+
+    ..  rubric:: as
 
     ..  confval:: as
         :name: FlexFormProcessor-as

--- a/Documentation/DataProcessing/GalleryProcessor.rst
+++ b/Documentation/DataProcessing/GalleryProcessor.rst
@@ -26,6 +26,8 @@ Options:
 
     ..  _GalleryProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: GalleryProcessor-if
         :Required: false
@@ -34,8 +36,9 @@ Options:
 
         Only if the condition is met the data processor is executed.
 
-
     ..  _GalleryProcessor-filesProcessedDataKey:
+
+    ..  rubric:: filesProcessedDataKey
 
     ..  confval:: filesProcessedDataKey
         :name: GalleryProcessor-filesProcessedDataKey
@@ -46,8 +49,9 @@ Options:
 
         Key of the array previously processed by the :php:`FilesProcessor`.
 
-
     ..  _GalleryProcessor-numberOfColumns:
+
+    ..  rubric:: numberOfColumns
 
     ..  confval:: numberOfColumns
         :name: GalleryProcessor-numberOfColumns
@@ -60,6 +64,8 @@ Options:
         `imagecols` (:guilabel:`Number of Columns`) if used with content elements.
 
     ..  _GalleryProcessor-mediaOrientation:
+
+    ..  rubric:: mediaOrientation
 
     ..  confval:: mediaOrientation
         :name: GalleryProcessor-mediaOrientation
@@ -82,6 +88,8 @@ Options:
 
     ..  _GalleryProcessor-maxGalleryWidth:
 
+    ..  rubric:: maxGalleryWidth
+
     ..  confval:: maxGalleryWidth
         :name: GalleryProcessor-maxGalleryWidth
         :Required: false
@@ -91,6 +99,8 @@ Options:
         Maximal gallery width in pixels.
 
     ..  _GalleryProcessor-maxGalleryWidthInText:
+
+    ..  rubric:: maxGalleryWidthInText
 
     ..  confval:: maxGalleryWidthInText
         :name: GalleryProcessor-maxGalleryWidthInText
@@ -102,6 +112,8 @@ Options:
 
     ..  _GalleryProcessor-equalMediaHeight:
     ..  _GalleryProcessor-equalMediaWidth:
+
+    ..  rubric:: equalMediaHeight, equalMediaWidth
 
     ..  confval:: equalMediaHeight, equalMediaWidth
         :name: GalleryProcessor-equalMediaHeight
@@ -122,8 +134,9 @@ Options:
 
             Media height and width in the content element Text and Images
 
-
     ..  _GalleryProcessor-columnSpacing:
+
+    ..  rubric:: columnSpacing
 
     ..  confval:: columnSpacing
         :name: GalleryProcessor-columnSpacing
@@ -135,6 +148,8 @@ Options:
         Space between columns in pixels
 
     ..  _GalleryProcessor-borderEnabled:
+
+    ..  rubric:: borderEnabled
 
     ..  confval:: borderEnabled
         :name: GalleryProcessor-borderEnabled
@@ -149,6 +164,8 @@ Options:
 
     ..  _GalleryProcessor-borderWidth:
 
+    ..  rubric:: borderWidth
+
     ..  confval:: borderWidth
         :name: GalleryProcessor-borderWidth
         :Required: false
@@ -160,6 +177,8 @@ Options:
 
     ..  _GalleryProcessor-borderPadding:
 
+    ..  rubric:: borderPadding
+
     ..  confval:: borderPadding
         :name: GalleryProcessor-borderPadding
         :Required: false
@@ -169,8 +188,9 @@ Options:
 
         Padding around the border in pixels.
 
-
     ..  _GalleryProcessor-cropVariant:
+
+    ..  rubric:: cropVariant
 
     ..  confval:: cropVariant
         :name: GalleryProcessor-cropVariant
@@ -183,6 +203,8 @@ Options:
 
     ..  _GalleryProcessor-as:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: GalleryProcessor-as
         :Required: false
@@ -192,6 +214,8 @@ Options:
         The variable name to be used in the Fluid template.
 
     ..  _GalleryProcessor-dataProcessing:
+
+    ..  rubric:: dataProcessing
 
     ..  confval:: dataProcessing
         :name: GalleryProcessor-dataProcessing

--- a/Documentation/DataProcessing/LanguageMenuProcessor.rst
+++ b/Documentation/DataProcessing/LanguageMenuProcessor.rst
@@ -33,6 +33,8 @@ Options:
 
     ..  _LanguageMenuProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: LanguageMenuProcessor-if
         :Required: false
@@ -41,6 +43,8 @@ Options:
         Only if the condition is met the data processor is executed.
 
     ..  _LanguageMenuProcessor-languages:
+
+    ..  rubric:: languages
 
     ..  confval:: languages
         :name: LanguageMenuProcessor-languages
@@ -53,8 +57,9 @@ Options:
         creation or `auto` to load from the :ref:`site configuration
         <t3coreapi:sitehandling>`.
 
-
     ..  _LanguageMenuProcessor-addQueryString-exclude:
+
+    ..  rubric:: addQueryString.exclude
 
     ..  confval:: addQueryString.exclude
         :name: LanguageMenuProcessor-addQueryString-exclude
@@ -67,6 +72,8 @@ Options:
         menu URLs.
 
     ..  _LanguageMenuProcessor-as:
+
+    ..  rubric:: as
 
     ..  confval:: as
         :name: LanguageMenuProcessor-as

--- a/Documentation/DataProcessing/MenuProcessor/Browse.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Browse.rst
@@ -35,6 +35,8 @@ Properties
     :type:
     :Default:
 
+    ..  rubric:: special.value
+
     ..  confval:: special.value
         :name: hmenu-browse-special-value
         :type: integer /:ref:`stdWrap <stdwrap>`
@@ -42,6 +44,8 @@ Properties
 
         The default value can be overridden with a different page ID as starting
         point for the menu in some rare use cases.
+
+    ..  rubric:: special.items
 
     ..  confval:: special.items
         :name: hmenu-browse-special-items
@@ -88,6 +92,8 @@ Properties
             page(up 2 levels). May not be available, if that page is out of the
             root line.
 
+    ..  rubric:: special.items.prevnextToSection
+
     ..  confval:: special.items.prevnextToSection
         :name: hmenu-browse-special-items-prevnextToSection
         :type: boolean
@@ -97,6 +103,8 @@ Properties
         when it reaches the end of pages in the current section. That way
         `prev` and `next` will also link to the first page of the next section
         / to the last page of the previous section.
+
+    ..  rubric:: special.excludeNoSearchPages
 
     ..  confval:: special.excludeNoSearchPages
         :name: hmenu-browse-special-excludeNoSearchPages

--- a/Documentation/DataProcessing/MenuProcessor/Categories.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Categories.rst
@@ -33,6 +33,9 @@ Properties
 
 ..  _hmenu-special-categories-value:
 
+special.value
+-------------
+
 ..  confval:: special.value
     :name: hmenu-categories-special-value
     :type: list of categories / :ref:`stdWrap <stdwrap>`
@@ -41,6 +44,9 @@ Properties
     Comma-separated list of categories UID's.
 
 ..  _hmenu-special-categories-relation:
+
+special.relation
+----------------
 
 ..  confval:: special.relation
     :name: hmenu-categories-special-relation
@@ -53,6 +59,9 @@ Properties
 
 ..  _hmenu-special-categories-sorting:
 
+special.sorting
+---------------
+
 ..  confval:: special.sorting
     :name: hmenu-categories-special-sorting
     :type: :ref:`data-type-string` / :ref:`stdWrap <stdwrap>`
@@ -64,6 +73,9 @@ Properties
     If an unknown field is defined, the pages will not be sorted.
 
 ..  _hmenu-special-categories-order:
+
+special.order
+-------------
 
 ..  confval:: special.order
     :name: hmenu-categories-special-order

--- a/Documentation/DataProcessing/MenuProcessor/Index.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Index.rst
@@ -37,6 +37,8 @@ Options
 
     ..  _MenuProcessor-as:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: MenuProcessor-as
         :Required: false
@@ -45,6 +47,8 @@ Options
 
         Name for the variable in the Fluid template.
 
+    ..  rubric:: alwaysActivePIDlist
+
     ..  confval:: alwaysActivePIDlist
         :name: MenuProcessor-alwaysActivePIDlist
         :type: list of :ref:`data-type-integer` /:ref:`stdWrap <stdwrap>`
@@ -52,6 +56,8 @@ Options
         This is a list of page UID numbers that will always be regarded as
         active menu items and thereby automatically opened regardless of the
         rootline.
+
+    ..  rubric:: entryLevel
 
     ..  confval:: entryLevel
         :name: MenuProcessor-entryLevel
@@ -79,6 +85,8 @@ Options
         it will start to be visible from the 4th level (and will contain only
         the subpages from that level).
 
+    ..  rubric:: excludeDoktypes
+
     ..  confval:: excludeDoktypes
         :name: MenuProcessor-excludeDoktypes
         :type: list of :ref:`data-type-integer`
@@ -87,6 +95,8 @@ Options
         Enter the list of page document types (doktype) to exclude from menus.
         By default pages that are "backend user access only" (6) or "folder"
         (254) are excluded.
+
+    ..  rubric:: excludeUidList
 
     ..  confval:: excludeUidList
         :name: MenuProcessor-excludeUidList
@@ -108,6 +118,8 @@ Options
 
     ..  _MenuProcessor-expandAll:
 
+    ..  rubric:: expandAll
+
     ..  confval:: expandAll
         :name: MenuProcessor-expandAll
         :Required: true
@@ -119,6 +131,8 @@ Options
 
     ..  _MenuProcessor-levels:
 
+    ..  rubric:: levels
+
     ..  confval:: levels
         :name: MenuProcessor-levels
         :Required: true
@@ -127,6 +141,8 @@ Options
         :Example: 5
 
         Maximal number of levels to be included in the output array.
+
+    ..  rubric:: includeNotInMenu
 
     ..  confval:: includeNotInMenu
         :name: MenuProcessor-includeNotInMenu
@@ -137,6 +153,8 @@ Options
 
     ..  _MenuProcessor-includeSpacer:
 
+    ..  rubric:: includeSpacer
+
     ..  confval:: includeSpacer
         :name: MenuProcessor-includeSpacer
         :Required: true
@@ -145,6 +163,8 @@ Options
         :Example: 1
 
         Include pages with type "spacer".
+
+    ..  rubric:: protectLvar
 
     ..  confval:: protectLvar
         :name: MenuProcessor-protectlvar
@@ -170,6 +190,8 @@ Options
         if "Hide page if no translation for current language exists" is set -
         it always reverts to default language if no translation is found.
 
+    ..  rubric:: special
+
     ..  confval:: special
         :name: MenuProcessor-special
         :type: *"directory" / "list" / "updated" / "rootline" / "browse" / "keywords"
@@ -184,6 +206,8 @@ Options
 
         See the section about the :ref:`.special property <MenuProcessor-special>`.
 
+        ..  rubric:: value
+
         ..  confval:: value
             :name: MenuProcessor-special-value
             :type: *list of page-uid's* / :ref:`stdWrap <stdwrap>`
@@ -193,6 +217,8 @@ Options
             section about the :ref:`.special property <MenuProcessor-special>`.
 
     ..  _MenuProcessor-titleField:
+
+    ..  rubric:: titleField
 
     ..  confval:: titleField
         :name: MenuProcessor-titleField

--- a/Documentation/DataProcessing/MenuProcessor/Keywords.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Keywords.rst
@@ -27,6 +27,9 @@ Properties
 
 ..  _hmenu-special-keywords-value:
 
+special.value
+-------------
+
 ..  confval:: special.value
     :name: hmenu-keywords-special-value
     :type: integer /:ref:`stdWrap <stdwrap>`
@@ -35,6 +38,9 @@ Properties
     UID of the page for which related pages by keyword should be found.
 
 ..  _hmenu-special-keywords-mode:
+
+special.mode
+------------
 
 ..  confval:: special.mode
     :name: hmenu-keywords-special-mode
@@ -64,8 +70,10 @@ Properties
     `starttime`
         Uses the :sql:`starttime` field.
 
-
 ..  _hmenu-special-keywords-entrylevel:
+
+special.entryLevel
+------------------
 
 ..  confval:: special.entryLevel
     :name: hmenu-keywords-special-entryLevel
@@ -77,6 +85,9 @@ Properties
 
 ..  _hmenu-special-keywords-depth:
 
+special.depth
+-------------
+
 ..  confval:: special.depth
     :name: hmenu-keywords-special-depth
     :type: integer
@@ -84,8 +95,10 @@ Properties
 
     Same as in section :ref:`"special = updated" <hmenu-special-updated-depth>`.
 
-
 ..  _hmenu-special-keywords-limit:
+
+special.limit
+-------------
 
 ..  confval:: special.limit
     :name: hmenu-keywords-special-limit
@@ -94,8 +107,10 @@ Properties
 
     Maximal number of items in the menu. Default is 10, maximum is 100.
 
-
 ..  _hmenu-special-keywords-excludenosearchpages:
+
+special.excludeNoSearchPages
+----------------------------
 
 ..  confval:: special.excludeNoSearchPages
     :name: hmenu-keywords-special-excludeNoSearchPages
@@ -106,6 +121,9 @@ Properties
 
 ..  _hmenu-special-keywords-begin:
 
+special.begin
+-------------
+
 ..  confval:: special.begin
     :name: hmenu-keywords-special-begin
     :type: boolean
@@ -113,6 +131,9 @@ Properties
     ..  TODO: What does this do?
 
 ..  _hmenu-special-keywords-setkeywords:
+
+special.setKeywords
+-------------------
 
 ..  confval:: special.setKeywords
     :name: hmenu-keywords-special-setKeywords
@@ -124,6 +145,9 @@ Properties
 
 ..  _hmenu-special-keywords-keywordsfield:
 
+special.keywordsField
+---------------------
+
 ..  confval:: special.keywordsField
     :name: hmenu-keywords-special-keywordsField
     :type: string
@@ -134,6 +158,9 @@ Properties
     if the field you enter here exists, so make sure to enter an existing field.
 
 ..  _hmenu-special-keywords-sourcefield:
+
+special.keywordsField.sourceField
+---------------------------------
 
 ..  confval:: special.keywordsField.sourceField
     :name: hmenu-keywords-special-setKeywords-sourceField

--- a/Documentation/DataProcessing/MenuProcessor/Rootline.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Rootline.rst
@@ -41,6 +41,9 @@ Properties
 
 ..  _hmenu-special-rootline-range:
 
+special.range
+-------------
+
 ..  confval:: special.range
     :name: hmenu-rootline-special-range
     :type: string /:ref:`stdWrap <stdwrap>`
@@ -52,6 +55,9 @@ Properties
 
 ..  _hmenu-special-rootline-reverseorder:
 
+special.reverseOrder
+--------------------
+
 ..  confval:: special.reverseOrder
     :name: hmenu-rootline-special-reverseOrder
     :type: boolean
@@ -60,8 +66,10 @@ Properties
     If set to true, the order of the root line menu elements will be
     reversed.
 
-
 ..  _hmenu-special-rootline-targets:
+
+special.targets.[level number]
+------------------------------
 
 ..  confval:: special.targets.[level number]
     :name: hmenu-rootline-special-targets

--- a/Documentation/DataProcessing/MenuProcessor/Updated.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Updated.rst
@@ -29,6 +29,9 @@ Properties
 
 ..  _hmenu-special-updated-value:
 
+special.value
+-------------
+
 ..  confval:: special.value
     :name: hmenu-updated-special-value
     :type: list of page IDs /:ref:`stdWrap <stdwrap>`
@@ -45,6 +48,9 @@ Properties
         20.special.value = 35, 56
 
 ..  _hmenu-special-updated-mode:
+
+special.mode
+------------
 
 ..  confval:: special.mode
     :name: hmenu-updated-special-mode
@@ -79,6 +85,9 @@ Properties
 
 ..  _hmenu-special-updated-depth:
 
+special.depth
+-------------
+
 ..  confval:: special.depth
     :name: hmenu-updated-special-depth
     :type: integer
@@ -94,6 +103,9 @@ Properties
     **Note:** "depth" is relative to :confval:`hmenu-updated-special-beginAtLevel`.
 
 ..  _hmenu-special-updated-beginatlevel:
+
+special.beginAtLevel
+--------------------
 
 ..  confval:: special.beginAtLevel
     :name: hmenu-updated-special-beginAtLevel
@@ -111,8 +123,10 @@ Properties
 
     **Note:** "depth" is relative to this property.
 
-
 ..  _hmenu-special-updated-maxage:
+
+special.maxAge
+--------------
 
 ..  confval:: special.maxAge
     :name: hmenu-updated-special-maxAge
@@ -127,6 +141,9 @@ Properties
 
 ..  _hmenu-special-updated-limit:
 
+special.limit
+-------------
+
 ..  confval:: special.limit
     :name: hmenu-updated-special-limit
     :type: integer
@@ -134,8 +151,10 @@ Properties
 
     Maximal number of items in the menu. Default is 10, max is 100.
 
-
 ..  _hmenu-special-updated-excludenosearchpages:
+
+special.excludeNoSearchPages
+----------------------------
 
 ..  confval:: special.excludeNoSearchPages
     :name: hmenu-updated-special-excludeNoSearchPages

--- a/Documentation/DataProcessing/PageContentFetchingProcessor.rst
+++ b/Documentation/DataProcessing/PageContentFetchingProcessor.rst
@@ -31,6 +31,8 @@ Options
     :type:
     :Default:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: PageContentFetchingProcessor-as
         :Required: false
@@ -38,6 +40,8 @@ Options
         :Default: "content"
 
         Name for the variable in the Fluid template.
+
+    ..  rubric:: if
 
     ..  confval:: if
         :name: PageContentFetchingProcessor-if

--- a/Documentation/DataProcessing/RecordTransformationProcessor.rst
+++ b/Documentation/DataProcessing/RecordTransformationProcessor.rst
@@ -90,6 +90,8 @@ Options of the `record-transformation` data processor
     :type:
     :Default:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: RecordTransformationProcessor-as
         :type: :ref:`data-type-string` / :ref:`stdWrap`
@@ -98,12 +100,16 @@ Options of the `record-transformation` data processor
         The target variable containing the resolved record objects.
         If empty, 'record' or 'records' (if multiple records are given) is used.
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: RecordTransformationProcessor-if
         :type: :ref:`if` condition
         :Default: ''
 
         Only if the condition is met the Data Processor is executed.
+
+    ..  rubric:: table
 
     ..  confval:: table
         :name: RecordTransformationProcessor-table
@@ -114,6 +120,8 @@ Options of the `record-transformation` data processor
         the table from context.
 
         If you are dealing with a custom data source you can adjust it here.
+
+    ..  rubric:: variableName
 
     ..  confval:: variableName
         :name: RecordTransformationProcessor-variableName

--- a/Documentation/DataProcessing/SplitProcessor.rst
+++ b/Documentation/DataProcessing/SplitProcessor.rst
@@ -25,6 +25,8 @@ Options
 
     ..  _splitProcessor-if:
 
+    ..  rubric:: if
+
     ..  confval:: if
         :name: splitProcessor-if
         :Required: false
@@ -34,6 +36,8 @@ Options
         Only if the condition is met the data processor is executed.
 
     ..  _splitProcessor-fieldName:
+
+    ..  rubric:: fieldName
 
     ..  confval:: fieldName
         :name: splitProcessor-fieldName
@@ -45,6 +49,8 @@ Options
 
     ..  _splitProcessor-as:
 
+    ..  rubric:: as
+
     ..  confval:: as
         :name: splitProcessor-as
         :Required: false
@@ -54,6 +60,8 @@ Options
         The variable name to be used in the Fluid template.
 
     ..  _splitProcessor-delimiter:
+
+    ..  rubric:: delimiter
 
     ..  confval:: delimiter
         :name: splitProcessor-delimiter
@@ -66,6 +74,8 @@ Options
 
     ..  _splitProcessor-filterIntegers:
 
+    ..  rubric:: filterIntegers
+
     ..  confval:: filterIntegers
         :name: splitProcessor-filterIntegers
         :Required: false
@@ -77,6 +87,8 @@ Options
 
     ..  _splitProcessor-filterUnique:
 
+    ..  rubric:: filterUnique
+
     ..  confval:: filterUnique
         :name: splitProcessor-filterUnique
         :Required: false
@@ -87,6 +99,8 @@ Options
         If set to `1`, all duplicates will be removed.
 
     ..  _splitProcessor-removeEmptyEntries:
+
+    ..  rubric:: removeEmptyEntries
 
     ..  confval:: removeEmptyEntries
         :name: splitProcessor-removeEmptyEntries

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -67,6 +67,8 @@ Properties for getting data
 
     ..  _stdwrap-setContentToCurrent:
 
+    ..  rubric:: setContentToCurrent
+
     ..  confval:: setContentToCurrent
         :name: stdwrap-setContentToCurrent
         :type: :ref:`data-type-boolean` / :ref:`stdWrap`
@@ -74,6 +76,8 @@ Properties for getting data
         Sets the current value to the incoming content of the function.
 
     ..  _stdwrap-addpagecachetags:
+
+    ..  rubric:: addPageCacheTags
 
     ..  confval:: addPageCacheTags
         :name: stdwrap-addpagecachetags
@@ -99,8 +103,9 @@ Properties for getting data
             caching framework use the :ref:`stdwrap-cache`:typoscript:`cache`
             property.
 
-
     ..  _stdwrap-setCurrent:
+
+    ..  rubric:: setCurrent
 
     ..  confval:: setCurrent
         :name: stdwrap-setCurrent
@@ -109,8 +114,9 @@ Properties for getting data
         Sets the "current"-value. This is normally set from an external
         routine, so be careful with this. But it might come in useful.
 
-
     ..  _stdwrap-lang:
+
+    ..  rubric:: lang
 
     ..  confval:: lang
         :name: stdwrap-lang
@@ -132,11 +138,15 @@ Properties for getting data
 
     ..  _stdwrap-data:
 
+    ..  rubric:: data
+
     ..  confval:: data
         :name: stdwrap-data
         :type: :ref:`data-type-gettext` / :ref:`stdWrap`
 
     ..  _stdwrap-field:
+
+    ..  rubric:: field
 
     ..  confval:: field
         :name: stdwrap-field
@@ -169,8 +179,9 @@ Properties for getting data
         unless it is a blank string. If it is a blank string, the value of
         the title field is returned.
 
-
     ..  _stdwrap-current:
+
+    ..  rubric:: current
 
     ..  confval:: current
         :name: stdwrap-current
@@ -178,8 +189,9 @@ Properties for getting data
 
         Sets the content to the "current" value (see :ref:`->split <split>`)
 
-
     ..  _stdwrap-cObject:
+
+    ..  rubric:: cObject
 
     ..  confval:: cObject
         :name: stdwrap-cObject
@@ -187,8 +199,9 @@ Properties for getting data
 
         Loads content from a content object.
 
-
     ..  _stdwrap-numRows:
+
+    ..  rubric:: numRows
 
     ..  confval:: numRows
         :name: stdwrap-numRows
@@ -196,8 +209,9 @@ Properties for getting data
 
         Returns the number of rows resulting from a supplied :sql:`SELECT` query.
 
-
     ..  _stdwrap-preUserFunc:
+
+    ..  rubric:: preUserFunc
 
     ..  confval:: preUserFunc
         :name: stdwrap-preUserFunc
@@ -227,6 +241,8 @@ Properties for overriding and conditions
 
     ..  _stdwrap-override:
 
+    ..  rubric:: override
+
     ..  confval:: override
         :name: stdwrap-override
         :type: :ref:`data-type-string` / :ref:`stdWrap`
@@ -234,15 +250,17 @@ Properties for overriding and conditions
         If `override` returns something other than "" or zero (trimmed), the
         content is loaded with this.
 
-
     ..  _stdwrap-preIfEmptyListNum:
+
+    ..  rubric:: preIfEmptyListNum
 
     ..  confval:: preIfEmptyListNum
         :name: stdwrap-preIfEmptyListNum
         :type: (as ":ref:`stdwrap-listNum`" below)
 
-
     ..  _stdwrap-ifNull:
+
+    ..  rubric:: ifNull
 
     ..  confval:: ifNull
         :name: stdwrap-ifNull
@@ -266,8 +284,9 @@ Properties for overriding and conditions
         This example displays the content of the description field or, if that
         value is :php:`NULL`, the text "No description defined.".
 
-
     ..  _stdwrap-ifEmpty:
+
+    ..  rubric:: ifEmpty
 
     ..  confval:: ifEmpty
         :name: stdwrap-ifEmpty
@@ -276,8 +295,9 @@ Properties for overriding and conditions
         If the trimmed content is empty, the content is loaded
         with :typoscript:`ifEmpty`. Zeros are treated as empty values.
 
-
     ..  _stdwrap-ifBlank:
+
+    ..  rubric:: ifBlank
 
     ..  confval:: ifBlank
         :name: stdwrap-ifBlank
@@ -286,8 +306,9 @@ Properties for overriding and conditions
         Same as :typoscript:`ifEmpty` but the check is done against '' (empty
         string). Zeros are not treated as blank values.
 
-
     ..  _stdwrap-listNum:
+
+    ..  rubric:: listNum
 
     ..  confval:: listNum
         :name: stdwrap-listNum
@@ -335,8 +356,9 @@ Properties for overriding and conditions
             page.10.value = item 1, item 2, item 3, item 4
             page.10.listNum = last – 1
 
-
         ..  _stdwrap-listNum-splitChar:
+
+        ..  rubric:: listNum.splitChar
 
         ..  confval:: listNum.splitChar
             :name: stdwrap-listNum-splitChar
@@ -361,8 +383,9 @@ Properties for overriding and conditions
                    }
                 }
 
-
     ..  _stdwrap-trim:
+
+    ..  rubric:: trim
 
     ..  confval:: trim
         :name: stdwrap-trim
@@ -370,8 +393,9 @@ Properties for overriding and conditions
 
         If set, the PHP-function :php:`trim()` removes whitespace around the value.
 
-
     ..  _stdwrap-strPad:
+
+    ..  rubric:: strPad
 
     ..  confval:: strPad
         :name: stdwrap-strPad
@@ -380,8 +404,9 @@ Properties for overriding and conditions
         Pads the current content to a certain length. You can define the padding
         characters and which side(s) the padding should be added.
 
-
     ..  _stdwrap-stdWrap:
+
+    ..  rubric:: stdWrap
 
     ..  confval:: stdWrap
         :name: stdwrap-stdWrap
@@ -389,8 +414,9 @@ Properties for overriding and conditions
 
         Recursive call to the :typoscript:`stdWrap` function.
 
-
     ..  _stdwrap-required:
+
+    ..  rubric:: required
 
     ..  confval:: required
         :name: stdwrap-required
@@ -403,8 +429,9 @@ Properties for overriding and conditions
 
         If the content is empty, "" is returned.
 
-
     ..  _stdwrap-if:
+
+    ..  rubric:: if
 
     ..  confval:: if
         :name: stdwrap-if
@@ -412,8 +439,9 @@ Properties for overriding and conditions
 
         If the if-object returns false, stdWrap returns "".
 
-
     ..  _stdwrap-fieldRequired:
+
+    ..  rubric:: fieldRequired
 
     ..  confval:: fieldRequired
         :name: stdwrap-fieldRequired
@@ -433,6 +461,8 @@ Properties for parsing data
 
     ..  _stdwrap-csConv:
 
+    ..  rubric:: csConv
+
     ..  confval:: csConv
         :name: stdwrap-csConv
         :type: :ref:`data-type-string` / :ref:`stdWrap`
@@ -440,8 +470,9 @@ Properties for parsing data
         Converts the charset of the string from the charset given as a value to
         the current rendering charset of the frontend (UTF-8).
 
-
     ..  _stdwrap-parseFunc:
+
+    ..  rubric:: parseFunc
 
     ..  confval:: parseFunc
         :name: stdwrap-parseFunc
@@ -517,6 +548,8 @@ Properties for parsing data
 
     ..  _stdwrap-htmlparser:
 
+    ..  rubric:: HTMLparser
+
     ..  confval:: HTMLparser
         :name: stdwrap-htmlparser
         :type: :ref:`data-type-boolean` / :ref:`htmlparser` / :ref:`stdWrap`
@@ -528,15 +561,17 @@ Properties for parsing data
 
         (See :ref:`t3coreapi:rte` for more information about RTE transformations)
 
-
     ..  _stdwrap-split:
+
+    ..  rubric:: split
 
     ..  confval:: split
         :name: stdwrap-split
         :type: :ref:`split` / :ref:`stdWrap`
 
-
     ..  _stdwrap-replacement:
+
+    ..  rubric:: replacement
 
     ..  confval:: replacement
         :name: stdwrap-replacement
@@ -547,8 +582,9 @@ Properties for parsing data
         indices defines the order of actions and thus allows multiple
         replacements at once.
 
-
     ..  _stdwrap-prioriCalc:
+
+    ..  rubric:: prioriCalc
 
     ..  confval:: prioriCalc
         :name: stdwrap-prioriCalc
@@ -581,8 +617,9 @@ Properties for parsing data
             -5 * (-4+6) ^ 2 - 100%7 = 98
             -5 * ((-4+6) ^ 2) - 100%7 = -22
 
-
     ..  _stdwrap-char:
+
+    ..  rubric:: char
 
     ..  confval:: char
         :name: stdwrap-char
@@ -598,8 +635,9 @@ Properties for parsing data
 
             $content = chr((int)$conf['char']);
 
-
     ..  _stdwrap-intval:
+
+    ..  rubric:: intval
 
     ..  confval:: intval
         :name: stdwrap-intval
@@ -611,8 +649,9 @@ Properties for parsing data
 
             $content = intval($content);
 
-
     ..  _stdwrap-hash:
+
+    ..  rubric:: hash
 
     ..  confval:: hash
         :name: stdwrap-hash
@@ -633,8 +672,9 @@ Properties for parsing data
                stdWrap.wrap = <img src="https://www.gravatar.com/avatar/|" />
             }
 
-
     ..  _stdwrap-round:
+
+    ..  rubric:: round
 
     ..  confval:: round
         :name: stdwrap-round
@@ -643,8 +683,9 @@ Properties for parsing data
         Round the value using the selected method to the given number of
         decimals.
 
-
     ..  _stdwrap-numberFormat:
+
+    ..  rubric:: numberFormat
 
     ..  confval:: numberFormat
         :name: stdwrap-numberFormat
@@ -653,8 +694,9 @@ Properties for parsing data
         Format a float value to the number format you need (e.g. useful for
         prices).
 
-
     ..  _stdwrap-date:
+
+    ..  rubric:: date
 
     ..  confval:: date
         :name: stdwrap-date
@@ -692,8 +734,9 @@ Properties for parsing data
             You should consider using the more flexible function
             :ref:`stdwrap-formattedDate`:typoscript:`formattedDate`.
 
-
     ..  _stdwrap-strtotime:
+
+    ..  rubric:: strtotime
 
     ..  confval:: strtotime
         :name: stdwrap-strtotime
@@ -725,9 +768,10 @@ Properties for parsing data
                strftime = %Y-%m-%d
             }
 
-
     ..  _data-type-strftime-conf:
     ..  _stdwrap-strftime:
+
+    ..  rubric:: strftime
 
     ..  confval:: strftime
         :name: stdwrap-strftime
@@ -755,8 +799,9 @@ Properties for parsing data
             You should consider using the more flexible function
             :ref:`stdwrap-formattedDate`:typoscript:`formattedDate`.
 
-
     ..  _stdwrap-formattedDate:
+
+    ..  rubric:: formattedDate
 
     ..  confval:: formattedDate
         :name: stdwrap-formattedDate
@@ -845,8 +890,9 @@ Properties for parsing data
             The timezone will be taken from the setting `date.timezone` in your
             :file:`php.ini`.
 
-
     ..  _stdwrap-age:
+
+    ..  rubric:: age
 
     ..  confval:: age
         :name: stdwrap-age
@@ -883,9 +929,10 @@ Properties for parsing data
             lib.ageFormat.stdWrap.data = page:tstamp
             lib.ageFormat.stdWrap.age = " Minuten | Stunden | Tage | Jahre | Minute | Stunde | Tag | Jahr"
 
-
     ..  _data-type-case:
     ..  _stdwrap-case:
+
+    ..  rubric:: case
 
     ..  confval:: case
         :name: stdwrap-case
@@ -927,8 +974,9 @@ Properties for parsing data
 
             HELLO WORLD!
 
-
     ..  _stdwrap-bytes:
+
+    ..  rubric:: bytes
 
     ..  confval:: bytes
         :name: stdwrap-bytes
@@ -1091,8 +1139,9 @@ Properties for parsing data
                bytes.base = 1024
             }
 
-
     ..  _stdwrap-substring:
+
+    ..  rubric:: substring
 
     ..  confval:: substring
         :name: stdwrap-substring
@@ -1103,8 +1152,9 @@ Properties for parsing data
 
         Uses "UTF-8".
 
-
     ..  _stdwrap-cropHTML:
+
+    ..  rubric:: cropHTML
 
     ..  confval:: cropHTML
         :name: stdwrap-cropHTML
@@ -1118,8 +1168,9 @@ Properties for parsing data
         Note that :typoscript:`stdWrap.crop` should not be used if :typoscript:`stdWrap.cropHTML` is
         already being used.
 
-
     ..  _stdwrap-stripHtml:
+
+    ..  rubric:: stripHtml
 
     ..  confval:: stripHtml
         :name: stdwrap-stripHtml
@@ -1127,8 +1178,9 @@ Properties for parsing data
 
         Strips all HTML tags.
 
-
     ..  _stdwrap-crop:
+
+    ..  rubric:: crop
 
     ..  confval:: crop
         :name: stdwrap-crop
@@ -1170,8 +1222,9 @@ Properties for parsing data
 
         Uses "UTF-8".
 
-
     ..  _stdwrap-rawUrlEncode:
+
+    ..  rubric:: rawUrlEncode
 
     ..  confval:: rawUrlEncode
         :name: stdwrap-rawUrlEncode
@@ -1180,8 +1233,9 @@ Properties for parsing data
         Passes the content through the `rawurlencode() <https://www.php.net/rawurlencode>`_
         PHP function .
 
-
     ..  _stdwrap-htmlSpecialChars:
+
+    ..  rubric:: htmlSpecialChars
 
     ..  confval:: htmlSpecialChars
         :name: stdwrap-htmlSpecialChars
@@ -1192,8 +1246,9 @@ Properties for parsing data
         Additional property :typoscript:`preserveEntities` will preserve entities so that only
         non-entity characters are affected.
 
-
     ..  _stdwrap-encodeForJavaScriptValue:
+
+    ..  rubric:: encodeForJavaScriptValue
 
     ..  confval:: encodeForJavaScriptValue
         :name: stdwrap-encodeForJavaScriptValue
@@ -1219,8 +1274,9 @@ Properties for parsing data
                   wrap = setSearchWord(|);
             }
 
-
     ..  _stdwrap-doubleBrTag:
+
+    ..  rubric:: doubleBrTag
 
     ..  confval:: doubleBrTag
         :name: stdwrap-doubleBrTag
@@ -1228,8 +1284,9 @@ Properties for parsing data
 
         Double line breaks are substituted with this value.
 
-
     ..  _stdwrap-br:
+
+    ..  rubric:: br
 
     ..  confval:: br
         :name: stdwrap-br
@@ -1238,8 +1295,9 @@ Properties for parsing data
         Pass the value through the `nl2br() <https://www.php.net/nl2br>`__ PHP function. This
         converts each line break to a :html:`<br />` or a :html:`<br>` tag depending on doctype.
 
-
     ..  _stdwrap-brTag:
+
+    ..  rubric:: brTag
 
     ..  confval:: brTag
         :name: stdwrap-brTag
@@ -1248,8 +1306,9 @@ Properties for parsing data
         All ASCII codes of "10" (line feed, LF) are substituted with the
         *value* of this property.
 
-
     ..  _stdwrap-encapsLines:
+
+    ..  rubric:: encapsLines
 
     ..  confval:: encapsLines
         :name: stdwrap-encapsLines
@@ -1258,8 +1317,9 @@ Properties for parsing data
         Lets you split the content with :php:`chr(10)` and process each line
         independently. Used to format RTE content .
 
-
     ..  _stdwrap-keywords:
+
+    ..  rubric:: keywords
 
     ..  confval:: keywords
         :name: stdwrap-keywords
@@ -1281,14 +1341,17 @@ Properties for wrapping data
 
     ..  _stdwrap-innerWrap:
 
+    ..  rubric:: innerWrap
+
     ..  confval:: innerWrap
         :name: stdwrap-innerWrap
         :type: :ref:`wrap <data-type-wrap>` / :ref:`stdWrap`
 
         Wraps content.
 
-
     ..  _stdwrap-innerWrap2:
+
+    ..  rubric:: innerWrap2
 
     ..  confval:: innerWrap2
         :name: stdwrap-innerWrap2
@@ -1296,8 +1359,9 @@ Properties for wrapping data
 
         Same as :typoscript:`innerWrap` (but watch the order in which they are executed).
 
-
     ..  _stdwrap-preCObject:
+
+    ..  rubric:: preCObject
 
     ..  confval:: preCObject
         :name: stdwrap-preCObject
@@ -1305,8 +1369,9 @@ Properties for wrapping data
 
         :ref:`stdwrap-cObject`:typoscript:`cObject` prepended the content.
 
-
     ..  _stdwrap-postCObject:
+
+    ..  rubric:: postCObject
 
     ..  confval:: postCObject
         :name: stdwrap-postCObject
@@ -1314,9 +1379,10 @@ Properties for wrapping data
 
         :ref:`stdwrap-cObject`:typoscript:`cObject` appended the content.
 
-
     ..  _data-type-align:
     ..  _stdwrap-wrapAlign:
+
+    ..  rubric:: wrapAlign
 
     ..  confval:: wrapAlign
         :name: stdwrap-wrapAlign
@@ -1326,8 +1392,9 @@ Properties for wrapping data
         Wraps content with :typoscript:`<div style=text-align:[*value*];"> | </div>`
         *if* align is set.
 
-
     ..  _stdwrap-typolink:
+
+    ..  rubric:: typolink
 
     ..  confval:: typolink
         :name: stdwrap-typolink
@@ -1335,8 +1402,9 @@ Properties for wrapping data
 
         Wraps content with a link tag.
 
-
     ..  _stdwrap-wrap:
+
+    ..  rubric:: wrap
 
     ..  confval:: wrap
         :name: stdwrap-wrap
@@ -1346,6 +1414,8 @@ Properties for wrapping data
         - the vertical line)
 
     ..  _stdwrap-noTrimWrap:
+
+    ..  rubric:: noTrimWrap
 
     ..  confval:: noTrimWrap
         :name: stdwrap-noTrimWrap
@@ -1388,8 +1458,9 @@ Properties for wrapping data
         each subpart :typoscript:`noTrimWrap` will then use the "^" as
         special character.
 
-
     ..  _stdwrap-wrap2:
+
+    ..  rubric:: wrap2
 
     ..  confval:: wrap2
         :name: stdwrap-wrap2
@@ -1397,8 +1468,9 @@ Properties for wrapping data
 
         same as :ref:`stdwrap-wrap`:typoscript:`wrap` (but watch the order in which they are executed)
 
-
     ..  _stdwrap-dataWrap:
+
+    ..  rubric:: dataWrap
 
     ..  confval:: dataWrap
         :name: stdwrap-dataWrap
@@ -1418,8 +1490,9 @@ Properties for wrapping data
         This will produce a :html:`<div>` tag around the content with an id attribute
         that contains the id of the current page.
 
-
     ..  _stdwrap-prepend:
+
+    ..  rubric:: prepend
 
     ..  confval:: prepend
         :name: stdwrap-prepend
@@ -1427,8 +1500,9 @@ Properties for wrapping data
 
         :ref:`stdwrap-cObject` prepended to content (before)
 
-
     ..  _stdwrap-append:
+
+    ..  rubric:: append
 
     ..  confval:: append
         :name: stdwrap-append
@@ -1436,8 +1510,9 @@ Properties for wrapping data
 
         :ref:`stdwrap-cObject` appended to content (after)
 
-
     ..  _stdwrap-wrap3:
+
+    ..  rubric:: wrap3
 
     ..  confval:: wrap3
         :name: stdwrap-wrap3
@@ -1445,8 +1520,9 @@ Properties for wrapping data
 
         same as :typoscript:`wrap` (but watch the order in which they are executed)
 
-
     ..  _stdwrap-orderedStdWrap:
+
+    ..  rubric:: orderedStdWrap
 
     ..  confval:: orderedStdWrap
         :name: stdwrap-orderedStdWrap
@@ -1481,8 +1557,9 @@ Properties for wrapping data
 
         This results in "This is a working solution."
 
-
     ..  _stdwrap-outerWrap:
+
+    ..  rubric:: outerWrap
 
     ..  confval:: outerWrap
         :name: stdwrap-outerWrap
@@ -1490,8 +1567,9 @@ Properties for wrapping data
 
         Wraps the complete content
 
-
     ..  _stdwrap-insertData:
+
+    ..  rubric:: insertData
 
     ..  confval:: insertData
         :name: stdwrap-insertData
@@ -1521,8 +1599,9 @@ Properties for wrapping data
         use this to insert data into wraps. Use :ref:`stdwrap-dataWrap`
         :typoscript:`dataWrap` instead.
 
-
     ..  _stdwrap-postUserFunc:
+
+    ..  rubric:: postUserFunc
 
     ..  confval:: postUserFunc
         :name: stdwrap-postUserFunc
@@ -1565,8 +1644,9 @@ Properties for wrapping data
         calling :typoscript:`cObject`, uses functions from
         :php:`ContentObjectRenderer` class.
 
-
     ..  _stdwrap-postUserFuncInt:
+
+    ..  rubric:: postUserFuncInt
 
     ..  confval:: postUserFuncInt
         :name: stdwrap-postUserFuncInt
@@ -1586,8 +1666,9 @@ Properties for wrapping data
 
         Supplied by Jens Ellerbrock
 
-
     ..  _stdwrap-prefixComment:
+
+    ..  rubric:: prefixComment
 
     ..  confval:: prefixComment
         :name: stdwrap-prefixComment
@@ -1620,6 +1701,8 @@ Properties for sanitizing and caching data
     :type:
 
     ..  _stdwrap-htmlSanitize:
+
+    ..  rubric:: htmlSanitize
 
     ..  confval:: htmlSanitize
         :name: stdwrap-htmlSanitize
@@ -1670,8 +1753,9 @@ Properties for sanitizing and caching data
                 // htmlSanitize.build = TYPO3\CMS\Core\Html\DefaultSanitizerBuilder
             }
 
-
     ..  _stdwrap-cache:
+
+    ..  rubric:: cache
 
     ..  confval:: cache
         :name: stdwrap-cache
@@ -1691,6 +1775,8 @@ Properties for debugging data
 
     ..  _stdwrap-debug:
 
+    ..  rubric:: debug
+
     ..  confval:: debug
         :name: stdwrap-debug
         :type: :ref:`data-type-boolean` / :ref:`stdWrap`
@@ -1702,8 +1788,9 @@ Properties for debugging data
 
        Only use this for debugging during development, otherwise output can break.
 
-
     ..  _stdwrap-debugFunc:
+
+    ..  rubric:: debugFunc
 
     ..  confval:: debugFunc
         :name: stdwrap-debugFunc
@@ -1717,8 +1804,9 @@ Properties for debugging data
 
         Only use this for debugging during development, otherwise output can break.
 
-
     ..  _stdwrap-debugData:
+
+    ..  rubric:: debugData
 
     ..  confval:: debugData
         :name: stdwrap-debugData

--- a/Documentation/PageTsconfig/Mod/WebLayout/BackendLayout.rst
+++ b/Documentation/PageTsconfig/Mod/WebLayout/BackendLayout.rst
@@ -29,10 +29,15 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
 
 ..  confval-menu::
 
+BackendLayouts.[backendLayout]
+------------------------------
+
 ..  confval:: BackendLayouts.[backendLayout]
     :name: mod-web-layout-BackendLayouts
     :type: array:guilabel:`Page` module
     :Path: mod.web_layout.BackendLayouts
+
+    ..  rubric:: title
 
     ..  confval:: title
         :name: mod-web-layout-BackendLayouts-backendLayout-title
@@ -43,6 +48,8 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
 
         ..  figure:: /Images/ManualScreenshots/BackendLayouts/PageProperties.png
             :caption: Choose the backend layout in the page properties
+
+    ..  rubric:: icon
 
     ..  confval:: icon
         :name: mod-web-layout-BackendLayouts-backendLayout-icon
@@ -57,7 +64,11 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
                 icon = EXT:bootstrap_package/Resources/Public/Icons/BackendLayouts/subnavigation_right_2_columns.svg
             }
 
+    ..  rubric:: config.backend_layout
+
     ..  confval:: config.backend_layout
+
+        ..  rubric:: colCount
 
         ..  confval:: colCount
             :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout.colCount
@@ -65,13 +76,19 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
 
             The total number of columns in the backend layout.
 
+        ..  rubric:: rowCount
+
         ..  confval:: rowCount
             :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout.rowCount
             :type: integer
 
             The total number of rows in the backend layout.
 
+        ..  rubric:: rows.[row].columns.[col]
+
         ..  confval:: rows.[row].columns.[col]
+
+            ..  rubric:: name
 
             ..  confval:: name
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-name
@@ -80,11 +97,15 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
                 The name of the input area where content elements can be added. Will be
                 displayed in the :guilabel:`Page` module.
 
+            ..  rubric:: colPos
+
             ..  confval:: colPos
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-colPos
                 :type: integer, 0 - maxInt
 
                 If content elements have been  added to this area, the value of `colPos`
+
+            ..  rubric:: identifier
 
             ..  confval:: identifier
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-identifier
@@ -96,6 +117,8 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
 
                 It is a more meaningful representation than just :confval:`colPos <mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-colPos>`,
                 such as "main", "sidebar" and "footerArea".
+
+            ..  rubric:: slideMode
 
             ..  confval:: slideMode
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-slideMode
@@ -112,12 +135,16 @@ package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/
                 `collectReverse`
                     The same as "collect", but in the opposite order
 
+            ..  rubric:: colspan
+
             ..  confval:: colspan
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-colspan
                 :type: integer, 1 - :confval:`mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout.colCount`
 
                 Can be used if the content element area should span multiple
                 columns as in the "Jumbotron" example above.
+
+            ..  rubric:: rowspan
 
             ..  confval:: rowspan
                 :name: mod-web-layout-BackendLayouts-backendLayout-title-config-backend_layout-rows-row-columns-col-rowspan

--- a/Documentation/PageTsconfig/Mod/Wizards.rst
+++ b/Documentation/PageTsconfig/Mod/Wizards.rst
@@ -29,6 +29,8 @@ newContentElement.wizardItems
 ..  confval-menu::
     :display: tree
 
+    ..  rubric:: newContentElement.wizardItems
+
     ..  confval:: newContentElement.wizardItems
         :name: mod-wizards-newContentElement-wizardItems
         :type: array
@@ -41,6 +43,8 @@ newContentElement.wizardItems
         ..  versionchanged:: 13.0
             The group `common` was renamed to `default`. A permanent migration is in
             place.
+
+        ..  rubric:: removeItems
 
         ..  confval:: removeItems
             :name: mod-wizards-newContentElement-wizardItems-removeItems
@@ -57,12 +61,16 @@ newContentElement.wizardItems
                 # This will remove the "menu" group
                 mod.wizards.newContentElement.wizardItems.removeItems := addToList(menu)
 
+        ..  rubric:: [group].before
+
         ..  confval:: [group].before
             :name: mod-wizards-newContentElement-wizardItems-group-before
             :type: string
             :Path: mod.wizards.newContentElement.wizardItems.[group].before
 
             Sorts [group] in front of the group given.
+
+        ..  rubric:: [group].after
 
         ..  confval:: [group].after
             :name: mod-wizards-newContentElement-wizardItems-group-after
@@ -71,12 +79,16 @@ newContentElement.wizardItems
 
             Sorts [group] after the group given.
 
+        ..  rubric:: [group].header
+
         ..  confval:: [group].header
             :name: mod-wizards-newContentElement-wizardItems-group-header
             :type: plain text label or `label reference <https://docs.typo3.org/permalink/t3coreapi:label-reference>`_
             :Path: mod.wizards.newContentElement.wizardItems.[group].header
 
             Name of the group.
+
+        ..  rubric:: [group].show
 
         ..  confval:: [group].show
             :name: mod-wizards-newContentElement-wizardItems-group-show
@@ -98,12 +110,16 @@ newContentElement.wizardItems
                 :confval:`[group].removeItems <mod-wizards-newContentElement-wizardItems-group-removeItems>`
                 options.
 
+        ..  rubric:: [group].elements
+
         ..  confval:: [group].elements
             :name: mod-wizards-newContentElement-wizardItems-group-elements
             :type: array
             :Path: mod.wizards.newContentElement.wizardItems.[group].elements
 
             List of items in the group.
+
+            ..  rubric:: [name]
 
             ..  confval:: [name]
                 :name: mod-wizards-newContentElement-wizardItems-group-elements-name
@@ -112,12 +128,16 @@ newContentElement.wizardItems
 
                 Configuration for a single item.
 
+                ..  rubric:: iconIdentifier
+
                 ..  confval:: iconIdentifier
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-iconIdentifier
                     :type: string
                     :Path: mod.wizards.newContentElement.wizardItems.[group].elements.[name].iconIdentifier
 
                     The icon identifier of the icon you want to display.
+
+                ..  rubric:: iconOverlay
 
                 ..  confval:: iconOverlay
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-iconOverlay
@@ -126,12 +146,16 @@ newContentElement.wizardItems
 
                     The icon identifier of the overlay icon you want to use.
 
+                ..  rubric:: title
+
                 ..  confval:: title
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-title
                     :type: plain text label or `label reference <https://docs.typo3.org/permalink/t3coreapi:label-reference>`_
                     :Path: mod.wizards.newContentElement.wizardItems.[group].elements.[name].title
 
                     Name of the item.
+
+                ..  rubric:: description
 
                 ..  confval:: description
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-description
@@ -140,12 +164,16 @@ newContentElement.wizardItems
 
                     Description text for the item.
 
+                ..  rubric:: tt_content_defValues
+
                 ..  confval:: tt_content_defValues
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-tt_content_defValues
                     :type: array
                     :Path: mod.wizards.newContentElement.wizardItems.[group].elements.[name].tt_content_defValues
 
                     Default values for tt_content fields.
+
+                ..  rubric:: saveAndClose
 
                 ..  confval:: saveAndClose
                     :name: mod-wizards-newContentElement-wizardItems-group-elements-name-saveAndClose
@@ -155,6 +183,8 @@ newContentElement.wizardItems
 
                     If `true`, directs the user back to the :guilabel:`Page` module
                     directly instead of showing the FormEngine.
+
+        ..  rubric:: [group].removeItems
 
         ..  confval:: [group].removeItems
             :name: mod-wizards-newContentElement-wizardItems-group-removeItems

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -127,6 +127,8 @@ Properties of 'config'
         Finally, a "Content-Length" header is sent, if enabled via
         :ref:`setup-config-enablecontentlengthheader`.
 
+    ..  rubric:: admPanel
+
     ..  confval:: admPanel
         :name: config-admPanel
         :type: boolean
@@ -134,11 +136,15 @@ Properties of 'config'
         :typoscript:`config.admPanel = 1` enables the admin panel. See
         :ref:`Configuration in the Admin Panel manual <ext_adminpanel:typoscript-config-admpanel>`.
 
+    ..  rubric:: ATagParams
+
     ..  confval:: ATagParams
         :name: config-ATagParams
         :type: *<A>-params*
 
         Additional parameters for all links in TYPO3 (excluding menu-links).
+
+    ..  rubric:: cache
 
     ..  confval:: cache
         :name: config-cache
@@ -171,6 +177,8 @@ Properties of 'config'
         Use the keyword "current" instead of a <storage-pid> to take only records
         on the current page into account for the cache lifetime calculation.
 
+    ..  rubric:: cache_clearAtMidnight
+
     ..  confval:: cache_clearAtMidnight
         :name: config-cache-clearAtMidnight
         :type: :ref:`data-type-boolean`
@@ -179,6 +187,7 @@ Properties of 'config'
         This setting ensures that the cache expires at midnight on the day that the
         page is scheduled to expire.
 
+    ..  rubric:: cache_period
 
     ..  confval:: cache_period
         :name: config-cache-period
@@ -322,6 +331,8 @@ Properties of 'config'
         To get rid of the error message, the error needs to be fixed
         and the cache must be cleared for the page.
 
+    ..  rubric:: debug
+
     ..  confval:: debug
         :name: config-debug
         :type: :ref:`data-type-boolean`
@@ -329,6 +340,8 @@ Properties of 'config'
         If set, debug information for the TypoScript code is sent.
         This applies to menu objects and parse-time output.
         The parse-time will be sent in HTTP response header `X-TYPO3-Parsetime`.
+
+    ..  rubric:: disableAllHeaderCode
 
     ..  confval:: disableAllHeaderCode
         :name: config-disableAllHeaderCode
@@ -350,6 +363,8 @@ Properties of 'config'
         This property can also be used to generate complete HTML pages,
         including the :html:`<html>` and :html:`<body>` tags.
 
+    ..  rubric:: disableBodyTag
+
     ..  confval:: disableBodyTag
         :name: config-disableBodyTag
         :type: :ref:`data-type-boolean`
@@ -365,6 +380,8 @@ Properties of 'config'
         :typoscript:`config.disableBodyTag = 1` then the other settings are ignored
         and won't have any effect.
 
+    ..  rubric:: disableCanonical
+
     ..  confval:: disableCanonical
         :name: config-disableCanonical
         :type: :ref:`data-type-boolean`
@@ -374,6 +391,8 @@ Properties of 'config'
         in many cases by default. For edge cases, you might want to disable the
         rendering of this tag by setting it to `1`.
 
+    ..  rubric:: disableHrefLang
+
     ..  confval:: disableHrefLang
         :name: config-disableHrefLang
         :type: :ref:`data-type-boolean`
@@ -381,6 +400,8 @@ Properties of 'config'
         If the SEO system extension is installed, hreflang tags are generated
         in multi-language setups. By settings this option to `1`
         the rendering of the tags will be skipped.
+
+    ..  rubric:: disablePrefixComment
 
     ..  confval:: disablePrefixComment
         :name: config-disablePrefixComment
@@ -390,12 +411,16 @@ Properties of 'config'
         preventing any potentially revealing and space-consuming comments in the HTML
         source code.
 
+    ..  rubric:: disablePreviewNotification
+
     ..  confval:: disablePreviewNotification
         :name: config-disablePreviewNotification
         :type: :ref:`data-type-boolean`
         :Default: `0`
 
         Disables the "preview" notification box.
+
+    ..  rubric:: disableLanguageHeader
 
     ..  confval:: disableLanguageHeader
         :name: config-disableLanguageHeader
@@ -408,6 +433,8 @@ Properties of 'config'
         :ref:`Site Configuration <t3coreapi:sitehandling>`.
 
         If :typoscript:`config.disableLanguageHeader` is set, this header will not be sent.
+
+    ..  rubric:: doctype
 
     ..  confval:: doctype
         :name: config-doctype
@@ -441,6 +468,8 @@ Properties of 'config'
 
             <!DOCTYPE html>
 
+    ..  rubric:: enableContentLengthHeader
+
     ..  confval:: enableContentLengthHeader
         :name: config-enableContentLengthHeader
         :type: :ref:`data-type-boolean`
@@ -453,6 +482,8 @@ Properties of 'config'
         objects and the content-length will truncate the length of the
         document in some browsers.
 
+    ..  rubric:: extTarget
+
     ..  confval:: extTarget
         :name: config-extTarget
         :type: target
@@ -460,11 +491,15 @@ Properties of 'config'
 
         Default external target. Used by :ref:`typolink` if no extTarget is set.
 
+    ..  rubric:: fileTarget
+
     ..  confval:: fileTarget
         :name: config-fileTarget
         :type: target
 
         Default file link target. Used by :ref:`typolink` if no fileTarget is set.
+
+    ..  rubric:: forceAbsoluteUrls
 
     ..  confval:: forceAbsoluteUrls
         :name: config-forceAbsoluteUrls
@@ -484,6 +519,8 @@ Properties of 'config'
             <setup-config-absrefprefix>` and any typolink
             :ref:`typolink-forceAbsoluteUrl` options.
 
+    ..  rubric:: forceTypeValue
+
     ..  confval:: forceTypeValue
         :name: config-forceTypeValue
         :type: :ref:`data-type-boolean`
@@ -494,6 +531,8 @@ Properties of 'config'
         This is useful if you have a template with special content, for example
         `&type=95`, but still want to keep your targets neutral. Then you can
         set your targets to blank and this value to your required type value.
+
+    ..  rubric:: headerComment
 
     ..  confval:: headerComment
         :name: config-headerComment
@@ -531,6 +570,7 @@ Properties of 'config'
         If you have set `htmlTag.attributes` this property (`htmlTag_setParams`)
         will not have any effect.
 
+    ..  rubric:: htmlTag_stdWrap
 
     ..  confval:: htmlTag_stdWrap
         :name: config-htmlTag-stdWrap
@@ -538,6 +578,8 @@ Properties of 'config'
 
         Modify the :html:`<html>` tag with stdWrap functionality. Use
         this property to extend or override this tag.
+
+    ..  rubric:: index_descrLgd
 
     ..  confval:: index_descrLgd
         :name: config-index-descrLgd
@@ -547,6 +589,8 @@ Properties of 'config'
         This indicates how many chars to preserve in the description of an
         indexed page. This can be used in search result output.
 
+    ..  rubric:: index_enable
+
     ..  confval:: index_enable
         :name: config-index-enable
         :type: :ref:`data-type-boolean`
@@ -554,6 +598,8 @@ Properties of 'config'
         Enables cached pages to be indexed.
 
         Automatically enabled when :t3-ext:`indexed_search` is enabled.
+
+    ..  rubric:: index_externals
 
     ..  confval:: index_externals
         :name: config-index-externals
@@ -563,6 +609,8 @@ Properties of 'config'
 
         Automatically enabled when :t3-ext:`indexed_search` is enabled.
 
+    ..  rubric:: index_metatags
+
     ..  confval:: index_metatags
         :name: config-index-metatags
         :type: :ref:`data-type-boolean`
@@ -570,6 +618,8 @@ Properties of 'config'
 
         This allows the indexing of metatags to be switched on or off. It is
         switched on by default.
+
+    ..  rubric:: inlineStyle2TempFile
 
     ..  confval:: inlineStyle2TempFile
         :name: config-inlineStyle2TempFile
@@ -582,6 +632,8 @@ Properties of 'config'
         the header then contains just a link to the stylesheet.
 
         The file hash is based on the content of the styles.
+
+    ..  rubric:: intTarget
 
     ..  confval:: intTarget
         :name: config-intTarget
@@ -622,12 +674,16 @@ Properties of 'config'
             Do **not** include the `type` and `L` parameters in the linkVars
             list as this will result in unexpected behavior.
 
+    ..  rubric:: message_preview
+
     ..  confval:: message_preview
         :name: config-message_preview
         :type: :ref:`data-type-string`
 
         Alternative message in HTML that appears when the preview function is
         active.
+
+    ..  rubric:: message_preview_workspace
 
     ..  confval:: message_preview_workspace
         :name: config-message-preview-workspace
@@ -638,6 +694,7 @@ Properties of 'config'
         active in a draft workspace. You can use sprintf() placeholders for
         Workspace title (first) and number (second).
 
+    ..  rubric:: moveJsFromHeaderToFooter
 
     ..  confval:: moveJsFromHeaderToFooter
         :name: config-moveJsFromHeaderToFooter
@@ -647,7 +704,7 @@ Properties of 'config'
         bottom of the HTML document, which is after the content and before the
         closing body tag.
 
-
+    ..  rubric:: MP_defaults
 
     ..  confval:: MP_defaults
         :name: config-MP-defaults
@@ -664,6 +721,7 @@ Properties of 'config'
         can ensure consistency and reduce the risk of broken links or incorrect
         content being displayed due to missing parameters.
 
+    ..  rubric:: MP_disableTypolinkClosestMPvalue
 
     ..  confval:: MP_disableTypolinkClosestMPvalue
         :name: config-MP-disableTypolinkClosestMPvalue
@@ -671,6 +729,8 @@ Properties of 'config'
 
         If set, the :ref:`typolink` function will not try to find the closest MP
         value for the id.
+
+    ..  rubric:: MP_mapRootPoints
 
     ..  confval:: MP_mapRootPoints
         :name: config-MP-mapRootPoints
@@ -693,6 +753,8 @@ Properties of 'config'
 
         Configured IDs have to be the uids of actual mount point pages, not the targets.
 
+    ..  rubric:: namespaces.[identifier]
+
     ..  confval:: namespaces.[identifier]
         :name: config-namespaces
         :type: string
@@ -701,6 +763,8 @@ Properties of 'config'
         This property enables you to add XML namespaces (`xmlns`) to the :html:`<html>`
         tag. This is especially useful if you want to add RDFa or microformats
         to your HTML.
+
+    ..  rubric:: no_cache
 
     ..  confval:: no_cache
         :name: config-no-cache
@@ -722,6 +786,8 @@ Properties of 'config'
         For more information about cache types see the
         :ref:`cache types chapter <t3coreapi:caching-architecture-core>`.
 
+    ..  rubric:: noPageTitle
+
     ..  confval:: noPageTitle
         :name: config-noPageTitle
         :type: :ref:`data-type-integer`
@@ -736,6 +802,8 @@ Properties of 'config'
         output, so you should only disable this tag if you have already
         generated it manually.
 
+    ..  rubric:: pageRendererTemplateFile
+
     ..  confval:: pageRendererTemplateFile
         :name: config-pageRendererTemplateFile
         :type: :ref:`data-type-string`
@@ -744,12 +812,16 @@ Properties of 'config'
         Sets the template for page renderer class
         :php:`TYPO3\CMS\Core\Page\PageRenderer`.
 
+    ..  rubric:: pageTitle
+
     ..  confval:: pageTitle
         :name: config-pageTitle
         :type: :ref:`stdwrap`
 
         stdWrap for the page title. This option will be executed *after* all
         other processing options like :ref:`setup-config-pageTitleFirst`.
+
+    ..  rubric:: pageTitleFirst
 
     ..  confval:: pageTitleFirst
         :name: config-pageTitleFirst
@@ -763,6 +835,8 @@ Properties of 'config'
         If :typoscript:`pageTitleFirst` is set (and if the page title is printed), then the
         page title will be printed before the template title, i.e. "page title: website".
 
+    ..  rubric:: pageTitleProviders
+
     ..  confval:: pageTitleProviders
         :name: config-pageTitleProviders
         :type: array
@@ -773,6 +847,8 @@ Properties of 'config'
         Based on the priority of providers, :php:`PageTitleProviderManager` will
         check the providers to see if they have titles. It will start with the
         highest priority :typoscript:`PageTitleProviders`.
+
+    ..  rubric:: pageTitleSeparator
 
     ..  confval:: pageTitleSeparator
         :name: config-pageTitleSeparator
@@ -785,6 +861,8 @@ Properties of 'config'
         sub-properties are defined, then a space will be added to the end of the
         separator. stdWrap can be used to adjust whitespace at the beginning and
         end of the separator.
+
+    ..  rubric:: recordLinks
 
     ..  confval:: recordLinks
         :name: config-recordLinks
@@ -806,6 +884,8 @@ Properties of 'config'
                 }
             }
 
+    ..  rubric:: removeDefaultCss
+
     ..  confval:: removeDefaultCss
         :name: config-removeDefaultCss
         :type: :ref:`data-type-boolean`
@@ -815,6 +895,8 @@ Properties of 'config'
         <setup-plugin-css-default-style>` extension property.
         (:typoscript:`_CSS_DEFAULT_STYLE` outputs a set of default styles for
         extensions with frontend plugins)
+
+    ..  rubric:: removeDefaultJS
 
     ..  confval:: removeDefaultJS
         :name: config-removeDefaultJS
@@ -828,6 +910,8 @@ Properties of 'config'
         **Special case:** If the value is set to the string `external`, then the default
         JavaScript is written to a temporary file and included in that file.
         See :ref:`setup-config-inlineStyle2TempFile`.
+
+    ..  rubric:: sendCacheHeaders
 
     ..  confval:: sendCacheHeaders
         :name: config-sendCacheHeaders
@@ -869,6 +953,8 @@ Properties of 'config'
          both browser- and reverse-proxy caches and make TYPO3 regenerate
          the page. A good tip worth knowing about!
 
+    ..  rubric:: sendCacheHeadersForSharedCaches
+
     ..  confval:: sendCacheHeadersForSharedCaches
         :name: config-sendCacheHeadersForSharedCaches
         :type: `auto`, `force`, or empty
@@ -901,6 +987,8 @@ Properties of 'config'
         See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control
         for details and whether your reverse proxy supports this directive.
 
+    ..  rubric:: showWebsiteTitle
+
     ..  confval:: showWebsiteTitle
         :name: config-showWebsiteTitle
         :type: :ref:`data-type-boolean`
@@ -912,6 +1000,8 @@ Properties of 'config'
 
         By default, the website title is added. To omit the website title, set the
         option to `0`.
+
+    ..  rubric:: spamProtectEmailAddresses
 
     ..  confval:: spamProtectEmailAddresses
         :name: config-spamProtectEmailAddresses
@@ -933,6 +1023,8 @@ Properties of 'config'
         Default JavaScript needs to be enabled.
         (see :ref:`removeDefaultJS <setup-config-removedefaultjs>`)
 
+    ..  rubric:: spamProtectEmailAddresses_atSubst
+
     ..  confval:: spamProtectEmailAddresses_atSubst
         :name: config-spamProtectEmailAddresses-atSubst
         :type: :ref:`data-type-string`
@@ -941,6 +1033,8 @@ Properties of 'config'
 
         Substitute label for the at-sign (`@`).
 
+    ..  rubric:: spamProtectEmailAddresses_lastDotSubst
+
     ..  confval:: spamProtectEmailAddresses_lastDotSubst
         :name: config-spamProtectEmailAddresses-lastDotSubst
         :type: :ref:`data-type-string`
@@ -948,6 +1042,8 @@ Properties of 'config'
         :Example: :ref:`setup-config-spamprotectemailaddresses-lastdotsubst`
 
         Substitute label for the last dot in the email address.
+
+    ..  rubric:: tx_[extension key with no underscores]_[*]
 
     ..  confval:: tx_[extension key with no underscores]_[*]
         :name: config-tx-extension-key-with-no-underscores
@@ -958,6 +1054,8 @@ Properties of 'config'
         have TypoScript configuration, but that don't display anything in the frontend
         (i.e. don't receive their configuration as an argument from the frontend
         rendering process).
+
+    ..  rubric:: typolinkLinkAccessRestrictedPages
 
     ..  confval:: typolinkLinkAccessRestrictedPages
         :name: config-typolinkLinkAccessRestrictedPages
@@ -977,6 +1075,8 @@ Properties of 'config'
         See :confval:`menu-common-properties-showaccessrestrictedpages`
         for menu objects as well (similar feature for menus)
 
+    ..  rubric:: typolinkLinkAccessRestrictedPages.ATagParams
+
     ..  confval:: typolinkLinkAccessRestrictedPages.ATagParams
         :name: config-typolinkLinkAccessRestrictedPages-ATagParams
         :type: :ref:`data-type-string`
@@ -985,12 +1085,16 @@ Properties of 'config'
         `typolinkLinkAccessRestrictedPages.ATagParams` Add custom attributes to
         the anchor tag.
 
+    ..  rubric:: typolinkLinkAccessRestrictedPages_addParams
+
     ..  confval:: typolinkLinkAccessRestrictedPages_addParams
         :name: config-typolinkLinkAccessRestrictedPages-addParams
         :type: :ref:`data-type-string`
         :Example: :ref:`setup-config-typolinklinkaccessrestrictedpages`
 
         See :ref:`setup-config-typolinklinkaccessrestrictedpages` above.
+
+    ..  rubric:: typolinkLinkAccessRestrictedPages_xmlprologue
 
     ..  confval:: typolinkLinkAccessRestrictedPages_xmlprologue
         :name: config-typolinkLinkAccessRestrictedPages-xmlprologue

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -184,6 +184,8 @@ Properties
     :display: table
     :type:
 
+    ..  rubric:: 1,2,3,4...
+
     ..  confval:: 1,2,3,4...
         :name: page-array
         :type: :ref:`cObject <data-type-cobject>`
@@ -205,6 +207,8 @@ Properties
         in the future. Therefore you will often see that people use the number
         10 and no number 1 is found.
 
+    ..  rubric:: bodyTag
+
     ..  confval:: bodyTag
         :name: page-bodyTag
         :type: string
@@ -212,6 +216,8 @@ Properties
         :Example: :ref:`Set a class on the body tag <setup-page-bodytag-example>`
 
         Body tag on the page
+
+    ..  rubric:: bodyTagAdd
 
     ..  confval:: bodyTagAdd
         :name: page-bodyTagAdd
@@ -221,6 +227,8 @@ Properties
         This content is added inside of the opening :html:`<body>` tag right
         before the :html:`>` character. This is mostly useful for adding
         attributes to the :html:`<body>` tag.
+
+    ..  rubric:: bodyTagCObject
 
     ..  confval:: bodyTagCObject
         :name: page-bodyTagCObject
@@ -235,6 +243,8 @@ Properties
             which, if set, disables body tag generation independently
             from what might be set here.
 
+    ..  rubric:: config
+
     ..  confval:: config
         :name: page-config
         :type: :ref:`->CONFIG <config>`
@@ -246,6 +256,8 @@ Properties
          Configuration for the page. Any entries made here override the same
          entries in the top-level object :ref:`config`.
 
+    ..  rubric:: cssInline.[array]
+
     ..  confval:: cssInline.[array]
         :name: page-cssInline
         :type: :ref:`cObject <data-type-cobject>`
@@ -254,6 +266,8 @@ Properties
         Allows to add inline CSS to the page :html:`<head>` section.
         The :typoscript:`cssInline` property contains any number of numeric keys, each representing one cObject.
         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
+
+    ..  rubric:: footerData.[array]
 
     ..  confval:: footerData.[array]
         :name: page-footerData
@@ -266,6 +280,8 @@ Properties
 
         The :typoscript:`footerData` property contains any number of numeric keys, each representing one cObject.
         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
+
+    ..  rubric:: headerData.[array]
 
     ..  confval:: headerData.[array]
         :name: page-headerData
@@ -286,12 +302,16 @@ Properties
         The :typoscript:`headerData` property contains any number of numeric keys, each representing one cObject.
         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
 
+    ..  rubric:: headTag
+
     ..  confval:: headTag
         :name: page-headTag
         :type: string / :ref:`stdwrap`
         :Default: `<head>`
 
         Head-tag if alternatives are wanted
+
+    ..  rubric:: includeCSS.[array]
 
     ..  confval:: includeCSS.[array]
         :name: page-includeCSS
@@ -343,6 +363,8 @@ Properties
 
         Additional data attributes can be configured using a key-value list.
 
+    ..  rubric:: includeCSSLibs.[array]
+
     ..  confval:: includeCSSLibs.[array]
         :name: page-includeCSSLibs
         :type: :ref:`data-type-resource`
@@ -388,6 +410,8 @@ Properties
             Setting the title of the :html:`<style>` tag.
 
         Additional data attributes can be configured using a key-value list.
+
+    ..  rubric:: includeJS.[array]
 
     ..  confval:: includeJS.[array]
         :name: page-includeJS
@@ -459,6 +483,8 @@ Properties
             Array with key/value for additional attributes to be added to
             the script tag.
 
+    ..  rubric:: includeJSFooter.[array]
+
     ..  confval:: includeJSFooter.[array]
         :name: page-includeJSFooter
         :type: :ref:`data-type-resource`
@@ -468,6 +494,8 @@ Properties
         Same as :confval:`includeJS <page-includeJS>` above, except that this block gets
         included at the bottom of the page (just before the closing :html:`</body>`
         tag).
+
+    ..  rubric:: includeJSFooterlibs.[array]
 
     ..  confval:: includeJSFooterlibs.[array]
         :name: page-includeJSFooterlibs
@@ -495,6 +523,8 @@ Properties
                 somefile.foo = bar
             }
 
+    ..  rubric:: includeJSLibs.[array]
+
     ..  confval:: includeJSLibs.[array]
         :name: page-includeJSLibs
         :type: :ref:`data-type-resource`
@@ -521,6 +551,8 @@ Properties
                 somefile.foo = bar
             }
 
+    ..  rubric:: inlineLanguageLabelFiles
+
     ..  confval:: inlineLanguageLabelFiles
         :name: page-inlineLanguageLabelFiles
         :type: (array of strings)
@@ -544,6 +576,8 @@ Properties
             0 - syslog entry, 1 - do nothing, 2 - throw an exception.
             Default: 0
 
+    ..  rubric:: inlineSettings
+
     ..  confval:: inlineSettings
         :name: page-inlineSettings
         :type: (array of strings)
@@ -551,6 +585,8 @@ Properties
 
         Adds settings to the page as inline javascript, which is accessible within
         the JavaScript object :js:`TYPO3.settings`.
+
+    ..  rubric:: jsFooterInline.[array]
 
     ..  confval:: jsFooterInline.[array]
         :name: page-jsFooterInline
@@ -562,6 +598,8 @@ Properties
 
         The :typoscript:`jsFooterInline` property contains any number of numeric keys, each representing one cObject.
         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
+
+    ..  rubric:: jsInline.[array]
 
     ..  confval:: jsInline.[array]
         :name: page-jsInline
@@ -577,6 +615,8 @@ Properties
 
         The :typoscript:`jsInline` property contains any number of numeric keys, each representing one cObject.
         Internally handled as PHP integer, maximum number is therefore restricted to :php:`PHP_INT_MAX`.
+
+    ..  rubric:: meta
 
     ..  confval:: meta
         :name: page-meta
@@ -613,6 +653,8 @@ Properties
             to 0 (default), the meta tag generated by the plugin will be used. If
             there is none yet, the one from TypoScript is set.
 
+    ..  rubric:: shortcutIcon
+
     ..  confval:: shortcutIcon
         :name: page-shortcutIcon
         :type: :ref:`data-type-resource`
@@ -626,11 +668,15 @@ Properties
 
         If the file is missing no tag will be rendered.
 
+    ..  rubric:: stdWrap
+
     ..  confval:: stdWrap
         :name: page-stdWrap
         :type: :ref:`stdwrap`
 
         Wraps the content of the cObject array with :ref:`stdwrap` options.
+
+    ..  rubric:: typeNum
 
     ..  confval:: typeNum
         :name: page-typeNum
@@ -645,6 +691,8 @@ Properties
         determines, which page object will be rendered. The value defaults to 0 for
         the first found :typoscript:`PAGE` object, but it **must** be set and be unique as
         soon as you use *more* than one such object.
+
+    ..  rubric:: wrap
 
     ..  confval:: wrap
         :name: page-wrap

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -36,11 +36,15 @@ Properties for all frontend plugin types
     :display: table
     :type:
 
+    ..  rubric:: userFunc
+
     ..  confval:: userFunc
         :name: plugin-userFunc
         :type: (array of keys)
 
         Property setting up the :ref:`cobj-user` object of the plugin.
+
+    ..  rubric:: _CSS_DEFAULT_STYLE
 
     ..  confval:: _CSS_DEFAULT_STYLE
         :name: plugin-css-default-style
@@ -97,6 +101,8 @@ plugins.
     :display: table
     :type:
 
+    ..  rubric:: ignoreFlexFormSettingsIfEmpty
+
     ..  confval:: ignoreFlexFormSettingsIfEmpty
         :name: plugin-ignoreFlexFormSettingsIfEmpty
         :type: :ref:`data-type-string`
@@ -111,12 +117,16 @@ plugins.
         available to further manipulate the merged configuration after standard
         override logic is applied.
 
+    ..  rubric:: persistence
+
     ..  confval:: persistence
         :name: plugin-persistence
         :type: array of settings
         :Example: :ref:`Set recursive storage PID for Extbase plugin <setup-plugin-persistence-storagePid-example>`
 
         Settings, relevant to the persistence layer of Extbase.
+
+    ..  rubric:: persistence.enableAutomaticCacheClearing
 
     ..  confval:: persistence.enableAutomaticCacheClearing
         :name: plugin-persistence-enableAutomaticCacheClearing
@@ -127,6 +137,8 @@ plugins.
         Enables the automatic cache clearing when changing data sets (see also
         :ref:`t3coreapi:extbase_caching`).
 
+    ..  rubric:: persistence.storagePid
+
     ..  confval:: persistence.storagePid
         :name: plugin-persistence-storagePid
         :type: :ref:`data-type-string` (comma separated list of integers)
@@ -134,6 +146,8 @@ plugins.
 
         **Only for Extbase plugins**. List of page IDs, from which all records
         are read.
+
+    ..  rubric:: persistence.classes.[classname].newRecordStoragePid
 
     ..  confval:: persistence.classes.[classname].newRecordStoragePid
         :name: plugin-persistence-classes-classname-newRecordStoragePid
@@ -143,6 +157,8 @@ plugins.
         **Only for Extbase plugins**. Page ID, where new records for objects
         of the class `[classname]` are stored.
 
+    ..  rubric:: persistence.recursive
+
     ..  confval:: persistence.recursive
         :name: plugin-persistence-recursive
         :type: :ref:`data-type-integer`
@@ -150,6 +166,8 @@ plugins.
 
         **Only for Extbase plugins**. Number of sub-levels of the
         storagePid are read.
+
+    ..  rubric:: view.[settings]
 
     ..  confval:: view.[settings]
         :name: plugin-view
@@ -164,6 +182,8 @@ plugins.
         The root paths work just like the one in the
         :ref:`FLUIDTEMPLATE <cobj-fluidtemplate-properties-templaterootpaths>`.
 
+    ..  rubric:: view.layoutRootPaths.[array]
+
     ..  confval:: view.layoutRootPaths.[array]
         :name: plugin-view-layoutRootPaths
         :type: :ref:`data-type-string`
@@ -173,6 +193,8 @@ plugins.
         for all Fluid layouts. If nothing is specified, the path
         :file:`EXT:my_extension/Resources/Private/Layouts` is used.
 
+    ..  rubric:: view.partialRootPaths.[array]
+
     ..  confval:: view.partialRootPaths.[array]
         :name: plugin-view-partialRootPaths
         :type: :ref:`data-type-string`
@@ -181,6 +203,8 @@ plugins.
         **Only for Extbase plugins**. This can be used to specify the root
         paths for all Fluid partials. If nothing is specified, the path
         :file:`EXT:my_extension/Resources/Private/Partials` is used.
+
+    ..  rubric:: view.templateRootPaths.[array]
 
     ..  confval:: view.templateRootPaths.[array]
         :name: plugin-view-templateRootPaths
@@ -192,6 +216,8 @@ plugins.
         plugin. If nothing is specified, the path
         :file:`EXT:my_extension/Resources/Private/Templates` is used.
 
+    ..  rubric:: view.pluginNamespace
+
     ..  confval:: view.pluginNamespace
         :name: plugin-view-pluginNamespace
         :type: :ref:`data-type-string`
@@ -201,11 +227,15 @@ plugins.
         Use this to shorten the Extbase default plugin namespace or to access
         arguments from other extensions by setting this option to their namespace.
 
+    ..  rubric:: mvc.[setting]
+
     ..  confval:: mvc.[setting]
         :name: plugin-mvc
         :type: array of settings
 
         **Only for Extbase plugins**. These are useful MVC settings about error handling:
+
+    ..  rubric:: mvc.callDefaultActionIfActionCantBeResolved
 
     ..  confval:: mvc.callDefaultActionIfActionCantBeResolved
         :name: plugin-mvc-callDefaultActionIfActionCantBeResolved
@@ -216,6 +246,8 @@ plugins.
         **Only for Extbase plugins**. If set, causes the controller to show
         its default action if the called action is not allowed by the controller.
 
+    ..  rubric:: mvc.throwPageNotFoundExceptionIfActionCantBeResolved
+
     ..  confval:: mvc.throwPageNotFoundExceptionIfActionCantBeResolved
         :name: plugin-mvc-throwPageNotFoundExceptionIfActionCantBeResolved
         :type: :ref:`data-type-boolean`
@@ -224,6 +256,8 @@ plugins.
 
         Same as :ref:`setup-plugin-mvc-callDefaultActionIfActionCantBeResolved`
         but this will raise a "page not found" error.
+
+    ..  rubric:: mvc.showPageNotFoundIfTargetNotFoundException
 
     ..  confval:: mvc.showPageNotFoundIfTargetNotFoundException
         :name: plugin-mvc-showPageNotFoundIfTargetNotFoundException
@@ -242,6 +276,8 @@ plugins.
         scope, or also plugin-specific via
         `plugin.tx_yourextension.mvc.showPageNotFoundIfTargetNotFoundException` /
         `plugin.tx_yourextension_pluginName.mvc.showPageNotFoundIfTargetNotFoundException`.
+
+    ..  rubric:: mvc.showPageNotFoundIfRequiredArgumentIsMissingException
 
     ..  confval:: mvc.showPageNotFoundIfRequiredArgumentIsMissingException
         :name: plugin-mvc-showPageNotFoundIfRequiredArgumentIsMissingException
@@ -264,6 +300,8 @@ plugins.
         :php:`ActionController->handleArgumentMappingExceptions()` to individually operate
         on invalid arguments.
 
+    ..  rubric:: format
+
     ..  confval:: format
         :name: plugin-format
         :type: :ref:`data-type-string`
@@ -276,6 +314,8 @@ plugins.
 
         Define the default file ending of the template files. The template files
         have to take care of creating the desired format output.
+
+    ..  rubric:: _LOCAL_LANG.[lang-key].[label-key]
 
     ..  confval:: _LOCAL_LANG.[lang-key].[label-key]
         :name: plugin-local-lang
@@ -297,6 +337,8 @@ plugins.
         TypoScript. The :file:`locallang.xlf` file in
         the plugin folder in the file system can be used to get an overview of
         the entries the extension uses.
+
+    ..  rubric:: settings.[setting]
 
     ..  confval:: settings.[setting]
         :name: plugin-settings

--- a/Documentation/UserTsconfig/Auth.rst
+++ b/Documentation/UserTsconfig/Auth.rst
@@ -32,6 +32,9 @@ Properties
 
 ..  _user-auth-mfa-required:
 
+auth.mfa.required
+-----------------
+
 ..  confval:: auth.mfa.required
     :name: user-auth-mfa-required
     :type: boolean
@@ -46,6 +49,9 @@ Properties
 
 ..  _user-auth-mfa-disableProviders:
 
+auth.mfa.disableProviders
+-------------------------
+
 ..  confval:: auth.mfa.disableProviders
     :name: auth.mfa.disableProviders
     :type: string, comma separated list of strings
@@ -57,6 +63,9 @@ Properties
     it will be disallowed for the user or user group.
 
 ..  _user-auth-mfa-recommendedProvider:
+
+auth.mfa.recommendedProvider
+----------------------------
 
 ..  confval:: auth.mfa.recommendedProvider
     :name: auth.mfa.recommendedProvider

--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -29,6 +29,8 @@ Properties
 
     ..  _useroptions-additionalPreviewLanguages:
 
+    ..  rubric:: additionalPreviewLanguages
+
     ..  confval:: additionalPreviewLanguages
         :name: useroptions-additionalPreviewLanguages
         :type: list of sys_language IDs
@@ -40,8 +42,9 @@ Properties
         :yaml:`languageId` property of the
         :ref:`site configuration <t3coreapi:sitehandling-addingLanguages>`.
 
-
     ..  _useroptions-alertPopups:
+
+    ..  rubric:: alertPopups
 
     ..  confval:: alertPopups
         :name: useroptions-alertPopups
@@ -56,8 +59,9 @@ Properties
         *   8 – FE editing
         *   128 – other (not used yet)
 
-
     ..  _useroptions-bookmarkGroups:
+
+    ..  rubric:: bookmarkGroups
 
     ..  confval:: bookmarkGroups
         :name: useroptions-bookmarkGroups
@@ -108,10 +112,14 @@ Properties
 
     ..  _useroptions-clearCache:
 
+    ..  rubric:: clearCache
+
     ..  confval:: clearCache
         :name: useroptions-clearCache
 
         ..  _useroptions-clearCache-all:
+
+        ..  rubric:: all
 
         ..  confval:: all
             :name: useroptions-clearCache-all
@@ -126,6 +134,8 @@ Properties
 
         ..  _useroptions-clearCache-pages:
 
+        ..  rubric:: pages
+
         ..  confval:: pages
             :name: useroptions-clearCache-pages
             :type: boolean
@@ -137,6 +147,8 @@ Properties
 
     ..  _useroptions-clipboardNumberPads:
 
+    ..  rubric:: clipboardNumberPads
+
     ..  confval:: clipboardNumberPads
         :name: useroptions-clipboardNumberPads
         :type: integer (0-20)
@@ -145,6 +157,8 @@ Properties
         This allows you to enter how many pads you want on the clipboard.
 
     ..  _useroptions-contextMenu-key-disableItems:
+
+    ..  rubric:: contextMenu.table.[tableName][.context].disableItems
 
     ..  confval:: contextMenu.table.[tableName][.context].disableItems
         :name: useroptions-contextMenu-key-disableItems
@@ -230,10 +244,14 @@ Properties
 
     ..  _useroptions-dashboard:
 
+    ..  rubric:: dashboard
+
     ..  confval:: dashboard
         :name: useroptions-dashboard
 
         ..  _useroptions-dashboard-dashboardPresetsForNewUsers:
+
+        ..  rubric:: dashboardPresetsForNewUsers
 
         ..  confval:: dashboardPresetsForNewUsers
             :name: useroptions-dashboard-dashboardPresetsForNewUsers
@@ -251,6 +269,8 @@ Properties
                 options.dashboard.dashboardPresetsForNewUsers := addToList(customDashboard)
 
     ..  _useroptions-defaultResourcesViewMode:
+
+    ..  rubric:: defaultResourcesViewMode
 
     ..  confval:: defaultResourcesViewMode
         :name: useroptions-defaultResourcesViewMode
@@ -272,6 +292,8 @@ Properties
             options.defaultResourcesViewMode = list
 
     ..  _useroptions-defaultUploadFolder:
+
+    ..  rubric:: defaultUploadFolder
 
     ..  confval:: defaultUploadFolder
         :name: useroptions-defaultUploadFolder
@@ -299,6 +321,8 @@ Properties
 
     ..  _useroptions-disableDelete:
 
+    ..  rubric:: disableDelete
+
     ..  confval:: disableDelete
         :name: useroptions-disableDelete
         :type: boolean
@@ -318,6 +342,8 @@ Properties
 
     ..  _useroptions-dontMountAdminMounts:
 
+    ..  rubric:: dontMountAdminMounts
+
     ..  confval:: dontMountAdminMounts
         :name: useroptions-dontMountAdminMounts
         :type: boolean
@@ -329,6 +355,8 @@ Properties
 
     ..  _useroptions-enableBookmarks:
 
+    ..  rubric:: enableBookmarks
+
     ..  confval:: enableBookmarks
         :name: useroptions-enableBookmarks
         :type: boolean
@@ -338,10 +366,14 @@ Properties
 
     ..  _useroptions-file_list:
 
+    ..  rubric:: file_list
+
     ..  confval:: file_list
         :name: useroptions-file_list
 
         ..  _useroptions-file_list-enableClipBoard:
+
+        ..  rubric:: enableClipBoard
 
         ..  confval:: enableClipBoard
             :name: useroptions-enableClipBoard
@@ -365,6 +397,8 @@ Properties
                 The checkbox is shown so that the option can be selected by the user.
 
         ..  _useroptions-file_list-displayColumnSelector:
+
+        ..  rubric:: displayColumnSelector
 
         ..  confval:: displayColumnSelector
             :name: useroptions-file_list-displayColumnSelector
@@ -393,6 +427,8 @@ Properties
 
         ..  _useroptions-file_list-enableDisplayThumbnails:
 
+        ..  rubric:: file_list.enableDisplayThumbnails
+
         ..  confval:: file_list.enableDisplayThumbnails
             :name: useroptions-file_list-enableDisplayThumbnails
             :type: list of keywords
@@ -415,6 +451,8 @@ Properties
 
         ..  _useroptions-file_list-filesPerPage:
 
+        ..  rubric:: filesPerPage
+
         ..  confval:: filesPerPage
             :name: useroptions-file_list-filesPerPage
             :type: integer
@@ -426,6 +464,7 @@ Properties
 
         ..  _useroptions-file_list-primaryActions:
 
+        ..  rubric:: primaryActions
 
         ..  confval:: primaryActions
             :name: useroptions-useroptions-file_list-primaryActions
@@ -476,6 +515,8 @@ Properties
 
         ..  _useroptions-file_list-thumbnail-height:
 
+        ..  rubric:: thumbnail.height
+
         ..  confval:: thumbnail.height
             :name: useroptions-file_list-thumbnail-height
             :type: integer
@@ -487,6 +528,8 @@ Properties
 
         ..  _useroptions-file_list-thumbnail-width:
 
+        ..  rubric:: thumbnail.width
+
         ..  confval:: thumbnail.width
             :name: useroptions-file_list-thumbnail-width
             :type: integer
@@ -497,6 +540,8 @@ Properties
             thumbnail width.
 
         ..  _useroptions-file_list-uploader-defaultaction:
+
+        ..  rubric:: uploader.defaultAction
 
         ..  confval:: uploader.defaultAction
             :name: useroptions-file_list-uploader-defaultaction
@@ -516,10 +561,14 @@ Properties
             :typoscript:`replace`
                 Override the file with the uploaded one.
 
+    ..  rubric:: folderTree
+
     ..  confval:: folderTree
         :name: useroptions-folderTree
 
         ..  _useroptions-folderTree-altElementBrowserMountPoints:
+
+        ..  rubric:: altElementBrowserMountPoints
 
         ..  confval:: altElementBrowserMountPoints
             :name: useroptions-folderTree-altElementBrowserMountPoints
@@ -555,6 +604,8 @@ Properties
 
         ..  _useroptions-folderTree-uploadFieldsInLinkBrowser:
 
+        ..  rubric:: uploadFieldsInLinkBrowser
+
         ..  confval:: uploadFieldsInLinkBrowser
             :name: useroptions-folderTree-uploadFieldsInLinkBrowser
             :type: integer
@@ -565,6 +616,8 @@ Properties
             Default value is 3, if set to 0, no upload form will be shown.
 
     ..  _useroptions-hideModules:
+
+    ..  rubric:: hideModules
 
     ..  confval:: hideModules
         :name: useroptions-hideModules
@@ -598,9 +651,13 @@ Properties
 
     ..  _useroptions-hideRecords:
 
+    ..  rubric:: hideRecords
+
     ..  confval:: hideRecords
 
         ..  _useroptions-hideRecords-pages:
+
+        ..  rubric:: pages
 
         ..  confval:: pages
             :name: useroptions-hideRecords-pages
@@ -629,10 +686,14 @@ Properties
 
     ..  _useroptions-impexp:
 
+    ..  rubric:: impexp
+
     ..  confval:: impexp
         :name: useroptions-impexp
 
         ..  _useroptions-impexp-enableExportForNonAdminUser:
+
+        ..  rubric:: enableExportForNonAdminUser
 
         ..  confval:: enableExportForNonAdminUser
             :name: useroptions-impexp-enableExportForNonAdminUser
@@ -667,14 +728,17 @@ Properties
 
     ..  _useroptions-mayNotCreateEditBookmarks:
 
+    ..  rubric:: mayNotCreateEditBookmarks
+
     ..  confval:: mayNotCreateEditBookmarks
         :name: useroptions-mayNotCreateEditBookmarks
         :type: boolean
 
         If set, the user can not create or edit bookmarks.
 
-
     ..  _useroptions-noThumbsInEB:
+
+    ..  rubric:: noThumbsInEB
 
     ..  confval:: noThumbsInEB
         :name: useroptions-noThumbsInEB
@@ -684,8 +748,9 @@ Properties
 
     ..  _useroptions-overridePageModule:
 
-
     ..  _useroptions-pageTree:
+
+    ..  rubric:: pageTree
 
     ..  confval:: pageTree
         :name: useroptions-pageTree
@@ -723,6 +788,8 @@ Properties
 
         ..  _useroptions-pageTree-altElementBrowserMountPoints:
 
+        ..  rubric:: altElementBrowserMountPoints
+
         ..  confval:: altElementBrowserMountPoints
             :name: useroptions-pageTree-altElementBrowserMountPoints
             :type: list of integers
@@ -746,8 +813,9 @@ Properties
 
                 options.pageTree.altElementBrowserMountPoints = 34,123
 
-
         ..  _useroptions-pageTree-altElementBrowserMountPoints-append:
+
+        ..  rubric:: altElementBrowserMountPoints.append
 
         ..  confval:: altElementBrowserMountPoints.append
             :name: useroptions-pageTree-altElementBrowserMountPoints-append
@@ -807,6 +875,8 @@ Properties
 
         ..  _useroptions-pageTree-doktypesToShowInNewPageDragArea:
 
+        ..  rubric:: doktypesToShowInNewPageDragArea
+
         ..  confval:: doktypesToShowInNewPageDragArea
             :name: useroptions-pageTree-doktypesToShowInNewPageDragArea
             :type: string
@@ -831,6 +901,8 @@ Properties
 
         ..  _useroptions-pageTree-excludeDoktypes:
 
+        ..  rubric:: excludeDoktypes
+
         ..  confval:: excludeDoktypes
             :name: useroptions-pageTree-excludeDoktypes
             :type: list of integers
@@ -849,6 +921,8 @@ Properties
                 options.pageTree.excludeDoktypes = 254,1
 
         ..  _useroptions-pageTree-label:
+
+        ..  rubric:: label.<page-id>
 
         ..  confval:: label.<page-id>
             :name: useroptions-pageTree-label
@@ -885,7 +959,10 @@ Properties
                 multiple labels to a page.
 
         ..  todo:: does this still work with site configuration?
+
         ..  _useroptions-pageTree-showDomainNameWithTitle:
+
+        ..  rubric:: showDomainNameWithTitle
 
         ..  confval:: showDomainNameWithTitle
             :name: useroptions-pageTree-showDomainNameWithTitle
@@ -899,6 +976,8 @@ Properties
 
         ..  _useroptions-pageTree-showNavTitle:
 
+        ..  rubric:: showNavTitle
+
         ..  confval:: showNavTitle
             :name: useroptions-pageTree-showNavTitle
             :type: boolean
@@ -908,8 +987,9 @@ Properties
             instead of the normal page title. The page title is shown in a
             tooltip if the mouse hovers the navigation title.
 
-
         ..  _useroptions-pageTree-showPageIdWithTitle:
+
+        ..  rubric:: showPageIdWithTitle
 
         ..  confval:: showPageIdWithTitle
             :name: useroptions-pageTree-showPageIdWithTitle
@@ -919,8 +999,9 @@ Properties
             If set, the titles in the page tree will have their ID numbers printed
             before the title.
 
-
         ..  _useroptions-pageTree-showPathAboveMounts:
+
+        ..  rubric:: showPathAboveMounts
 
         ..  confval:: showPathAboveMounts
             :name: useroptions-pageTree-showPathAboveMounts
@@ -937,6 +1018,8 @@ Properties
                 Active user db mount
 
     ..  _useroptions-passwordReset:
+
+    ..  rubric:: passwordReset
 
     ..  confval:: passwordReset
         :name: useroptions-passwordReset
@@ -968,6 +1051,8 @@ Properties
 
     ..  _useroptions-saveClipboard:
 
+    ..  rubric:: saveClipboard
+
     ..  confval:: saveClipboard
         :name: useroptions-saveClipboard
         :type: boolean
@@ -975,8 +1060,9 @@ Properties
         If set, the clipboard content will be preserved for the next login.
         Normally the clipboard content lasts only during the session.
 
-
     ..  _useroptions-saveDocNew:
+
+    ..  rubric:: saveDocNew
 
     ..  confval:: saveDocNew
         :name: useroptions-saveDocNew
@@ -1004,6 +1090,8 @@ Properties
 
     ..  _useroptions-saveDocView:
 
+    ..  rubric:: saveDocView
+
     ..  confval:: saveDocView
         :name: useroptions-saveDocView
         :type: boolean
@@ -1018,6 +1106,8 @@ Properties
 
     ..  _useroptions-showDuplicate:
 
+    ..  rubric:: showDuplicate
+
     ..  confval:: showDuplicate
         :name: useroptions-showDuplicate
         :type: boolean
@@ -1030,8 +1120,9 @@ Properties
         Any value set for a single table will override the default value set for
         :typoscript:`showDuplicate`.
 
-
     ..  _useroptions-showHistory:
+
+    ..  rubric:: showHistory
 
     ..  confval:: showHistory
         :name: useroptions-showHistory
@@ -1043,6 +1134,8 @@ Properties
         :typoscript:`options.showHistory.[tableName]`.
         Any value set for a single table will override the default value set for
         :typoscript:`showHistory`.
+
+    ..  rubric:: hideSets
 
     ..  confval:: hideSets
         :name: useroptions-hideSets

--- a/Documentation/UserTsconfig/Setup.rst
+++ b/Documentation/UserTsconfig/Setup.rst
@@ -33,6 +33,8 @@ Properties
 
     ..  _user-setup-default:
 
+    ..  rubric:: setup.default.[someProperty]
+
     ..  confval:: setup.default.[someProperty]
         :name: user-setup-default
         :type: any
@@ -50,6 +52,8 @@ Properties
             :caption: EXT:site_package/Configuration/user.tsconfig
 
     ..  _user-setup-override:
+
+    ..  rubric:: setup.override.[someProperty]
 
     ..  confval:: setup.override.[someProperty]
         :name: user-setup-override
@@ -70,6 +74,8 @@ Properties
 
     ..  _user-setup-fields-fieldName-disabled:
 
+    ..  rubric:: setup.fields.[fieldName].disabled
+
     ..  confval:: setup.fields.[fieldName].disabled
         :name: user-setup-fields-fieldName-disabled
         :type: boolean
@@ -87,6 +93,10 @@ Properties
             # And force the value of this field to be set to 1
             setup.override.emailMeAtLogin = 1
 
+backendTitleFormat
+------------------
+
+
     ..  index::  User settings; Format of window title in backend
 
     ..  _user-setup-backendTitleFormat:
@@ -102,6 +112,10 @@ Properties
         `sitenameFirst`
             [sitename] · [title]
 
+copyLevels
+----------
+
+
 
     ..  index:: User settings; Copy levels
 
@@ -112,6 +126,10 @@ Properties
         :type: positive integer
 
         Recursive Copy: Enter the number of page sub-levels to include, when a page is copied
+
+edit_docModuleUpload
+--------------------
+
 
 
     ..  index:: File upload; In doc module
@@ -130,6 +148,8 @@ Properties
 
     ..  _user-setup-emailMeAtLogin:
 
+    ..  rubric:: emailMeAtLogin
+
     ..  confval:: emailMeAtLogin
         :name: user-setup-emailMeAtLogin
         :type:  boolean
@@ -137,6 +157,8 @@ Properties
         Notify me by email, when somebody logs into my account
 
     ..  _user-setup-lang:
+
+    ..  rubric:: lang
 
     ..  confval:: lang
         :name: user-setup-lang
@@ -147,6 +169,8 @@ Properties
 
     ..  _user-setup-neverHideAtCopy:
 
+    ..  rubric:: neverHideAtCopy
+
     ..  confval:: neverHideAtCopy
         :name: user-setup-neverHideAtCopy
         :type: boolean
@@ -154,6 +178,8 @@ Properties
         If set, then the hideAtCopy feature for records in TCE will not be used.
 
     ..  _user-setup-showHiddenFilesAndFolders:
+
+    ..  rubric:: showHiddenFilesAndFolders
 
     ..  confval:: showHiddenFilesAndFolders
         :name: user-setup-showHiddenFilesAndFolders
@@ -163,6 +189,8 @@ Properties
 
     ..  _user-setup-startModule:
 
+    ..  rubric:: startModule
+
     ..  confval:: startModule
         :name: user-setup-startModule
         :type: string
@@ -171,6 +199,8 @@ Properties
         example `web_layout`, `web_list`, `web_view`, `web_info`, `web_ts` etc.
 
     ..  _user-setup-titleLen:
+
+    ..  rubric:: titleLen
 
     ..  confval:: titleLen
         :name: user-setup-titleLen


### PR DESCRIPTION
# Description
Backport of #1793 to `13.4`.

Manual cherry-pick — the automatic backport failed on conflicts in four
files, because 13.4 has diverged from `main`. Resolved as follows:

*   `PageTsconfig/Mod/WebLayout/BackendLayout.rst`: dropped the
    `allowedContentTypes` / `disallowedContentTypes` confvals
    (`versionadded:: 14.1`, not present on 13.4).
*   `PageTsconfig/Mod/Wizards.rst`: kept the 13.4-only
    `versionchanged:: 13.0` note and the `[group].show` confval (both
    removed on `main`), and gave `[group].show` a rubric for
    consistency. Dropped the `before` / `after` confvals
    (`versionadded:: 14.2`) but kept the `[group].removeItems` rubric,
    since that confval does exist on 13.4.
*   `TopLevelObjects/Config.rst`: kept 13.4's `absRefPrefix`,
    `compressCss` / `compressJs` and the un-renamed `htmlTag.attributes`
    confval. Dropped `linkSecurityRelValue` (`versionadded:: 14.2`) and
    `main`'s renamed/expanded `htmlTag.attributes.[attribute]` examples.
*   `UserTsconfig/Options.rst`: dropped `liveSearch` and
    `searchByFrontendUri` (both `versionadded:: 14.2`).

Verified that no 14.x-only content leaked in, that no headings remain in
front of indented confvals, that heading underline lengths match, and
that `make test-docs` passes.