### PR TITLE
[TASK] Align the Makefile with the other documentation manuals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ CONTRIBUTING.md                  # how to contribute
 ## Commands
 
 - `make docs` — render the manual locally with Docker
-- `make test-docs` — render in fail-on-log mode; use this to validate any change before committing
+- `make test-docs` — render in minimal-test mode (the same validation CI runs); use this to validate any change before committing
 - `pre-commit run --all-files` — apply the whitespace hooks (`trailing-whitespace`,
   `end-of-file-fixer`) configured in `.pre-commit-config.yaml`; `pre-commit install`
   wires them into `git commit`

--- a/Makefile
+++ b/Makefile
@@ -4,32 +4,37 @@ help: ## Displays this list of targets with descriptions
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[32m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: docs
-docs: ## Generate projects docs (from "Documentation" directory)
+docs: ## Generate projects documentation (from "Documentation" directory)
 	mkdir -p Documentation-GENERATED-temp
-
 	docker run --user $(shell id -u):$(shell id -g) --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation
 
 .PHONY: test-docs
 test-docs: ## Test the documentation rendering
 	mkdir -p Documentation-GENERATED-temp
-
 	docker run --user $(shell id -u):$(shell id -g) --rm --pull always -v "$(shell pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --minimal-test
 
+.PHONY: test
+test: test-docs test-lint test-cgl test-yaml ## Run all test suites
+
 .PHONY: test-lint
-test-lint: ## Lint included code snippets
+test-lint: ## Lint the included PHP files
 	Build/Scripts/runTests.sh -s lint
 
 .PHONY: test-cgl
-test-cgl: ## Apply cgl to included code snippets
+test-cgl: ## Check the TYPO3 coding guidelines (dry-run)
 	Build/Scripts/runTests.sh -s cgl -n
 
 .PHONY: test-yaml
-test-yaml: ## lint the yaml
+test-yaml: ## Lint the YAML files
 	Build/Scripts/runTests.sh -s yamlLint
 
-.PHONY: test
-test: test-docs test-lint test-cgl test-yaml## Test the documentation rendering
-
 .PHONY: fix
-fix: ## Fix cgl
+fix: fix-cgl ## Apply all automatic fixes
+
+.PHONY: fix-cgl
+fix-cgl: ## Fix TYPO3 coding guidelines violations
 	Build/Scripts/runTests.sh -s cgl
+
+.PHONY: install
+install: ## Install/update the Composer dependencies
+	Build/Scripts/runTests.sh -s composerUpdate


### PR DESCRIPTION
The Makefiles across the documentation manuals had drifted apart: the
strict rendering target was named docs-test in one manual and test-docs in
the others, some ran --fail-on-log while their own CI ran --minimal-test,
two had lost `make help` to space indentation, and several help
descriptions were copy-paste leftovers from unrelated targets. They are
being unified on one shared block, so the same command means the same
thing in every manual.

fix ran the coding-guideline fixer directly, with no fix-cgl target to
delegate to as the other manuals have. Add install, the one target this
manual lacked while its CI already invokes runTests.sh -s composerUpdate
directly.

Also correct AGENTS.md, which described `make test-docs` as rendering in
fail-on-log mode while the Makefile used --minimal-test.

Releases: main, 14.3
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf