### PR TITLE
[TASK] Add the missing captions to 50 code blocks

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -1328,6 +1328,7 @@ locale()
         *   `TYPO3 explained: Locale API <https://docs.typo3.org/permalink/t3coreapi:locale-api>`_
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [locale().getName() == "en-US"]
             page.20.value = Language is American English.

--- a/Documentation/ContentObjects/Files/Index.rst
+++ b/Documentation/ContentObjects/Files/Index.rst
@@ -80,6 +80,7 @@ references
     sys_file_reference with the UIDs 27 and 28.
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         references {
           table = tt_content
@@ -91,6 +92,7 @@ references
     tt_content record "256".
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         references {
           table = pages
@@ -145,6 +147,7 @@ folders
     Example for option :typoscript:`recursive`:
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         filecollection = FILES
         filecollection {
@@ -226,6 +229,7 @@ renderObj
     **Example:**
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.renderObj = TEXT
         page.10.renderObj {
@@ -297,6 +301,7 @@ Then we use the :ref:`TEXT <cobj-text>` cObject as :ref:`cobj-files-renderObj`
 to output the file size of all files that were found:
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = FILES
 
@@ -323,6 +328,7 @@ as an :ref:`IMAGE <cobj-image>` cObject with some meta data coming from
 the file itself or from the reference to it (title):
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.20 = FILES
     page.20 {
@@ -354,6 +360,7 @@ One usual feature is to use images attached to pages and use
 them up and down the page tree, a process called "sliding".
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.banner = FILES
     lib.banner {

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -577,6 +577,7 @@ Standard rendering
 This returns:
 
 ..  code-block:: html
+    :caption: Example output
 
     <img src="/fileadmin/toplogo.png"
          width="300"
@@ -654,6 +655,7 @@ Responsive/adaptive rendering
 This returns as an example all per default possible HTML output:
 
 ..  code-block:: html
+    :caption: Example output
 
     <img src="/fileadmin/_processed_/imagefilenamename_595cc36c48.png"
          width="600" height="423" alt="">

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -343,6 +343,7 @@ You can use the directories defined in :confval:`pageview-paths` to
 define fallback directories for the templates:
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page {

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -265,6 +265,7 @@ The PHP method :php:`run()` **must** be marked with
 via TypoScript:
 
 ..  code-block:: php
+    :caption: EXT:site_package/Classes/UserFunctions/MyClass.php
 
     use TYPO3\CMS\Core\Attribute\AsAllowedCallable;
     use Psr\Http\Message\ServerRequestInterface;

--- a/Documentation/DataProcessing/MenuProcessor/Categories.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Categories.rst
@@ -115,6 +115,7 @@ Example: List pages in categories with UID 1 and 2
 --------------------------------------------------
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     20 = HMENU
     20 {

--- a/Documentation/Functions/Encapslines.rst
+++ b/Documentation/Functions/Encapslines.rst
@@ -149,6 +149,7 @@ removeWrapping
     This:
 
     ..  code-block:: html
+        :caption: Example input
 
         First line of text
         Some <div>text</div>
@@ -159,6 +160,7 @@ removeWrapping
     becomes this:
 
     ..  code-block:: html
+        :caption: Example output
 
         First line of text
         Some <div>text</div>

--- a/Documentation/Functions/Imagelinkwrap.rst
+++ b/Documentation/Functions/Imagelinkwrap.rst
@@ -94,6 +94,7 @@ Example for effects
 ~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     imageLinkWrap {
         effects = gamma=1.3 | sharpen=80 | solarize=70
@@ -156,6 +157,7 @@ Example setting a bodytag for the preview window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # "onBlur" closes the window automatically if it looses focus
     imageLinkWrap.JSwindow = 1
@@ -198,6 +200,7 @@ Example: Use an alternative target for the JavaScript Window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # (1) to produce:  <a target="preview" ... >
     imageLinkWrap.target = preview
@@ -345,6 +348,7 @@ resized images in the frontend. A more complete example is
 :ref:`imageLinkWrap-example-fancybox`.
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     JSwindow = 0
     directImageLink = 1
@@ -413,6 +417,7 @@ Basic example: Create a link to the showpic script
 --------------------------------------------------
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = IMAGE
     10 {
@@ -434,6 +439,7 @@ Basic example: Link directly to the original image
 --------------------------------------------------
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = IMAGE
     10 {
@@ -455,6 +461,7 @@ Example: Larger display in a popup window
 -----------------------------------------
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.10 = IMAGE
@@ -494,6 +501,7 @@ Example: Printlink
 ------------------
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     5 = IMAGE
     5 {
@@ -523,6 +531,7 @@ Let's follow this `lightbox.ts example <https://github.com/georgringer/modernpac
 and use `fancybox <http://fancybox.net>`_:
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Add the CSS and JS files
     page {

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -169,6 +169,7 @@ bullet-gif (ln 8). Finally the whole thing is wrapped in the proper
 table-tags (ln 10). :
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
     :linenos:
 
     20 = TEXT

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -69,6 +69,7 @@ language
     ..  rubric:: Example
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10 = TEXT
         page.10.value = Link to the page with the ID 23 in the current language
@@ -172,6 +173,7 @@ addQueryString
     ..  rubric:: Example
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Pass resolved query parameters to the link
         typolink.addQueryString = 1
@@ -470,6 +472,7 @@ returnLast
     internal ``LinkResult`` object.
 
     ..  code-block:: json
+        :caption: Example output
 
         {
             "href": "/my-page",

--- a/Documentation/Functions/_Examples/Typolink-Example.rst
+++ b/Documentation/Functions/_Examples/Typolink-Example.rst
@@ -45,6 +45,8 @@ attributes, pass it to a new immutable object and return that. Then this is what
 gets emitted after full processing:
 
 ..  code-block:: html
+    :caption: Example output
+
     <a href="/en/pages/4711"
        target="_blank"
        title="Custom Title"
@@ -65,6 +67,8 @@ alter it, pass it to a new immutable object and return that. Then this is what f
 gets emitted after full processing:
 
 ..  code-block:: html
+    :caption: Example output
+
     <a href="/en/pages/4711/event/18"
        target="_blank"
        title="Custom: My Link Text"

--- a/Documentation/Gifbuilder/Examples.rst
+++ b/Documentation/Gifbuilder/Examples.rst
@@ -51,6 +51,7 @@ To generate such an overlayed image with the GIFBUILDER you have to use
 code like the following:
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.test = IMAGE
     lib.test {
@@ -194,6 +195,7 @@ The base image is the same as above. Below is the result - just see
 yourself:
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.header = IMAGE
     lib.header {
@@ -324,6 +326,7 @@ Setup
 ~~~~~
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     tt_content.image.20.1.file >
     tt_content.image.20.1.file = GIFBUILDER
@@ -404,6 +407,7 @@ Setup
 ~~~~~
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     tt_content.image.20.1.file >
     tt_content.image.20.1.file = GIFBUILDER

--- a/Documentation/Gifbuilder/Properties.rst
+++ b/Documentation/Gifbuilder/Properties.rst
@@ -125,6 +125,7 @@ charRangeMap
     **Example**:
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         _GIFBUILDER.charRangeMap {
           123 = arial.ttf

--- a/Documentation/PageTsconfig/Mod/WebList.rst
+++ b/Documentation/PageTsconfig/Mod/WebList.rst
@@ -699,6 +699,7 @@ tableDisplayOrder
     to other table names.
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/page.tsconfig
 
         mod.web_list.tableDisplayOrder.<tableName> {
             before = <tableA>, <tableB>, ...

--- a/Documentation/PageTsconfig/TceForm.rst
+++ b/Documentation/PageTsconfig/TceForm.rst
@@ -360,6 +360,7 @@ config
      within :ref:`FormEngine code <t3coreapi:FormEngine>` defines details:
 
      ..  code-block:: php
+         :caption: typo3/sysext/backend/Classes/Form/Utility/FormEngineUtility.php
 
           'input' => ['size', 'max', 'readOnly'],
           'number' => ['size', 'readOnly'],

--- a/Documentation/Syntax/Conditions/Index.rst
+++ b/Documentation/Syntax/Conditions/Index.rst
@@ -128,6 +128,7 @@ Nesting conditions via TypoScript imports
 Conditions can *not* be nested within code blocks.
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Invalid: Conditions must not be used within code blocks
     # someIdentifier {

--- a/Documentation/Syntax/FileImports/Index.rst
+++ b/Documentation/Syntax/FileImports/Index.rst
@@ -82,6 +82,7 @@ The following rules apply:
 Some examples:
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Import a single file
     @import 'EXT:my_extension/Configuration/TypoScript/randomfile.typoscript'

--- a/Documentation/Syntax/Operators/Index.rst
+++ b/Documentation/Syntax/Operators/Index.rst
@@ -243,6 +243,7 @@ parenthesis. These predefined functions are available:
     duplicate values, and the list is not sorted in any way.
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         foo = 123,456
         foo := addToList(789)
@@ -296,6 +297,7 @@ parenthesis. These predefined functions are available:
         Apply numeric sorting: Numbers from small to big, letters sorted after "0".
 
     ..  code-block:: typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         foo = 10,100,0,20,abc
         foo := sortList()

--- a/Documentation/TopLevelObjects/Page/Examples.rst
+++ b/Documentation/TopLevelObjects/Page/Examples.rst
@@ -16,6 +16,7 @@ Demonstrates:
     * :confval:`page.10 <page-array>`
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    # Default PAGE object:
    page = PAGE
@@ -32,6 +33,7 @@ Demonstrates:
     * :confval:`page.10 <page-array>`
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    page = PAGE
    page.10 = FLUIDTEMPLATE
@@ -69,6 +71,7 @@ This can be achieved for example by using a non-cacheable array, the
 :ref:`COA_INT <cobj-coa-int>`.
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    myAjax = PAGE
    myAjax {
@@ -96,6 +99,7 @@ To create a page type in the format json an additional
 header with `Content-type:application/json` has to be set:
 
 .. code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    json = PAGE
    json {

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -57,6 +57,7 @@ An empty :typoscript:`PAGE` object without further configuration renders a HTML 
 like the following:
 
 ..  code-block:: html
+    :caption: Example output
 
     <!DOCTYPE html>
     <html lang="en">

--- a/Documentation/UsingSetting/Constants.rst
+++ b/Documentation/UsingSetting/Constants.rst
@@ -57,6 +57,7 @@ Here :typoscript:`bgCol` is set to "red", :typoscript:`file.toplogo` is set to
 expected location.
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/constants.typoscript
     :emphasize-lines: 2,7
 
     bgCol = red
@@ -84,6 +85,7 @@ one would perform any ordinary string replacement. Constants are used in the
 :typoscript:`$` sign:
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     {$bgCol}
     {$topimg.width}

--- a/Documentation/UsingSetting/Register.rst
+++ b/Documentation/UsingSetting/Register.rst
@@ -32,6 +32,7 @@ Example
 =======
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = COA
     10 {
@@ -88,6 +89,7 @@ the pages following the spacer page will get the class `col-right`.
 `variablename`. A register stack can be like any TypoScript setup.
 
 ..  code-block:: typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = COA
     10 {


### PR DESCRIPTION
Half of the pages in this manual show TypoScript without saying which
file it belongs in. The reader who has just learned what page.10 does
is then left guessing whether it goes into setup, into constants or
into page TSconfig — the question the caption exists to answer.

Frontend TypoScript is named as a site set,
EXT:site_package/Configuration/Sets/Main/, because a set is what gets
setup.typoscript and constants.typoscript loaded once a site lists the
set. The path used by the captions already present in this manual,
EXT:site_package/Configuration/TypoScript/setup.typoscript, does nothing
unless someone includes that file by hand, which is a poor thing to show
a reader who is asking where the code goes.

Page TSconfig is taken from the same set, to keep one site package
together in the examples. It would be loaded either way: an extension's
own Configuration/page.tsconfig is included automatically since v12, as
is Configuration/user.tsconfig since v13.

Rendered markup gets "Example output" rather than a file name, following
what the manual already does for output blocks.

Two blocks in Functions/_Examples/Typolink-Example.rst had no blank line
between the directive and the code. An option added there would make the
block render empty, so the blank line is added with the caption.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
