### PR TITLE
[BUGFIX] Use the caption option on literalinclude, not captions

### DIFF
--- a/Documentation/Syntax/Conditions/Index.rst
+++ b/Documentation/Syntax/Conditions/Index.rst
@@ -37,7 +37,7 @@ Basic usage of TypoScript conditions
 ====================================
 
 ..  literalinclude:: _codesnippets/_basic.typoscript
-    :captions: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
 
 ..  _typoscript-syntax-conditions-syntax:
 
@@ -72,7 +72,7 @@ is considered if the condition criteria did *not* evaluate to true.
 This is similar to a closing curly brace :code:`}` in programming languages like PHP.
 
 ..  literalinclude:: _codesnippets/_condition.typoscript
-    :captions: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
 
 Conditions automatically stop at the end of a text snippet (file or record), even
 without :typoscript:`[END]` or :typoscript:`[GLOBAL]`. Another snippet on the same
@@ -96,7 +96,7 @@ Multiple condition criteria can be combined using :typoscript:`or` or :typoscrip
 as well as :typoscript:`and` or :typoscript:`&&`
 
 ..  literalinclude:: _codesnippets/_andor.typoscript
-    :captions: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
 
 Single criteria can be negated using :typoscript:`!`
 


### PR DESCRIPTION
The three literalinclude directives on the TypoScript conditions syntax
page pass ":captions:", which the renderer does not know and silently
ignores, so the code examples were published without the file name they
were meant to carry. The option is called ":caption:"; with it, all
three captions render.

Releases: main, 14.3, 13.4
Signed-off-by: Lina Wolf
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011hMW1LqMyafG9e1Si6eL9W

