### PR TITLE
[BUGFIX] Import constants.typoscript in the set constants example

### DIFF
--- a/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
+++ b/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
@@ -173,7 +173,7 @@ until now:
 ..  code-block:: typoscript
     :caption: packages/my_extension/Configuration/Sets/MySet/constants.typoscript
 
-    @import 'EXT:my_extension/Configuration/TypoScript/setup.typoscript'
+    @import 'EXT:my_extension/Configuration/TypoScript/constants.typoscript'
 
 ..  code-block:: typoscript
     :caption: packages/my_extension/Configuration/Sets/MySet/setup.typoscript


### PR DESCRIPTION
The example showing how to provide a former static file include as a
site set imported setup.typoscript from the set's own
constants.typoscript. Readers copying the snippet get the extension's
setup TypoScript parsed as constants, and the constants file is never
included at all.

Resolves: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/1794
Releases: main, 14.3, 13.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W
