### PR TITLE
[BUGFIX] Fix wrong ELTS link on the data types page

### DIFF
--- a/Documentation/DataTypes/Index.rst
+++ b/Documentation/DataTypes/Index.rst
@@ -48,11 +48,10 @@ boolean
     Possible values for boolean variables are `1` and `0`
     meaning TRUE and FALSE.
 
-    Everything else is `evaluated to one of these values by PHP`__:
+    Everything else is `evaluated to one of these values by PHP
+    <https://www.php.net/manual/en/language.types.boolean.php>`__:
     Non-empty strings (except `0` [zero]) are treated as TRUE,
     empty strings are evaluated to FALSE.
-
-    __ https://www.php.net/manual/en/language.types.boolean.php
 
     ..  rubric:: Examples
 


### PR DESCRIPTION
The end-of-life banner from Includes.rst.txt is prepended to every page
and ends with an anonymous link reference. On the data types page the
renderer matched it against the standalone anonymous target of the boolean
confval, so the banner's "TYPO3 ELTS" link pointed at php.net while the
PHP reference itself stayed unresolved and rendering failed. Embedding the
URL in the reference removes that standalone target, the last one in the
manual.

Releases: 12.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W