### PR TITLE
[TASK] Drop the dead link to bootstrap package backend layouts

### DIFF
--- a/Documentation/PageTsconfig/Mod/WebLayout/BackendLayout.rst
+++ b/Documentation/PageTsconfig/Mod/WebLayout/BackendLayout.rst
@@ -24,9 +24,6 @@ backend, use an extension like :composer:`b13/container`.
 The page TSconfig for the backend layout above can be found in the site package
 tutorial: :ref:`Create backend page layouts <t3sitepackage:backend-page-layouts>`.
 
-For further examples, see `backend layouts in the bootstrap
-package (GitHub) <https://github.com/benjaminkott/bootstrap_package/tree/master/Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts>`__.
-
 ..  confval-menu::
 
 BackendLayouts.[backendLayout]


### PR DESCRIPTION
The sentence pointed at Configuration/TsConfig/Page/Mod/WebLayout/BackendLayouts
in benjaminkott/bootstrap_package. That directory is gone — Configuration/ now
holds FlexForms, Fluid, Form, RTE, Sets and TCA, and a code search across the
repository finds no BackendLayouts path at all. The extension appears to have
moved to site sets.

The sentence is dropped rather than repointed. The line directly above already
refers readers to the site package tutorial for a worked example, which is what
"further examples" was offering, and it is a reference this manual controls.

Releases: main, 14.3
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf