### PR TITLE
[BUGFIX] Repair a link that renders as literal text

### DIFF
--- a/Documentation/PageTsconfig/Mod/WebList.rst
+++ b/Documentation/PageTsconfig/Mod/WebList.rst
@@ -604,7 +604,7 @@ noViewWithDokTypes (removed)
 ..  versionchanged:: 14.0
     The TSconfig option :typoscript:`mod.web_list.noViewWithDokTypes` has been
     removed since it just duplicated the existing configuration
-    `TCEMAIN.preview.disableButtonForDokType <https://docs.typo3.org/permalink/t3tsref:confval-tcemain-preview>`.
+    `TCEMAIN.preview.disableButtonForDokType <https://docs.typo3.org/permalink/t3tsref:confval-tcemain-preview>`_.
 
 Remove any usage of :typoscript:`mod.web_list.noViewWithDokTypes` from Page
 TSconfig.


### PR DESCRIPTION
The permalink to TCEMAIN.preview.disableButtonForDokType was missing its
trailing underscore, so reST rendered it as plain text with the angle
brackets and the raw URL visible. Nothing reports this: a malformed link is
valid reST, it simply does not become a link.

Releases: main, 14.3
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf