### PR TITLE
[TASK] Document how multiple condition criteria are combined

### DIFF
--- a/Documentation/Syntax/Conditions/Index.rst
+++ b/Documentation/Syntax/Conditions/Index.rst
@@ -98,7 +98,26 @@ as well as :typoscript:`and` or :typoscript:`&&`
 ..  literalinclude:: _codesnippets/_andor.typoscript
     :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
 
-Single criteria can be negated using :typoscript:`!`
+Single criteria can be negated using :typoscript:`not` or :typoscript:`!`
+
+..  literalinclude:: _codesnippets/_not.typoscript
+    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+
+As in most programming languages, :typoscript:`not` binds more strongly than
+:typoscript:`and`, which in turn binds more strongly than :typoscript:`or`. Use
+parentheses whenever the intended grouping is not the default one:
+
+..  literalinclude:: _codesnippets/_precedence.typoscript
+    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+
+..  warning::
+    All criteria of a condition belong into *one* pair of square brackets.
+    Chaining several bracketed conditions with :typoscript:`&&` or
+    :typoscript:`||` was the syntax used before the Symfony expression
+    language was introduced in TYPO3 v9. It has been removed since and now
+    fails *silently*: everything after the first closing bracket is treated
+    as a comment, so all criteria but the first one are ignored without any
+    error message.
 
 ..  _typoscript-syntax-end-condition-constants:
 

--- a/Documentation/Syntax/Conditions/_codesnippets/_andor.typoscript
+++ b/Documentation/Syntax/Conditions/_codesnippets/_andor.typoscript
@@ -1,7 +1,14 @@
+# "or" is an alias for "||": one of the criteria is enough
 [frontend.user.isLoggedIn || ip('127.0.0.1')]
   page.20 = TEXT
   page.20 {
     value = A frontend user is logged in, or the browser IP is 127.0.0.1
     stdWrap.case = upper
   }
+[GLOBAL]
+
+# "and" is an alias for "&&": both criteria must apply
+[frontend.user.isLoggedIn && siteLanguage("languageId") == 1]
+  page.30 = TEXT
+  page.30.value = A logged in frontend user browses the second site language
 [GLOBAL]

--- a/Documentation/Syntax/Conditions/_codesnippets/_precedence.typoscript
+++ b/Documentation/Syntax/Conditions/_codesnippets/_precedence.typoscript
@@ -1,0 +1,11 @@
+# Reads as: isLoggedIn or (languageId == 1 and not ip('127.0.0.1'))
+[frontend.user.isLoggedIn || siteLanguage("languageId") == 1 && !ip('127.0.0.1')]
+  page.40 = TEXT
+  page.40.value = Default grouping
+[GLOBAL]
+
+# Parentheses enforce a different grouping
+[(frontend.user.isLoggedIn || siteLanguage("languageId") == 1) && !ip('127.0.0.1')]
+  page.50 = TEXT
+  page.50.value = Grouping enforced by parentheses
+[GLOBAL]


### PR DESCRIPTION
Issue 518 asked whether several criteria belong into one pair of square brackets or into several chained ones. The answer was given in the issue but never reached the manual: chaining, the syntax used before TYPO3 v9, was removed and now fails silently, because the tokenizer treats everything after the first closing bracket as a comment. State that, add the missing "and" example next to the existing "or" one, document that "not" binds more strongly than "and" and "and" more strongly than "or", and include the _not.typoscript snippet, which sat unused in the repository while the negation was mentioned without an example.

See: https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-Typoscript/issues/518
Releases: main, 14.3, 13.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W