### PR TITLE
[TASK] Track reusable backport workflow on main

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,10 +8,11 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   backport:
-    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@9d884304b1a5cdeeb2e21349a5bbfe52da5548d5
+    uses: TYPO3-Documentation/.github/.github/workflows/reusable-backport.yml@main
     with:
       label_pattern: "^backport (.+)$"
     secrets:


### PR DESCRIPTION
The `14.3` branch was pinned to a commit that predates `46ed94f` in
`TYPO3-Documentation/.github`. That commit makes the backport job skip pull
requests that already carry the success or failure label. Without it, removing
`backport-failed` re-triggers the backport, which fails because the change is
already on the branch, and the label is immediately re-applied by the bot.

Same fix as applied to `main` in this organization's other repositories, and
to `TYPO3CMS-Reference-TCA`'s `14.3` branch in TYPO3-Documentation/TYPO3CMS-Reference-TCA#1441.

Where missing, the `issues: write` permission that `reusable-backport.yml`
declares is added too — a called workflow cannot grant itself more than the
caller holds.

Assisted-by: Claude Sonnet 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf