### PR TITLE
[BUGFIX] Repoint the SA-2016-015 link at the advisory page

### DIFF
--- a/Documentation/UserTsconfig/Options.rst
+++ b/Documentation/UserTsconfig/Options.rst
@@ -784,7 +784,7 @@ Properties
             :Path: options.impexp.enableImportForNonAdminUser
 
             ..  note::
-                This option was introduced to avoid `information disclosure <https://typo3.org/article/typo3-core-sa-2016-015>`__.
+                This option was introduced to avoid `information disclosure <https://typo3.org/security/advisory/typo3-core-sa-2016-015>`__.
 
             The import/export module of `EXT:impexp` is disabled by default for
             non-admin users. Enable this option, if non-admin users need to use the


### PR DESCRIPTION
typo3.org/article/typo3-core-sa-2016-015 returns 404. Security advisories
are no longer served under /article/; the same advisory is reachable at
/security/advisory/typo3-core-sa-2016-015, which returns 200.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
