### PR TITLE
[BUGFIX] Mark RTE.config.contentsLanguageDirection as without effect

### DIFF
--- a/Documentation/404.rst
+++ b/Documentation/404.rst
@@ -1,0 +1,32 @@
+:orphan:
+
+..  _not-found:
+
+===================
+Content was removed
+===================
+
+..  contents::
+
+..  _not-found-v12:
+
+TYPO3 v12
+=========
+
+..  _rte-config-contentsLanguageDirection:
+..  _confval-rte-config-contentsLanguageDirection:
+
+`RTE.config.contentsLanguageDirection` has been removed
+-------------------------------------------------------
+
+..  versionchanged:: 12.0
+    TYPO3 v12 ships CKEditor 5, see `Breaking: #96874 - CKEditor-related
+    plugins and configuration
+    <https://docs.typo3.org/permalink/changelog:breaking-96874-1664488429>`_.
+    CKEditor 5 has no `contentsLangDirection` option, so the page TSconfig
+    setting no longer had any effect. The last remnants in the Core were
+    removed with issue `#99916 <https://forge.typo3.org/issues/99916>`_.
+
+The text direction of the rich text editor now follows the content language
+of the edited record and is determined automatically. There is no page
+TSconfig replacement for this setting.

--- a/Documentation/PageTsconfig/Rte.rst
+++ b/Documentation/PageTsconfig/Rte.rst
@@ -111,6 +111,17 @@ Properties
     :depth: 2
     :local:
 
+..  versionchanged:: 12.0
+    The page TSconfig option :typoscript:`RTE.config.contentsLanguageDirection`
+    has no effect anymore. TYPO3 v12 ships CKEditor 5, see `Breaking: #96874 -
+    CKEditor-related plugins and configuration
+    <https://docs.typo3.org/permalink/changelog:breaking-96874-1664488429>`_.
+    CKEditor 5 has no `contentsLangDirection` option, and the last Core code
+    setting it was removed with issue
+    `#99916 <https://forge.typo3.org/issues/99916>`_. The text direction now
+    follows the content language of the edited record and is determined
+    automatically.
+
 ..  index:: RTE; disable
 
 disabled
@@ -263,35 +274,6 @@ buttons.link.[ *type* ].properties.target.default
     Specifies a default target for links of the given type.
     Possible types are: page, file, url, mail, spec. More types may be
     provided by extensions.
-
-..  index::
-    RTE; Content language direction
-    RTE config; contentsLanguageDirection
-..  _rte-config-contentsLanguageDirection:
-
-config.contentsLanguageDirection
---------------------------------
-
-..  confval:: config.contentsLanguageDirection
-    :name: rte-config-contentsLanguageDirection
-    :type: string
-
-    The configuration `contentsLangDirection` of the ckeditor is used to define the
-    direction of the content. It is filled by the direction defined in the site
-    language of the current element.
-
-    As fallback the following page TsConfig configuration can be used:
-
-    ..  code-block:: typoscript
-        :caption: EXT:my_sitepackage/Configuration/page.tsconfig
-
-        # always use right to left
-        RTE.config.contentsLanguageDirection = rtl
-
-        # except for the following language:
-        [siteLanguage("locale").getName() == "en-US"]
-            RTE.config.contentsLanguageDirection = ltr
-        [END]
 
 ..  index::
     RTE; Server processing


### PR DESCRIPTION
The option was documented as a fallback for the CKEditor 4 setting
contentsLangDirection, which CKEditor 5 does not have. TYPO3 v12 ships
CKEditor 5, and the last Core code writing that setting was dropped with
issue #99916, so the option has had no effect since v12.0. The documented
property path was wrong as well — RTE.config is the table namespace
(RTE.config.[table].[field]). The confval and its heading give way to a
versionchanged note at the top of the properties section, and the
published permalinks move to 404.rst, which this branch did not have yet.

See: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/1565
Releases: main, 14.3, 13.4, 12.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W