### PR TITLE
[BUGFIX] Correct two permalink URLs that return 404

### DIFF
--- a/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
+++ b/Documentation/UsingSetting/AddTypoScriptWithExtensions.rst
@@ -281,8 +281,8 @@ for the backend <typo3/cms-form:concepts-configuration-yamlregistration-backend>
 
 ..  warning::
     While the content from the files
-    `ext_typoscript_setup.typoscript <https://docs.typo3.org/permalink/t3coreapi:ext_typoscript_setup_typoscript>`_
-    and `ext_typoscript_constants.typoscript <https://docs.typo3.org/permalink/t3coreapi:ext_typoscript_constants_typoscript>`_
+    `ext_typoscript_setup.typoscript <https://docs.typo3.org/permalink/t3coreapi:ext-typoscript-setup-typoscript>`_
+    and `ext_typoscript_constants.typoscript <https://docs.typo3.org/permalink/t3coreapi:ext-typoscript-constants-typoscript>`_
     is loaded by default in sites based on **TypoScript records** it is not
     loaded in sites depending on **site sets as TypoScript providers**.
 


### PR DESCRIPTION
A permalink slug is normalised: underscores become hyphens. Both links to
the TYPO3 Explained pages on ext_typoscript_setup.typoscript and
ext_typoscript_constants.typoscript used the raw anchor name, so they 404
even though the anchors exist.

Both were verified to return 200 after the change. Rendering does not
catch this: it resolves a permalink against the anchors held in memory,
while docs.typo3.org resolves against the published, normalised
objects.inv.json, in which only the hyphenated key exists.

Releases: main, 14.3
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf