### PR TITLE
[BUGFIX] Correct example paths in "Multiple TypoScript include sets"

### DIFF
--- a/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
+++ b/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
@@ -246,23 +246,23 @@ template record:
 
    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
-       'Configuration/TypoScript/Example1/',
-       'My Extension - Additional example 1'
+       'Configuration/TypoScript/SpecialFeature1/',
+       'My Extension - Some special feature 1'
    );
 
    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(
        'my_extension',
        'Configuration/TypoScript/SpecialFeature2/',
-       'My Extension - Some special feature'
+       'My Extension - Some special feature 2'
    );
 
 Each site set then provides the TypoScript files the according location by
 importing it, for example:
 
 ..  code-block:: typoscript
-    :caption: packages/my_extension/Configuration/Sets/MySet/setup.typoscript
+    :caption: packages/my_extension/Configuration/Sets/MySpecialFeature2Set/setup.typoscript
 
-    @import 'EXT:my_extension/Configuration/TypoScript/MySpecialFeature2Set/setup.typoscript'
+    @import 'EXT:my_extension/Configuration/TypoScript/SpecialFeature2/setup.typoscript'
 
 ..  index:: TypoScript in extensions; Load always
 ..  _extdev-always-load:


### PR DESCRIPTION
The snippets referenced files and folders that do not exist in the
directory tree the section itself shows: addStaticFile() registered
Configuration/TypoScript/Example1/ instead of SpecialFeature1/, and the
closing import example was captioned as MySet while importing from a
folder named after the site set rather than the TypoScript folder.

Releases: main, 14.3, 13.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W
