### PR TITLE
[TASK] Move the caption paths onto site sets

### DIFF
--- a/Documentation/Conditions/Index.rst
+++ b/Documentation/Conditions/Index.rst
@@ -54,7 +54,7 @@ applicationContext
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [applicationContext == "Development"]
             # ...
@@ -82,7 +82,7 @@ page
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Check single page UID
         [traverse(page, "uid") == 2]
@@ -150,7 +150,7 @@ tree.level
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Check, if the page is on level 0:
         [tree.level == 0]
@@ -174,7 +174,7 @@ tree.pagelayout
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Using backend layout records
         [tree.pagelayout === "2"]
@@ -213,7 +213,7 @@ tree.rootLine
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [tree.rootLine[0]["uid"] == 1]
             # ...
@@ -237,7 +237,7 @@ tree.rootLineIds
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Check, if page with uid 2 is inside the root line
         [2 in tree.rootLineIds]
@@ -262,7 +262,7 @@ tree.rootLineParentIds
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Check, if the page with UID 2 is the parent of a page inside the root line
         [2 in tree.rootLineParentIds]
@@ -313,7 +313,7 @@ backend.user.isAdmin
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Evaluates to true, if the current backend user is administrator
         [backend.user.isAdmin]
@@ -336,7 +336,7 @@ backend.user.isLoggedIn
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Evaluates to true, if a backend user is logged in
         [backend.user.isLoggedIn]
@@ -359,7 +359,7 @@ backend.user.userId
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Evaluates to true, if the user UID of the current logged-in backend
         # user is equal to 5
@@ -384,7 +384,7 @@ backend.user.userGroupIds
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [2 in backend.user.userGroupIds]
             # ...
@@ -406,7 +406,7 @@ backend.user.userGroupList
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [like(","~backend.user.userGroupList~",", "*,1,*")]
             # ...
@@ -454,7 +454,7 @@ frontend.user.isLoggedIn
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [frontend.user.isLoggedIn]
             # ...
@@ -476,7 +476,7 @@ frontend.user.userId
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [frontend.user.userId == 5]
             # ...
@@ -499,7 +499,7 @@ frontend.user.userGroupIds
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [4 in frontend.user.userGroupIds]
             # ...
@@ -521,7 +521,7 @@ frontend.user.userGroupList
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [like(","~frontend.user.userGroupList~",", "*,1,*")]
             # ...
@@ -556,7 +556,7 @@ workspace.workspaceId
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Check, if in live workspace
         [workspace.workspaceId == 0]
@@ -579,7 +579,7 @@ workspace.isLive
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [workspace.isLive]
             # ...
@@ -601,7 +601,7 @@ workspace.isOffline
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [workspace.isOffline]
             # ...
@@ -636,7 +636,7 @@ typo3.version
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [typo3.version == "14.3.1"]
             # ...
@@ -658,7 +658,7 @@ typo3.branch
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [typo3.branch == "14.3"]
             # ...
@@ -680,7 +680,7 @@ typo3.devIpMask
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [typo3.devIpMask == "172.18.0.6"]
             # ...
@@ -707,7 +707,7 @@ date()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # True, if the day of the current month is 7
         [date("j") == 7]
@@ -748,7 +748,7 @@ like()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Search a string with * within another string
         [like("fooBarBaz", "*Bar*")]
@@ -788,7 +788,7 @@ traverse()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Traverse query parameters of current request along tx_news_pi1[news]
         [request && traverse(request.getQueryParams(), 'tx_news_pi1/news') > 0]
@@ -826,7 +826,7 @@ compatVersion()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # True, if the current TYPO3 version is 14.3.x
         [compatVersion("14.3")]
@@ -851,7 +851,7 @@ getTSFE(): Migration
     condition like `getTSFE()` will never evaluate to true and needs adaption.
 
 ..  code-block:: diff
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript (diff)
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript (diff)
 
     - [getTSFE() && getTSFE().id == 42]
 
@@ -872,7 +872,7 @@ getenv()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [getenv("VIRTUAL_HOST") == "www.example.org"]
             # ...
@@ -895,7 +895,7 @@ feature()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # True, if the feature toggle for enforcing the Content Security Policy
         # in the frontend is enabled
@@ -924,7 +924,7 @@ ip()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [ip("172.18.*")]
             page.10.value = Your IP matches "172.18.*"
@@ -988,7 +988,7 @@ request.getQueryParams()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Safely check the query parameter array to avoid error logs in case key
         # is not defined. This will check if the GET parameter
@@ -1014,7 +1014,7 @@ request.getParsedBody()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [request && traverse(request.getParsedBody(), 'foo') == 1]
             # ...
@@ -1036,7 +1036,7 @@ request.getHeaders()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [request && request.getHeaders()['Accept'] == 'json']
             page.10.value = Accepts json
@@ -1062,7 +1062,7 @@ request.getCookieParams()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [request && request.getCookieParams()['foo'] == 1]
             # ...
@@ -1087,7 +1087,7 @@ request.getNormalizedParams()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [request && request.getNormalizedParams().isHttps()]
             page.10.value = HTTPS is being used
@@ -1115,7 +1115,7 @@ request.getPageArguments()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [request && request.getPageArguments().get('foo_id') > 0]
             # ...
@@ -1145,7 +1145,7 @@ session()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Match, if the session has the value 1234567 in the structure :php:`$foo['bar']`:
         [session("foo|bar") == 1234567]
@@ -1200,7 +1200,7 @@ site()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # Site identifier
         [site("identifier") == "my_site"]
@@ -1230,7 +1230,7 @@ site()
     Site settings can also be used in the conditions in TypoScript constants:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/constants.typoscript
 
         my.constant = my global value
         [traverse(site('configuration'), 'settings/some/setting') == 'someValue']
@@ -1297,7 +1297,7 @@ siteLanguage()
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         [siteLanguage("fallbackType") == "strict"]
             page.10.value = This site has a strict language fallback
@@ -1354,7 +1354,7 @@ TypoScript constants can be used in conditions with the
 :ref:`Syntax <typoscript-syntax-conditions-syntax>` for conditions:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} == 1]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1384,14 +1384,14 @@ Without using strict type comparison following two examples are true if
 constant is set to 1:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} == 1]
         page.10.value = The feature 1 of my_extension is enabled.
     [END]
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} == "1"]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1402,14 +1402,14 @@ That's because the stored number of the constant was not wrapped with quotes
 and was therefor interpreted as integer.
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} === 1]
         page.10.value = The feature 1 of my_extension is enabled.
     [END]
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} === "1"]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1427,7 +1427,7 @@ to prevent interpreting the values as integer or float.
 Following condition is always false:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [{$tx_my_extension.settings.feature1Enabled} == "active"]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1436,7 +1436,7 @@ Following condition is always false:
 If you are working with strings in conditions please do it that way:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     ["{$tx_my_extension.settings.feature1Enabled}" == "active"]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1445,7 +1445,7 @@ If you are working with strings in conditions please do it that way:
 Sure, strict type string comparisons are also working:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     ["{$tx_my_extension.settings.feature1Enabled}" === "active"]
         page.10.value = The feature 1 of my_extension is enabled.
@@ -1462,7 +1462,7 @@ processed by expression language. That allows experimental structures: If
 and page title is `Home` following condition is true:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [traverse({$foo}, "title") == "Home"]
         page.10.value (
@@ -1473,7 +1473,7 @@ and page title is `Home` following condition is true:
 After the replacement of the constant the example will result into:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     [traverse(page, "title") == "Home"]
         page.10.value (

--- a/Documentation/ContentObjects/Case/Index.rst
+++ b/Documentation/ContentObjects/Case/Index.rst
@@ -144,7 +144,7 @@ renderings of some content depending on whether the :ref:`cobj-case-key` field
 The result is in either case wrapped with :typoscript:`|<br>`.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     stuff = CASE
     stuff.if.isTrue.field = header

--- a/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
+++ b/Documentation/ContentObjects/CoaAndCoaInt/Index.rst
@@ -102,7 +102,7 @@ Examples:
 =========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.contentexample = COA
     lib.contentexample {
@@ -124,7 +124,7 @@ The previous example will print a simple :html:`<h1>` header, followed by the pa
 content records and a :html:`<footer>` element.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.currentDate = COA_INT
     lib.currentDate {

--- a/Documentation/ContentObjects/Content/Index.rst
+++ b/Documentation/ContentObjects/Content/Index.rst
@@ -202,7 +202,7 @@ See PHP class :php:`\TYPO3\CMS\Frontend\ContentObject\ContentContentObject`
 for details on code level.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     1 = CONTENT
     1 {
@@ -228,7 +228,7 @@ for details on code level.
 Expanded form:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     1 = CONTENT
 
@@ -240,7 +240,7 @@ Expanded form:
 
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     // STEP 2: define parameters
 
@@ -269,7 +269,7 @@ Expanded form:
 
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     // STEP 3: find all records
 
@@ -297,7 +297,7 @@ Display all tt_content records from this page
 Here is an example of the CONTENT object:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     1 = CONTENT
     1.table = tt_content
@@ -321,7 +321,7 @@ Apply special rendering
 Here is an example of record-rendering objects:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.typeNum = 0

--- a/Documentation/ContentObjects/Extbaseplugin/Index.rst
+++ b/Documentation/ContentObjects/Extbaseplugin/Index.rst
@@ -62,7 +62,7 @@ Example: Display an Extbase plugin via TypoScript
 =================================================
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     page.10 = EXTBASEPLUGIN
     page.10.extensionName = MyExtension
@@ -83,7 +83,7 @@ Create a lib object which utilizes the :typoscript:`EXTBASEPLUGIN` into
 a :typoscript:`lib` object:
 
 ..  literalinclude:: _CodeSnippets/_libMyPlugin.typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
 For `extensionName` and `pluginName` use the names as configured in
 :php:`\TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin()`:

--- a/Documentation/ContentObjects/Fluidtemplate/Index.rst
+++ b/Documentation/ContentObjects/Fluidtemplate/Index.rst
@@ -166,7 +166,7 @@ file
     ..  rubric:: Example
 
     ..  literalinclude:: _includes/_fluidtemplate-file.typoscript
-        :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 ..  _cobj-fluidtemplate-properties-format:
 
@@ -223,7 +223,7 @@ layoutRootPaths
     ..  rubric:: Example
 
     ..  literalinclude:: _includes/_layoutRootPaths.typoscript
-        :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
     If property
     :ref:`layoutRootPath <cobj-fluidtemplate-properties-layoutrootpath>`
@@ -286,7 +286,7 @@ settings
     ..  rubric:: Example
 
     ..  literalinclude:: _includes/_settings.typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     To access copyrightYear in the template file use:
 
@@ -338,12 +338,12 @@ templateName
     ..  rubric:: Example 1
 
     ..  literalinclude:: _includes/_templateName.typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     ..  rubric:: Example 2
 
     ..  literalinclude:: _includes/_templateNameAutomatic.typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 ..  _cobj-fluidtemplate-properties-templaterootpath:
 
@@ -390,7 +390,7 @@ templateRootPaths
     ..  rubric:: Example
 
     ..  literalinclude:: _includes/_templateRootPaths.typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 ..  _cobj-fluidtemplate-properties-variables:
 
@@ -422,7 +422,7 @@ custom ones. In this example the Fluid Styled Content
 element "Text" has its data transformed for easier and enhanced usage.
 
 ..  literalinclude:: /DataProcessing/_RecordTransformationProcessor/_WithDatabaseFluidTemplate.typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
 For usage of the variables within Fluid see
 :ref:`RecordTransformationProcessor-fluidtemplate-example`.
@@ -446,7 +446,7 @@ like this:
 You could use it with TypoScript code like this:
 
 ..  literalinclude:: _includes/_example.typoscript
-    :caption: Before migration, EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: Before migration, EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 As a result, the page title and the label from TypoScript will be inserted as
 titles. The copyright year will be taken from the TypoScript constant
@@ -466,11 +466,11 @@ Migration from `FLUIDTEMPLATE` to `PAGEVIEW`
 
 ..  literalinclude:: _includes/_BeforeMigrationToPageview.typoscript
     :language: typoscript
-    :caption: Before migration, EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: Before migration, EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 ..  literalinclude:: _includes/_AfterMigrationToPageview.typoscript
     :language: typoscript
-    :caption: After migration, EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: After migration, EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 In Fluid, the pageUid is available as :fluid:`{page.uid}` and pageTitle
 as :fluid:`{page.title}`, the subtitle with :fluid:`{page.subtitle}`.

--- a/Documentation/ContentObjects/GeneralInformation/Index.rst
+++ b/Documentation/ContentObjects/GeneralInformation/Index.rst
@@ -41,7 +41,7 @@ values.
 This example will show you how it works:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    #
    # Temporary objects are defined:
@@ -123,7 +123,7 @@ Example:
 --------
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    page.10 = TEXT
    page.10.value = kasper

--- a/Documentation/ContentObjects/Hmenu/Tmenu/Index.rst
+++ b/Documentation/ContentObjects/Hmenu/Tmenu/Index.rst
@@ -247,7 +247,7 @@ Properties
             drops the filter "colPos=x" completely.
 
             ..  code-block:: typoscript
-                :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+                :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
                 tt_content.menu.20.3.1.sectionIndex.useColPos = -1
 

--- a/Documentation/ContentObjects/Image/Index.rst
+++ b/Documentation/ContentObjects/Image/Index.rst
@@ -201,7 +201,7 @@ layout.layoutKey
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         picture {
           element = <picture>###SOURCECOLLECTION###<img src="###SRC###" ###PARAMS### ###ALTPARAMS### ###SELFCLOSINGTAGSLASH###></picture>
@@ -309,7 +309,7 @@ sourceCollection
     define to suit your needs.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         sourceCollection {
           small {
@@ -564,7 +564,7 @@ Standard rendering
 ------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = IMAGE
     # toplogo.png has the dimensions 300 x 150 pixels.
@@ -593,7 +593,7 @@ Responsive/adaptive rendering
 -----------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     30 = IMAGE
     30 {

--- a/Documentation/ContentObjects/LoadRegister/Index.rst
+++ b/Documentation/ContentObjects/LoadRegister/Index.rst
@@ -42,7 +42,7 @@ Properties
     :typoscript:`head`.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.27 = LOAD_REGISTER
         page.27 {
@@ -60,7 +60,7 @@ Example:
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     1 = LOAD_REGISTER
     1.param.cObject = TEXT

--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -33,7 +33,7 @@ Example: Display a page with Fluid templates
 
 ..  literalinclude:: _includes/_pageWithFluid.typoscript
     :language: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 ..  _cobj-pageview-template-naming:
 
@@ -161,7 +161,7 @@ Let us assume, the current page loads the following TypoScript constants:
 
 ..  literalinclude:: _includes/_constants.typoscript
     :language: html
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/constants.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/constants.typoscript
 
 ..  literalinclude:: _includes/_PageWithConstant.fluid.html
     :language: html
@@ -253,7 +253,7 @@ Example: Display a main menu and a breadcrumb on the page
 
 ..  literalinclude:: _includes/_pageWithBreadcrumb.typoscript
     :language: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 The page template could look like this:
 
@@ -283,7 +283,7 @@ This is a basic definition of a :fluid:`PAGEVIEW` object with only one path to t
 templates:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.10 = PAGEVIEW
@@ -367,7 +367,7 @@ Example: Make additional variables available in the Fluid template
 
 ..  literalinclude:: _includes/_pageWithVariables.typoscript
     :langugage: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
 The following variables are now available in the Fluid template:
 

--- a/Documentation/ContentObjects/Records/Index.rst
+++ b/Documentation/ContentObjects/Records/Index.rst
@@ -209,7 +209,7 @@ The following example would display some related content
 referenced from the :guilabel:`page properties`.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.42 = RECORDS
     page.42 {
@@ -229,7 +229,7 @@ Selection with source II
 ------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 	20 = RECORDS
 	20 {
@@ -253,7 +253,7 @@ If you want to display categorized content with a :typoscript:`RECORDS` object
 you could do it like this:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 	categorized_content = RECORDS
 	categorized_content {
@@ -279,7 +279,7 @@ data processing. This way templating is much more flexible. See the following
 example from the system extension :file:`fluid_styled_content`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     tt_content.menu_categorized_content =< lib.contentElement
     tt_content.menu_categorized_content {

--- a/Documentation/ContentObjects/RestoreRegister/Index.rst
+++ b/Documentation/ContentObjects/RestoreRegister/Index.rst
@@ -33,7 +33,7 @@ be used to load values into the register and to restore previous values
 again.
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
      # Put first block into the register
      10 = LOAD_REGISTER

--- a/Documentation/ContentObjects/Svg/Index.rst
+++ b/Documentation/ContentObjects/Svg/Index.rst
@@ -72,7 +72,7 @@ src
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         src = fileadmin/svg/tiger.svg
 
@@ -105,7 +105,7 @@ Example
 Output the SVG with the defined dimensions:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = SVG
     10 {

--- a/Documentation/ContentObjects/Text/Index.rst
+++ b/Documentation/ContentObjects/Text/Index.rst
@@ -71,7 +71,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     10.value = This is a text in uppercase
@@ -81,7 +81,7 @@ The above example uses the stdWrap property :ref:`case <stdwrap-case>`. It
 returns "THIS IS A TEXT IN UPPERCASE".
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     10.value.field = title
@@ -95,7 +95,7 @@ stored in the database field :sql:`title`). The header is then wrapped in
 Now let us have a look at an extract from a more complex example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     10.value.field = bodytext
@@ -110,7 +110,7 @@ is useful inside :ref:`COA <cobj-coa>` objects.
 Here is the same example in its context:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = CONTENT
     10 {

--- a/Documentation/ContentObjects/UserAndUserInt/Index.rst
+++ b/Documentation/ContentObjects/UserAndUserInt/Index.rst
@@ -142,7 +142,7 @@ from TypoScript. Use this TypoScript configuration:
 
 ..  literalinclude:: _ExampleTime.typoscript
     :language: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 The file :file:`EXT:site_package/Classes/UserFunctions/ExampleTime.php` might
 amongst other things contain:
@@ -172,7 +172,7 @@ order. For this we use the following TypoScript:
 
 ..  literalinclude:: _ExampleListRecords.typoscript
     :language: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 The file :file:`EXT:site_package/Classes/UserFunctions/ExampleListRecords.php`
 may contain amongst other things:
@@ -214,7 +214,7 @@ the local machine". You can make it available like this:
 
 ..  literalinclude:: _Hostname.typoscript
     :language: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 Contents of :file:`EXT:site_package/Classes/UserFunctions/Hostname.php`:
 
@@ -296,7 +296,7 @@ cached.
 
 ..  literalinclude:: _ConvertUserToUserInt.typoscript
     :language: typoscript
-    :caption: Configuration/TypoScript/setup.typoscript
+    :caption: Configuration/Sets/Main/setup.typoscript
 
 This PHP class performs the dynamic transition from :typoscript:`USER` to :typoscript:`USER_INT`.
 

--- a/Documentation/DataProcessing/DatabaseQueryProcessor.rst
+++ b/Documentation/DataProcessing/DatabaseQueryProcessor.rst
@@ -98,7 +98,7 @@ Example usage for the data processor in conjunction with the
 :ref:`RecordTransformationProcessor`.
 
 ..  literalinclude:: _RecordTransformationProcessor/_WithDatabaseQueryProcessor.typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
 For usage of the variables within Fluid see
 :ref:`RecordTransformationProcessor-fluidtemplate-example`.

--- a/Documentation/DataProcessing/FilesProcessor.rst
+++ b/Documentation/DataProcessing/FilesProcessor.rst
@@ -241,7 +241,7 @@ The following example implements a slide functionality on root line
 for file resources:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10.dataProcessing {
         10 = TYPO3\CMS\Frontend\DataProcessing\FilesProcessor
@@ -268,7 +268,7 @@ Therefore, you can do the following:
 
 ..  literalinclude:: _FilesProcessorFlexForm.typoscript
     :language: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 This assumes that the image was stored in a FlexForm in the table
 :sql:`tt_content` like this:

--- a/Documentation/DataProcessing/FlexFormProcessor.rst
+++ b/Documentation/DataProcessing/FlexFormProcessor.rst
@@ -79,7 +79,7 @@ Example of a minimal TypoScript configuration
 ---------------------------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     10 = flex-form
 
@@ -92,7 +92,7 @@ Example of an advanced TypoScript configuration
 -----------------------------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     10 = flex-form
     10 {
@@ -109,7 +109,7 @@ Example with a custom sub-processor
 -----------------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     10 = flex-form
     10 {
@@ -130,7 +130,7 @@ Example of an advanced TypoScript configuration, which processes the field
 the :typoscript:`myOutputVariable` variable:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     10 = flex-form
     10 {

--- a/Documentation/DataProcessing/Index.rst
+++ b/Documentation/DataProcessing/Index.rst
@@ -61,7 +61,7 @@ the system extension :doc:`fluid_styled_content <typo3/cms-fluid-styled-content:
 In this system extension it is defined as follows:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.contentElement >
     lib.contentElement = FLUIDTEMPLATE

--- a/Documentation/DataProcessing/MenuProcessor/Directory.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Directory.rst
@@ -40,7 +40,7 @@ Properties
     This will generate a menu of all pages with pid = 35 and pid = 56.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         lib.metaMenu = HMENU
         lib.metaMenu {

--- a/Documentation/DataProcessing/MenuProcessor/Index.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Index.rst
@@ -80,7 +80,7 @@ Options
         So, for example if you build a simple "sitemap" menu like this one:
 
         ..  literalinclude:: _code-snippets/_entryLevel.typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         it will start to be visible from the 4th level (and will contain only
         the subpages from that level).
@@ -112,7 +112,7 @@ Options
         Additionally the current page is always excluded too.
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.dataProcessing.20.excludeUidList = 34,2,current
 

--- a/Documentation/DataProcessing/MenuProcessor/Keywords.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Keywords.rst
@@ -201,7 +201,7 @@ Example: Find related pages of the current page
 -----------------------------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.relatedPagesMenu = HMENU
     lib.relatedPagesMenu {

--- a/Documentation/DataProcessing/MenuProcessor/List.rst
+++ b/Documentation/DataProcessing/MenuProcessor/List.rst
@@ -36,7 +36,7 @@ Properties
     listed:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         lib.listOfSelectedPages = HMENU
         lib.listOfSelectedPages {

--- a/Documentation/DataProcessing/MenuProcessor/Rootline.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Rootline.rst
@@ -121,7 +121,7 @@ example will start at level 1 and does not show the page the user is
 currently on:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     temp.breadcrumbs = HMENU
     temp.breadcrumbs.special = rootline
@@ -137,7 +137,7 @@ all other levels will have :html:`target="_top"` as defined for the
 :ref:`TMENU <tmenu>` property :confval:`menu-common-properties-target`.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.2 = HMENU
     page.2.special = rootline

--- a/Documentation/DataProcessing/MenuProcessor/Updated.rst
+++ b/Documentation/DataProcessing/MenuProcessor/Updated.rst
@@ -41,7 +41,7 @@ special.value
     listed.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = HMENU
         20.special = updated

--- a/Documentation/DataProcessing/RecordTransformationProcessor.rst
+++ b/Documentation/DataProcessing/RecordTransformationProcessor.rst
@@ -36,7 +36,7 @@ Example usage for the Data Processor in conjunction with the
 :ref:`DatabaseQueryProcessor`.
 
 ..  literalinclude:: _RecordTransformationProcessor/_WithDatabaseQueryProcessor.typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
 
 ..  _RecordTransformationProcessor-fluidtemplate-example:
@@ -50,7 +50,7 @@ custom ones. In this example the Fluid Styled Content
 element "Text" has its data transformed for easier and enhanced usage.
 
 ..  literalinclude:: _RecordTransformationProcessor/_WithDatabaseFluidTemplate.typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
 ..  _RecordTransformationProcessor-fluid:
 

--- a/Documentation/Functions/Cache.rst
+++ b/Documentation/Functions/Cache.rst
@@ -101,7 +101,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     5 = TEXT
     5 {
@@ -123,7 +123,7 @@ cObject will be cached and reused on all pages (showing you the same
 timestamp). :
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     5 = TEXT
     5 {
@@ -148,7 +148,7 @@ content objects. This skips the rendering even for content objects that evaluate
 Usage:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.10 = COA

--- a/Documentation/Functions/Calc.rst
+++ b/Documentation/Functions/Calc.rst
@@ -37,7 +37,7 @@ The :typoscript:`HMENU` :typoscript:`maxAge` property is of a type
 
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    20 = HMENU
    20.special = updated

--- a/Documentation/Functions/Data.rst
+++ b/Documentation/Functions/Data.rst
@@ -15,7 +15,7 @@ from database tables.
 The general syntax is as follows:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = <key> : <code>
 
@@ -26,7 +26,7 @@ The :typoscript:`code` can contain pipe characters :typoscript:`|` which will
 result in a multidimensional array. This, for example, works with :typoscript:`TSFE`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = request : frontend.user | username
 
@@ -43,7 +43,7 @@ content of the "header" field. If "header" is empty, "title" is
 retrieved. If "title" is also empty, the "uid" field is retrieved:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = field : header // field : title // field : uid
 
@@ -76,7 +76,7 @@ Example: Evaluate the current application context
 Evaluate if the current application context is "Production":
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     if {
         value.data = applicationcontext
@@ -106,7 +106,7 @@ Example: Display extension icon with cache buster
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     page.20 = TEXT
     page.20 {
@@ -132,7 +132,7 @@ Example: Get the number of the current cObject record
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = cObj : parentRecordNumber
 
@@ -160,7 +160,7 @@ Example: Retrieve current workspace ID
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = TEXT
     page.10.data = context:workspace:id
@@ -184,7 +184,7 @@ Example: Get the current value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = current
 
@@ -205,7 +205,7 @@ Example:  Get the current time formatted dd-mm-yy
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = date : d-m-y
 
@@ -233,7 +233,7 @@ Get the value of the header field of record with uid 234 from table
 :sql:`tt_content`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = DB : tt_content:234:header
 
@@ -241,7 +241,7 @@ Get the value of the header field of a record, where the uid is in the
 `myContentId` GET parameter :
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data.dataWrap = DB : tt_content:{GP : myContentId}:header
     lib.foo.data.wrap3 = {|}
@@ -274,7 +274,7 @@ Example: Debug the current root-line
 Outputs the current root-line visually in HTML:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = debug : rootLine
 
@@ -309,7 +309,7 @@ Example: Get header data
 Get content from :php:`$cObj->data['header']`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = field : header
 
@@ -321,7 +321,7 @@ Example: Get data in a field
 Get content from :php:`$cObj->data['fieldname']['level1']['level2']`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = field : fieldname | level1 | level2
 
@@ -359,7 +359,7 @@ Example: Get the size of a file
 Get the size of the file with sys\_file UID 17:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = file : 17 : size
 
@@ -382,7 +382,7 @@ Example: Get a FlexForm value
 Return the FlexForm value of given name:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = flexform : pi_flexform:settings.categories
 
@@ -421,7 +421,7 @@ Example: Get the title of the previous page
 Get the title of the page before the start of the current website:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = fullRootLine : -1, title
 
@@ -445,7 +445,7 @@ Example: Get the HTTP referer
 Get the environment variable `HTTP_REFERER`.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = getenv : HTTP_REFERER
 
@@ -499,7 +499,7 @@ Example: Get the remote address
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # get and output the client IP
     page = PAGE
@@ -538,14 +538,14 @@ Example: Get the input value from query string
 Get input value from query string `&stuff=...`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = GP : stuff
 
 Get input value from query string `&stuff[bar]=...`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = GP : stuff | bar
 
@@ -565,7 +565,7 @@ Example: Get the root line level of the current page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = level
 
@@ -589,7 +589,7 @@ Example: Get a field from a page up the root-line
 Get the value of user-defined field :sql:`tx_myextension_myfield` in the root line.
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = levelfield : -1, tx_myextension_myfield, slide
 
@@ -632,7 +632,7 @@ Example: Get the title of a page up the root line
 Get the title of the page on the first level of the root line:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = leveltitle : 1
 
@@ -641,7 +641,7 @@ it is empty, walk to the bottom of the root line until there is a
 title:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = leveltitle : -2, slide
 
@@ -667,7 +667,7 @@ Example: Get the ID of the root page of the page tree
 Get the ID of the root page of the website (level zero):
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = leveluid : 0
 
@@ -692,7 +692,7 @@ Example: Get a localized label
 Get the localized label for the logout button:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = LLL : EXT:felogin/Resources/Private/Language/locallang.xlf:logout
 
@@ -713,7 +713,7 @@ Example: Get the current page title
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = page : title
 
@@ -733,7 +733,7 @@ Example: Get the current backend layout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = pagelayout
 
@@ -756,7 +756,7 @@ Example: Get the parameter `color`
 Get content from :php:`$cObj->parameters['color']`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = parameters : color
 
@@ -775,7 +775,7 @@ path
     does not exist.
 
     ..  code-block:: typoscript
-        :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
         :emphasize-lines: 3
 
         page.20 = TEXT
@@ -793,7 +793,7 @@ Example: Resolve the path to a file
 Get path to file `rsaauth.js` (inside extension rsaauth) relative to siteroot:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = path : EXT:rsaauth/resources/rsaauth.js
 
@@ -801,7 +801,7 @@ It can also be helpful in combination with the stdWrap function
 :ref:`stdwrap-insertData`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.headerData.10 = TEXT
     page.headerData.10 {
@@ -828,7 +828,7 @@ Example: Get the content of a register
 Get content from a :ref:`register <using-setting-register>`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = register : color
 
@@ -856,7 +856,7 @@ Example: Get the page type
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = request : routing | pageType
 
@@ -866,7 +866,7 @@ Example: Get a query argument
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Retrieve the value of the query parameter ?myParam=<value>
     lib.foo.data = request : routing | queryArguments | myParam
@@ -880,7 +880,7 @@ Example: Get the nonce
 ~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = request : nonce | value
 
@@ -904,7 +904,7 @@ Example: Get a value stored in the current session
 Get the number of items of a stored shopping cart array/object:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.foo.data = session : shop_cart | itemCount
 
@@ -947,7 +947,7 @@ Example: Get values from the current site
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = TEXT
     page.10.data = site:base
@@ -957,7 +957,7 @@ Example: Get values from the current site
 configuration key(s) to access.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = TEXT
     page.10.data = site:customConfigKey.nested.value
@@ -1043,7 +1043,7 @@ Example: Get values from the current site language
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = TEXT
     page.10.data = siteLanguage:navigationTitle
@@ -1074,7 +1074,7 @@ Example: Access the redirects HTTP status code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10 = TEXT
     page.10.data = siteSettings:redirects.httpStatusCode

--- a/Documentation/Functions/Encapslines.rst
+++ b/Documentation/Functions/Encapslines.rst
@@ -12,7 +12,7 @@ This function is a sub-function of :ref:`stdWrap <stdwrap>` and can be used
 like this:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     page.20 = TEXT
     page.20 {
@@ -52,7 +52,7 @@ encapsTagList
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         encapsTagList = div, p
 
@@ -113,7 +113,7 @@ addAttributes.[*tagname*]
     ([*tagname*] is in uppercase.)
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         addAttributes.P.setOnly = exists
 
@@ -127,7 +127,7 @@ addAttributes.[*tagname*]
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         addAttributes.P {
             style = padding-bottom: 0px; margin-top: 1px; margin-bottom: 1px;
@@ -183,7 +183,7 @@ wrapNonWrappedLines
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         wrapNonWrappedLines = <p>|</p>
 
@@ -271,7 +271,7 @@ Examples
 ------------------------------------------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     encapsLines {
         encapsTagList = div,p
@@ -318,7 +318,7 @@ Advanced example
 ----------------
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Make sure nonTypoTagStdWrap operates
     # on content outside <typolist> and <typohead> only:

--- a/Documentation/Functions/GetEnv.rst
+++ b/Documentation/Functions/GetEnv.rst
@@ -31,7 +31,7 @@ Example
 =======
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    # Define default value
    myConstant = defaultValue

--- a/Documentation/Functions/HtmlparserTags.rst
+++ b/Documentation/Functions/HtmlparserTags.rst
@@ -234,7 +234,7 @@ fixAttrib.[attribute].prefixRelPathWith
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         lib.parser.fixAttrib.src.prefixRelPathWith = https://example.org/typo3/32/dummy/
 
@@ -262,7 +262,7 @@ fixAttrib.[attribute].userFunc
     Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         lib.parser.fixAttrib.href.userFunc = \Vendor\ExtName\ClassName->function
 
@@ -277,7 +277,7 @@ fixAttrib.[attribute].userFunc
     user function:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         lib.parser.fixAttrib.href.userFunc.myCustomParm = myCustomValue
 

--- a/Documentation/Functions/If.rst
+++ b/Documentation/Functions/If.rst
@@ -50,7 +50,7 @@ bitAnd
     TYPO3 uses bits to store radio and checkboxes via TCA, `bitAnd` can be used to test against these fields.
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        lib.hideDefaultLanguageOfPage = TEXT
        lib.hideDefaultLanguageOfPage {
@@ -79,7 +79,7 @@ contains
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
         :emphasize-lines: 11
 
         # Add a span tag before the page title if the page title
@@ -126,7 +126,7 @@ endsWith
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
         :emphasize-lines: 7
 
         # Add a footer note, if the page author ends with "Kott"
@@ -153,7 +153,7 @@ equals
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         if.equals = POST
         if.value.data = GETENV:REQUEST_METHOD
@@ -200,7 +200,7 @@ isInList
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         if.isInList.field = uid
         if.value = 1,2,34,50,87
@@ -237,7 +237,7 @@ isNull
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10 = COA_INT
         page.10.10 = TEXT
@@ -307,7 +307,7 @@ startsWith
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
         :emphasize-lines: 6
 
         page.10 = TEXT
@@ -354,7 +354,7 @@ If you want to compare values, you must load a base-value in the
 :typoscript:`value`-property. Example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10.if.value = 10
     page.10.if.isGreaterThan = 11
@@ -365,7 +365,7 @@ greater than 10, which is the base-value.
 More complex is this:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.10.if {
       value = 10
@@ -388,7 +388,7 @@ This is a GIFBUILDER object that will write "NEW" on a menu-item if
 the field "newUntil" has a date less than the current date!
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     30 = TEXT
     30.text = NEW!

--- a/Documentation/Functions/Imgresource.rst
+++ b/Documentation/Functions/Imgresource.rst
@@ -25,7 +25,7 @@ An imgResource one of the following:
 Here "file" is an imgResource:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = IMAGE
     10 {
@@ -36,7 +36,7 @@ Here "file" is an imgResource:
 GIFBUILDER:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = IMAGE
     10.file = GIFBUILDER
@@ -108,7 +108,7 @@ width
     This crops 120x80px from the center of the scaled image:
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        lib.image {
            width = 120c
@@ -119,7 +119,7 @@ width
     images centered:
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        lib.image {
            width = 100c-100
@@ -130,7 +130,7 @@ width
     and portrait-images a bit higher than centered:
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        lib.image {
            width = 100c+30
@@ -198,7 +198,7 @@ noScale
     Here :file:`test.jpg` could have 1600 x 1200 pixels for example:
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        file = fileadmin/test.jpg
        file.width = 240m
@@ -236,21 +236,21 @@ crop
     Disable cropping set by the editor in the back-end:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tt_content.image.20.1.file.crop =
 
     Overrule/set cropping for all images:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tt_content.image.20.1.file.crop = 50,50,100,100
 
     Natively crop a SVG image:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10 = IMAGE
         page.10.file = 2:/myfile.svg
@@ -277,7 +277,7 @@ cropVariant
     Use 'desktop' crop variant:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tt_content.image.20.1.file {
             crop.data = file:current:crop
@@ -318,7 +318,7 @@ import
     data-array:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tt_content.image.20.1.file {
             import = uploads/pics/
@@ -411,7 +411,7 @@ stripProfile
     ..  rubric:: Examples
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 = IMAGE
         10.file = fileadmin/images/image1.jpg
@@ -501,7 +501,7 @@ This scales the image :file:`fileadmin/toplogo.png` to the width of 200
 pixels:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     file = fileadmin/toplogo.png
     file.width = 200

--- a/Documentation/Functions/Makelinks.rst
+++ b/Documentation/Functions/Makelinks.rst
@@ -97,7 +97,7 @@ http.keep
     get the following results:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         http.keep = "":                   # example.org
         http.keep = "scheme":             # https://example.org
@@ -118,7 +118,7 @@ http.ATagParams
     ..  rubric:: Examples
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         http.ATagParams = class="board"
 
@@ -174,6 +174,6 @@ mailto.ATagParams
     ..  rubric:: Examples
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         mailto.ATagParams = class="board"

--- a/Documentation/Functions/Numberformat.rst
+++ b/Documentation/Functions/Numberformat.rst
@@ -74,7 +74,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.myPrice = TEXT
     lib.myPrice {

--- a/Documentation/Functions/Numrows.rst
+++ b/Documentation/Functions/Numrows.rst
@@ -55,7 +55,7 @@ Get the number of content elements within certain :sql:`colPos` of the current
 page.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = FLUIDTEMPLATE
     10 {

--- a/Documentation/Functions/OptionSplit.rst
+++ b/Documentation/Functions/OptionSplit.rst
@@ -26,7 +26,7 @@ As a result all A-tags generated from this definition will have the `class` attr
 set like this: :html:`<a class="z" ... >`:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    topmenu.1.NO {
        ATagParams = class="z"
@@ -85,7 +85,7 @@ will be ignored.
 On the input side we may have for example:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    wrap =                      # We have: M=0  items; 1  mainpart : A      ; mainpart is empty
    wrap = A                    # We have: M=1  items; 1  mainpart : A      ;
@@ -117,7 +117,7 @@ subparts is `||`.
 Example:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    wrap = a                       # We have: M=1  item,  1 mainpart,  1 subparts
    wrap = a || b                  # We have: M=2  items, 1 mainpart,  2 subparts
@@ -143,7 +143,7 @@ We have all three mainparts A, R and Z. And each mainpart is split into three
 subparts:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    wrap = a || b || c  |*|  r || s || t  |*|  x || y || z
 
@@ -157,7 +157,7 @@ And this is what happens:
 
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    wrap = a || b || c  |*|  r || s || t  |*|  x || y || z
 
@@ -921,7 +921,7 @@ Test Code 1 (TypoScript)
 ========================
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/constants.typoscript
 
    os_1 = a
    os_2 = a || b || c
@@ -938,7 +938,7 @@ Test Code 1 (TypoScript)
    os6 = a||b|*|c|*|d||e
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    temp.marray = HMENU
    temp.marray {
@@ -1257,7 +1257,7 @@ Test Code 2 (TypoScript)
 This is the code that was used to produce many of the above examples.
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/constants.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/constants.typoscript
 
    os1 = a
    os2 = a||b||c
@@ -1319,7 +1319,7 @@ This is the code that was used to produce many of the above examples.
    os6 = a   |*|r|||||||*|  z
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    lib.marray = HMENU
    lib.marray {

--- a/Documentation/Functions/Parsefunc.rst
+++ b/Documentation/Functions/Parsefunc.rst
@@ -98,7 +98,7 @@ externalBlocks
     overridden
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 
         tt_content.text.20.parseFunc.externalBlocks {
@@ -139,7 +139,7 @@ short
     and "T3web" with a link to typo3.org.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10 = TEXT
         page.10.value = Learn more about T3, look here: T3web
@@ -286,7 +286,7 @@ allowTags
     The example allows any tag, except :html:`<u>` which will be encoded:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 = TEXT
         10.value = <p><em>Example</em> <u>underlined</u> text</p>
@@ -327,7 +327,7 @@ denyTags
     This allows :html:`<b>`, :html:`<i>`, :html:`<a>` and :html:`<img>` -tags to exist:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tt_content.text.20.parseFunc {
             allowTags = b,i,a,img
@@ -357,7 +357,7 @@ through the :ref:`parsefunc-makelinks`-functions and substitutes all
 :html:`<LINK>` and :html:`<TYPOLIST>`-tags with something else.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     tt_content.text.default {
         20 = TEXT

--- a/Documentation/Functions/Replacement.rst
+++ b/Documentation/Functions/Replacement.rst
@@ -63,7 +63,7 @@ useRegExp
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 {
             search = #(a )CAT#i
@@ -93,7 +93,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     10 {
@@ -121,7 +121,7 @@ block! Yeah!".
 The following examples demonstrate the use of :ref:`optionsplit`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     20 = TEXT
     20.value = There_are_a_cat,_a_dog_and_a_tiger_in_da_hood!_Yeah!
@@ -134,7 +134,7 @@ The following examples demonstrate the use of :ref:`optionsplit`:
 This returns: "There1are2a3cat,3a3dog3and3a3tiger3in3da3hood!3Yeah!"
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     30 = TEXT
     30.value = There are a cat, a dog and a tiger in da hood! Yeah!

--- a/Documentation/Functions/Round.rst
+++ b/Documentation/Functions/Round.rst
@@ -79,7 +79,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.number = TEXT
     lib.number {

--- a/Documentation/Functions/Select.rst
+++ b/Documentation/Functions/Select.rst
@@ -56,7 +56,7 @@ uidInList
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         select {
            uidInList = 1,2,3
@@ -104,7 +104,7 @@ pidInList
     Fetch related `sys_category` records stored in the MM intermediate table:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 = CONTENT
         10 {
@@ -151,7 +151,7 @@ orderBy
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         orderBy = sorting, title
 
@@ -170,7 +170,7 @@ groupBy
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         groupBy = CType
 
@@ -218,7 +218,7 @@ where
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         where = (title LIKE '%SOMETHING%' AND NOT doktype)
 
@@ -226,7 +226,7 @@ where
     framework quote these fields:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         where = ({#title} LIKE {#%SOMETHING%} AND NOT {#doktype})
 
@@ -299,7 +299,7 @@ join, leftjoin, rightjoin
     Fetch related `sys_category` records stored in the MM intermediate table:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 = CONTENT
         10 {
@@ -351,7 +351,7 @@ markers
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.60 = CONTENT
         page.60 {
@@ -370,7 +370,7 @@ markers
     "first".
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.60 = CONTENT
         page.60 {
@@ -400,7 +400,7 @@ It is possible to use `{#fieldname}` to make the database
 framework quote these fields (see :doc:`ext_core:Changelog/8.7/Important-80506-DbalCompatibleFieldQuotingInTypoScript`):
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     select.where = ({#title} LIKE {#%SOMETHING%} AND NOT {#doktype})
 
@@ -429,7 +429,7 @@ See PHP source code for
 Condensed form:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = CONTENT
     10 {

--- a/Documentation/Functions/Split.rst
+++ b/Documentation/Functions/Split.rst
@@ -86,7 +86,7 @@ returnCount
     ..  rubric:: Example
 
     .. code-block:: typoscript
-       :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+       :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
        # returns 9
        1 = TEXT
@@ -127,7 +127,7 @@ cObjNum
     ..  rubric:: Example for stdWrap
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         1.current = 1
         1.wrap = <b> | </b>
@@ -135,7 +135,7 @@ cObjNum
     ..  rubric:: Example for stdWrap
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         1 {
             10 = TEXT

--- a/Documentation/Functions/Stdwrap.rst
+++ b/Documentation/Functions/Stdwrap.rst
@@ -42,7 +42,7 @@ because the value is imported from the header field in
 :php:`$cObj->data-array`.
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    10 = TEXT
    10.value = some text
@@ -128,7 +128,7 @@ Properties for getting data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = TEXT
             page.10.value = I am a Berliner!
@@ -162,7 +162,7 @@ Properties for getting data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.field = title
 
@@ -171,7 +171,7 @@ Properties for getting data
         You can provide multiple field name options separated by "//".
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.field = nav_title // title
 
@@ -282,7 +282,7 @@ Properties for overriding and conditions
 
         ..  rubric:: Examples
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = COA_INT
             page.10 {
@@ -353,7 +353,7 @@ Properties for overriding and conditions
         This would return "item 1":
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = TEXT
             page.10.value = item 1, item 2, item 3, item 4
@@ -362,7 +362,7 @@ Properties for overriding and conditions
         This would return "item 3"
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = TEXT
             page.10.value = item 1, item 2, item 3, item 4
@@ -383,7 +383,7 @@ Properties for overriding and conditions
             a random element
 
             ..  code-block:: typoscript
-                :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+                :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
                 page.5 = COA_INT
                 page.5 {
@@ -502,7 +502,7 @@ Properties for parsing data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 {
                 parseFunc = < lib.parseFunc_RTE
@@ -521,7 +521,7 @@ Properties for parsing data
     by default). This is not recommended.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         // either disable globally
         lib.parseFunc.htmlSanitize = 0
@@ -540,7 +540,7 @@ Properties for parsing data
     sanitized and can be solved by explicitly disabling it with :typoscript:`htmlSanitize = 0`.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10 = FLUIDTEMPLATE
         10 {
@@ -675,7 +675,7 @@ Properties for parsing data
 
         ..  rubric:: Examples
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = TEXT
             page.10 {
@@ -733,7 +733,7 @@ Properties for parsing data
         Render in human readable form:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 = TEXT
             page.10.value {
@@ -762,7 +762,7 @@ Properties for parsing data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.date_as_timestamp = TEXT
             lib.date_as_timestamp {
@@ -771,7 +771,7 @@ Properties for parsing data
             }
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.next_weekday = TEXT
             lib.next_weekday {
@@ -859,7 +859,7 @@ Properties for parsing data
         ..  rubric:: Example: Full German output from a date/time value
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.my_formatted_date = TEXT
             lib.my_formatted_date {
@@ -874,7 +874,7 @@ Properties for parsing data
         ..  rubric:: Example: Full French output from a relative date value
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.my_formatted_date = TEXT
             lib.my_formatted_date {
@@ -888,7 +888,7 @@ Properties for parsing data
         ..  rubric:: Example: Custom format from a timestamp
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.my_formatted_date = TEXT
             lib.my_formatted_date {
@@ -935,7 +935,7 @@ Properties for parsing data
 
         ..  rubric:: Examples
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             lib.ageFormat = TEXT
             lib.ageFormat.stdWrap.data = page:tstamp
@@ -973,7 +973,7 @@ Properties for parsing data
         Code:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             10 = TEXT
             10.value = Hello world!
@@ -1039,7 +1039,7 @@ Properties for parsing data
             handling settings. Example:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10 {
                value = abc
@@ -1053,7 +1053,7 @@ Properties for parsing data
         Output value 1000 without special formatting. Shows `1000`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1064,7 +1064,7 @@ Properties for parsing data
         Format value 1000 in IEC style with base=1024. Shows `0.98 Ki`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1077,7 +1077,7 @@ Properties for parsing data
         Shows `0.98 KiB`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1090,7 +1090,7 @@ Properties for parsing data
         Format value 1000 in SI style with base=1000. Shows `1.00 k`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1104,7 +1104,7 @@ Properties for parsing data
         Shows `1.00 kb`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1119,7 +1119,7 @@ Properties for parsing data
         `1.00 x 1000 Bytes`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1134,7 +1134,7 @@ Properties for parsing data
         `1.00 kilobyte (kB)`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1149,7 +1149,7 @@ Properties for parsing data
         `0.98 kibibyte (KiB)`:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page = PAGE
             page.10 = TEXT
@@ -1286,7 +1286,7 @@ Properties for parsing data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             10 = TEXT
             10.stdWrap {
@@ -1459,7 +1459,7 @@ Properties for wrapping data
 
         ..  rubric:: Examples
         .. code-block:: typoscript
-           :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+           :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
            page.10.noTrimWrap = | val1 | val2 |
 
@@ -1468,7 +1468,7 @@ Properties for wrapping data
 
         ..  rubric:: Examples
         .. code-block:: typoscript
-           :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+           :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
            page.10 {
               noTrimWrap = ^ val1 ^ val2 ^ || ^ val3 ^ val4 ^
@@ -1504,7 +1504,7 @@ Properties for wrapping data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.dataWrap = <div id="{page : uid}"> | </div>
 
@@ -1557,7 +1557,7 @@ Properties for wrapping data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             10 = TEXT
             10.value = a
@@ -1603,7 +1603,7 @@ Properties for wrapping data
         Displays the page title:
 
         .. code-block:: typoscript
-           :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+           :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
            10 = TEXT
            10.value = This is the page title: {page:title}
@@ -1654,7 +1654,7 @@ Properties for wrapping data
         You can paste this example directly into a new template record:
 
         ..  literalinclude:: _StdWrap/_UserFunction.typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         Your methods will get the parameters :php:`$content` and :php:`$conf`
         (in that order) and need to return a string.
@@ -1722,7 +1722,7 @@ Properties for wrapping data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             prefixComment = 2 | CONTENT ELEMENT, uid:{field:uid}/{field:CType}
 
@@ -1763,7 +1763,7 @@ Properties for sanitizing and caching data
         ..  rubric:: Examples
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             10 = TEXT
             10 {
@@ -1780,7 +1780,7 @@ Properties for sanitizing and caching data
         The following code is equivalent to the above, but specifies a builder:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             10 = TEXT
             10 {
@@ -1866,7 +1866,7 @@ Example
 Content object ":ref:`cobj-text`" containing property "value":
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     10.value = some text

--- a/Documentation/Functions/Strpad.rst
+++ b/Documentation/Functions/Strpad.rst
@@ -73,7 +73,7 @@ Examples
 ========
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     10 = TEXT
     # The input value is 34 signs long.

--- a/Documentation/Functions/Tags.rst
+++ b/Documentation/Functions/Tags.rst
@@ -63,7 +63,7 @@ Properties
     ..  rubric:: Examples
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         tags.bold = TEXT
         tags.bold {
@@ -95,7 +95,7 @@ the content of the tag.
 should be the image-reference in :file:`fileadmin/images/`.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     tags {
         link = TEXT

--- a/Documentation/Functions/Typolink.rst
+++ b/Documentation/Functions/Typolink.rst
@@ -120,7 +120,7 @@ additionalParams
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.typolink.additionalParams = '&print=1'
         page.20.typolink.additionalParams = '&sword_list[]=word1&sword_list[]=word2'
@@ -132,7 +132,7 @@ additionalParams
     SWORD\_PARAMS and can be insert directly like this:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
            page.20.typolink.additionalParams.data = register:SWORD_PARAMS
 
@@ -256,7 +256,7 @@ parameter
         the correct target language will be resolved from the parameter):
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.typolink.parameter = t3://page?uid=51
 
@@ -265,7 +265,7 @@ parameter
         title attribute reading "Very important information":
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.typolink.parameter = t3://page?uid=current _blank specialLink "Very important information"
 
@@ -281,14 +281,14 @@ parameter
         define a class (third value) without having to define a target:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.typolink.parameter = https://example.com/ - specialLink
 
     #.  A mailto link with a title attribute (but no target and no class):
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             page.10.typolink.parameter = mailto:info@example.org - - "Send a mail to main TYPO3 contact"
 
@@ -338,7 +338,7 @@ parameter
         Open page 51 in a popup window measuring 400 by 300 pixels:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             typolink.parameter = 51 400x300
 
@@ -346,7 +346,7 @@ parameter
         not make the window resizable and show the location bar:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             typolink.parameter = 51 400x300:resizable=0,location=1
 
@@ -371,7 +371,7 @@ parameter
             be defined explicitly, but imported like this:
 
             ..  code-block:: typoscript
-                :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+                :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
                 typolink.parameter.data = parameters : allParams
 
@@ -412,7 +412,7 @@ forceAbsoluteUrl.scheme
     default value. Example:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         typolink {
            parameter = 13
@@ -446,7 +446,7 @@ JSwindow\_params
     possible attributes:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.typolink.JSwindow_params = status=1,menubar=1,scrollbars=1,resizable=1,location=1,directories=1,toolbar=1
 
@@ -514,7 +514,7 @@ ATagParams
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.typolink.ATagParams = class="board"
 
@@ -929,7 +929,7 @@ Examples
 Create a link to page with uid 2:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.20 = TEXT
     page.20.value = anchor text
@@ -945,7 +945,7 @@ Output:
 Just display the URL:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.30 = TEXT
     page.30.typolink.parameter = 2

--- a/Documentation/Functions/Wrap.rst
+++ b/Documentation/Functions/Wrap.rst
@@ -29,6 +29,6 @@ Wrap
     value red:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.wrap = <p class="bg-red"> | </p>

--- a/Documentation/Functions/_Examples/Typolink-Example.rst
+++ b/Documentation/Functions/_Examples/Typolink-Example.rst
@@ -22,7 +22,7 @@ Given this TypoScript example:
 
 ..  literalinclude:: ../_StdWrap/_UserFunc.typoscript
     :language: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
 This would first create a TypoLink :php:`LinkResultInterface` that would resolve to something like
 :html:`<a href="/en/pages/4711?someKey=someValue" rel="noreferrer">My Link Text</a>`.

--- a/Documentation/Gifbuilder/Calc.rst
+++ b/Documentation/Gifbuilder/Calc.rst
@@ -20,14 +20,14 @@ On using the special function :typoscript:`max()`, the maximum of multiple
 values can be determined. Example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     XY = [10.w]+[20.w], max([10.h], [20.h])
 
 Here is a full example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
     :emphasize-lines: 5
 
     lib.example = IMAGE

--- a/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Adjust/Index.rst
@@ -18,7 +18,7 @@ Example
 =======
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     20 = ADJUST
     20.value = inputLevels = 13, 230
@@ -58,7 +58,7 @@ inputLevels
     to end at 190 of the original (which is set as 255 for the new image).
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = ADJUST
         20.value = inputLevels = 50, 190
@@ -90,7 +90,7 @@ outputLevels
     above 190 in the image.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = ADJUST
         20.value = outputLevels = 50, 190
@@ -110,7 +110,7 @@ autoLevels
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = ADJUST
         20.value = autoLevels

--- a/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Box/Index.rst
@@ -14,7 +14,7 @@ Example
 =======
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     lib.example = IMAGE
     lib.example {
@@ -81,7 +81,7 @@ align
     Horizontally centered, vertically at the bottom:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         align = c, b
 

--- a/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Crop/Index.rst
@@ -60,7 +60,7 @@ align
     Horizontally centered, vertically at the bottom:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         align = c, b
 

--- a/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Effect/Index.rst
@@ -33,7 +33,7 @@ Example
 =======
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     lib.image = IMAGE
     lib.image {
@@ -73,7 +73,7 @@ blur
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = blur=10
@@ -95,7 +95,7 @@ charcoal
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = charcoal=5
@@ -115,7 +115,7 @@ colors
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = colors=100
@@ -138,7 +138,7 @@ edge
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = edge=8
@@ -158,7 +158,7 @@ emboss
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = emboss
@@ -177,7 +177,7 @@ flip
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = flip
@@ -196,7 +196,7 @@ flop
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = flop
@@ -217,7 +217,7 @@ gamma
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = gamma=1.3
@@ -239,7 +239,7 @@ gray
     renders it in gray.
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = wave=1,20 | gray
@@ -258,7 +258,7 @@ invert
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = invert
@@ -282,7 +282,7 @@ rotate
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = rotate=180
@@ -303,7 +303,7 @@ sharpen
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = sharpen=12
@@ -327,7 +327,7 @@ shear
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = shear=-30
@@ -352,7 +352,7 @@ solarize
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = solarize=15
@@ -373,7 +373,7 @@ swirl
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = swirl=200
@@ -396,7 +396,7 @@ wave
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         20 = EFFECT
         20.value = wave=1,20

--- a/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Ellipse/Index.rst
@@ -14,7 +14,7 @@ Example
 =======
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     file = GIFBUILDER
     file {

--- a/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Image/Index.rst
@@ -59,7 +59,7 @@ align
     Horizontally centered, vertically at the bottom:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         align = c, b
 

--- a/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
+++ b/Documentation/Gifbuilder/ObjectNames/Text/Index.rst
@@ -422,7 +422,7 @@ splitRendering
     **Example:**
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         10.splitRendering.compX = 2
         10.splitRendering.compY = -2

--- a/Documentation/Glossary.rst
+++ b/Documentation/Glossary.rst
@@ -36,7 +36,7 @@ To reuse the OOP analogy and compare with PHP:
 Example 1 (assign value to property in object1:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    object1 = OBJECTTYPE1
    object1 {
@@ -47,7 +47,7 @@ Example 1 (assign value to property in object1:
 Example 2:
 
 .. code-block:: typoscript
-   :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+   :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
    # here, object1 is defined as type OBJECTTYPE1
    #   "OBJECTTYPE1" is an object type, so is OTHER

--- a/Documentation/Syntax/Conditions/Index.rst
+++ b/Documentation/Syntax/Conditions/Index.rst
@@ -37,7 +37,7 @@ Basic usage of TypoScript conditions
 ====================================
 
 ..  literalinclude:: _codesnippets/_basic.typoscript
-    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/Sets/Main/setup.typoscript
 
 ..  _typoscript-syntax-conditions-syntax:
 
@@ -72,7 +72,7 @@ is considered if the condition criteria did *not* evaluate to true.
 This is similar to a closing curly brace :code:`}` in programming languages like PHP.
 
 ..  literalinclude:: _codesnippets/_condition.typoscript
-    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/Sets/Main/setup.typoscript
 
 Conditions automatically stop at the end of a text snippet (file or record), even
 without :typoscript:`[END]` or :typoscript:`[GLOBAL]`. Another snippet on the same
@@ -96,7 +96,7 @@ Multiple condition criteria can be combined using :typoscript:`or` or :typoscrip
 as well as :typoscript:`and` or :typoscript:`&&`
 
 ..  literalinclude:: _codesnippets/_andor.typoscript
-    :caption: packages/my_site_package/Configuration/TypoScript/setup.typoscript
+    :caption: packages/my_site_package/Configuration/Sets/Main/setup.typoscript
 
 Single criteria can be negated using :typoscript:`!`
 

--- a/Documentation/Syntax/Operators/Index.rst
+++ b/Documentation/Syntax/Operators/Index.rst
@@ -345,7 +345,7 @@ Example that evaluates to `$config.oldThing` if set, otherwise the newer setting
 `$myext.thing` would be used:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     plugin.tx_myext.settings.example = {$config.oldThing ?? $myext.thing}
 
@@ -354,7 +354,7 @@ The null coalescing operator cannot be used in conditions. Use
 instead:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     # Wrong
     # [{$config.oldThing ?? $myext.thing} == 5]

--- a/Documentation/Syntax/StringFormats/Index.rst
+++ b/Documentation/Syntax/StringFormats/Index.rst
@@ -41,7 +41,7 @@ boolean
     ..  rubric:: Examples
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         dummy.enable = 0   # false, preferred notation
         dummy.enable = 1   # true,  preferred notation
@@ -63,7 +63,7 @@ date-conf
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.date-conf = d-m-y
 
@@ -125,7 +125,7 @@ path
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.settings.somePath = fileadmin/stuff/
 
@@ -158,7 +158,7 @@ resource
     Reference to a file in the file system:
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         # PKG should be preferred to EXT
         page.10.settings.someFile = PKG:my-vendor/package-name:Resources/Public/Icons/MyIcon.svg
@@ -194,7 +194,7 @@ string
     ..  rubric:: Example
 
     ..  code-block:: typoscript
-        :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
         page.10.value = The quick brown fox jumps over the lazy dog.
 

--- a/Documentation/TopLevelObjects/Config.rst
+++ b/Documentation/TopLevelObjects/Config.rst
@@ -146,7 +146,7 @@ Properties of 'config'
         lifetime calculation of page <page-id>, add the following TypoScript:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             config.cache.<page-id> = <table name>:<storage-pid>
 
@@ -1052,7 +1052,7 @@ This includes the :sql:`fe_users` records on page 2 in the cache lifetime
 calculation for page 10:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.cache.10 = fe_users:2
 
@@ -1060,7 +1060,7 @@ This includes records from multiple sources; :sql:`fe_users`
 records on page 2 and :sql:`tt_new` records on page 11:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.cache.10 = fe_users:2,tt_news:11
 
@@ -1068,7 +1068,7 @@ Take :sql:`fe_users` records on storage page 2 into account for the cache lifeti
 pages:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.cache.all = fe_users:2
 
@@ -1076,7 +1076,7 @@ Each page's cache lifetime is affected if fe_users stored on the same page are
 changed:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.cache.all = fe_users:current
 
@@ -1089,7 +1089,7 @@ Demonstrates:
     *   :confval:`config.contentObjectExceptionHandler <config-contentObjectExceptionHandler>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # Use 1 for the default exception handler (enabled by default in production context)
     config.contentObjectExceptionHandler = 1
@@ -1123,7 +1123,7 @@ Provide JSON and disable HTML headers
 A page type providing JSON:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     json = PAGE
     json {
@@ -1144,7 +1144,7 @@ Demonstrates:
     * :confval:`config.htmlTag.attributes <config-htmlTag-attributes>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.htmlTag.attributes.class = no-js
 
@@ -1156,7 +1156,7 @@ Results in :
     <html lang="fr" class="no-js">
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.htmlTag.attributes.amp =
 
@@ -1187,7 +1187,7 @@ Demonstrates:
     * :confval:`config.htmlTag_setParams <config-htmlTag-setParams>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.htmlTag_setParams = xmlns="http://www.w3.org/1999/xhtml" xml:lang="en-US"
 
@@ -1200,7 +1200,7 @@ Demonstrates:
     * :confval:`config.inlineStyle2TempFile <config-inlineStyle2TempFile>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.inlineStyle2TempFile = 0
 
@@ -1213,14 +1213,14 @@ Demonstrates:
     * :confval:`config.linkVars <config-linkVars>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.linkVars = print
 
 This will add `&print=[print-value]` to all links in TYPO3.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.linkVars = tracking|green(0-5)
 
@@ -1236,7 +1236,7 @@ Demonstrates:
     * :confval:`config.message_preview_workspace <config-message_preview_workspace>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.message_preview_workspace = <div class="previewbox">Displaying workspace named "%s" (number %s)!</div>
     config.message_preview_workspace = <div class="previewbox">Displaying workspace number %2$s named "%1$s"!</div>
@@ -1251,7 +1251,7 @@ Demonstrates:
     * :confval:`config.MP_defaults <config-MP_defaults>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.MP_defaults = 36,37,48 : 2-207
 
@@ -1267,7 +1267,7 @@ Demonstrates:
     * :confval:`config.namespaces <config-namespaces>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.namespaces.dc = http://purl.org/dc/elements/1.1/
     config.namespaces.foaf = http://xmlns.com/foaf/0.1/
@@ -1275,7 +1275,7 @@ Demonstrates:
 This configuration will result in an :html:`<html>` tag like:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     <html xmlns:dc="http://purl.org/dc/elements/1.1/"
        xmlns:foaf="http://xmlns.com/foaf/0.1/">
@@ -1289,7 +1289,7 @@ Demonstrates:
     * :confval:`config.pageRendererTemplateFile <config-pageRendererTemplateFile>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageRendererTemplateFile = EXT:my_extension/Resources/Private/Templates/TestPagerender.fluid.html
 
@@ -1305,7 +1305,7 @@ Demonstrates:
 By default, TYPO3 ships with two providers:
 
 .. code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageTitleProviders {
         record {
@@ -1341,14 +1341,14 @@ Demonstrates:
 This produces a title tag with the format "website . page title":
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageTitleSeparator = .
 
 This produces a title tag with the format "website - page title":
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageTitleSeparator = -
     config.pageTitleSeparator.noTrimWrap = | | |
@@ -1356,7 +1356,7 @@ This produces a title tag with the format "website - page title":
 This produces a title tag with the format "website*page title":
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageTitleSeparator = *
     config.pageTitleSeparator.noTrimWrap = |||
@@ -1365,7 +1365,7 @@ If you want to remove the web page title from the title, choose a separator that
 Then split the title from that character and return the second part only:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.pageTitleSeparator = *
     config.pageTitle.stdWrap {
@@ -1385,7 +1385,7 @@ Demonstrates:
     * :confval:`config.removeDefaultCss <config-removeDefaultCss>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config  {
         removeDefaultJS = external
@@ -1404,7 +1404,7 @@ Demonstrates:
     * :confval:`config.spamProtectEmailAddresses_lastDotSubst <config-spamProtectEmailAddresses_lastDotSubst>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config {
         spamProtectEmailAddresses = -2
@@ -1421,7 +1421,7 @@ Demonstrates:
     * :confval:`config.tx_myextension <config-tx-extension-key-with-no-underscores>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config.tx_realurl_enable = 1
     config.tx_myextension.width  = 10
@@ -1438,7 +1438,7 @@ Demonstrates:
     * :confval:`config.typolinkLinkAccessRestrictedPages_addParams <config-typolinkLinkAccessRestrictedPages_addParams>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     config {
         typolinkLinkAccessRestrictedPages = 29

--- a/Documentation/TopLevelObjects/Other.rst
+++ b/Documentation/TopLevelObjects/Other.rst
@@ -29,7 +29,7 @@ lib
     :ref:`reference operator <typoscript-syntax-syntax-object-referencing>` :typoscript:`=<`.
 
 ..  code-block:: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
     lib.some_content = TEXT
     lib.some_content.value = Hello World!

--- a/Documentation/TopLevelObjects/Page/Index.rst
+++ b/Documentation/TopLevelObjects/Page/Index.rst
@@ -22,7 +22,7 @@ TYPO3 does not initialize :typoscript:`page` by default. You must initialize thi
 explicitly, for example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
 
@@ -80,7 +80,7 @@ This default behaviour can be changed by setting the property
 :ref:`setup-config-disableallheadercode`:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.config.disableAllHeaderCode = 1
 
@@ -88,7 +88,7 @@ If the output represents another format different from HTML the HTTP header
 should also be set, for example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.config.additionalHeaders.10.header = Content-type:application/json
 
@@ -113,7 +113,7 @@ the page will be used.
 Example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.typeNum = 0
@@ -511,7 +511,7 @@ Properties
         There is no :typoscript:`data`-array as optional parameter but all keys not explicitly mentioned as parameters are used as additional attributes - behaviour is the same as in :confval:`includeCSS <page-includeCSS>`.
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             # This will lead to <script src="/_assets/.../Frontend/JavaScript/somefile.js?123456" data-foo="data-bar" foo="bar"></script>
             page.includeJSFooterlibs {
@@ -539,7 +539,7 @@ Properties
         There is no :typoscript:`data`-array as optional parameter but all keys not explicitly mentioned as parameters are used as additional attributes - behaviour is the same as in :confval:`includeCSS <page-includeCSS>`.
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             # This will lead to <script src="/_assets/.../Frontend/JavaScript/somefile.js?123456" data-foo="data-bar" foo="bar"></script>
             page.includeJSLibs {
@@ -715,7 +715,7 @@ Demonstrates:
 
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page.20 = TEXT
@@ -734,7 +734,7 @@ Demonstrates:
     * :confval:`page.bodyTag <page-bodytag>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # This will lead to <body class="example"> if constant "bodyClass" is set accordingly.
     page.bodyTag = <body class="{$bodyClass}">
@@ -748,7 +748,7 @@ Demonstrates:
     * :confval:`page.bodyTagAdd <page-bodyTagAdd>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     # This will lead to <body class="example">
     page.bodyTagAdd = class="example"
@@ -762,7 +762,7 @@ Demonstrates:
     * :confval:`page.cssInline <page-cssInline>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -784,7 +784,7 @@ Demonstrates:
     * :confval:`page.footerData <page-footerData>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -806,7 +806,7 @@ Demonstrates:
     * :confval:`page.headerData <page-headerData>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -828,7 +828,7 @@ Demonstrates:
     * :confval:`page.includeCSS <page-includeCSS>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -859,7 +859,7 @@ Demonstrates:
     * :confval:`page.includeCSSLibs <page-includeCSSLibs>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -880,7 +880,7 @@ Demonstrates:
     * :confval:`page.includeJS <page-includeJS>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -917,7 +917,7 @@ Demonstrates:
     * :confval:`page.inlineLanguageLabelFiles <page-inlineLanguageLabelFiles>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -938,7 +938,7 @@ Demonstrates:
     * :confval:`page.inlineSettings <page-inlineSettings>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -963,7 +963,7 @@ Demonstrates:
     * :confval:`page.jsFooterInline <page-jsFooterInline>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -982,7 +982,7 @@ Demonstrates:
     * :confval:`page.jsFooterInline <page-jsFooterInline>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -1001,7 +1001,7 @@ Demonstrates:
     * :confval:`page.meta <page-meta>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -1023,7 +1023,7 @@ Demonstrates:
 If the page record is not set search up the root line of pages.
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -1041,7 +1041,7 @@ Demonstrates:
     * :confval:`page.meta <page-meta>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.meta.refresh = 5; url=https://example.org/
     page.meta.refresh.attribute = http-equiv
@@ -1058,7 +1058,7 @@ Meta tags with a different attribute name are supported like the
 Open Graph meta tags:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     # [...]
@@ -1117,7 +1117,7 @@ Demonstrates:
     * :confval:`page.shortcutIcon <page-shortcutIcon>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page.shortcutIcon = EXT:site_package/Resources/Public/Images/favicon.ico
 

--- a/Documentation/TopLevelObjects/PageAndConfig.rst
+++ b/Documentation/TopLevelObjects/PageAndConfig.rst
@@ -35,7 +35,7 @@ TYPO3 does not initialize :typoscript:`page` by default. You must initialize thi
 explicitly, for example:
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
 

--- a/Documentation/TopLevelObjects/Plugin.rst
+++ b/Documentation/TopLevelObjects/Plugin.rst
@@ -63,7 +63,7 @@ Properties for all frontend plugin types
         default styles can be removed with:
 
         ..  code-block:: typoscript
-            :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+            :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
             plugin.tx_frontend._CSS_DEFAULT_STYLE >
             plugin.tx_indexedsearch._CSS_DEFAULT_STYLE >
@@ -375,14 +375,14 @@ Demonstrates:
 Definition for *all* plugins of an extension:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     plugin.tx_myextension.ignoreFlexFormSettingsIfEmpty = field1,field2
 
 Definition for *one* plugin of an extension:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     plugin.tx_myextension_myplugin.ignoreFlexFormSettingsIfEmpty = field1,field2
 
@@ -391,7 +391,7 @@ integrators are advised to use :typoscript:`addToList` or
 :typoscript:`removeFromList` to modify existing settings:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
     plugin.tx_myextension_myplugin.ignoreFlexFormSettingsIfEmpty := removeFromList(field1)
     plugin.tx_myextension_myplugin.ignoreFlexFormSettingsIfEmpty := addToList(field3)
@@ -410,7 +410,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].persistence.enableAutomaticCacheClearing <plugin-persistence-enableautomaticcacheclearing>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample_admin {
         persistence {
@@ -431,7 +431,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].persistence.recursive <plugin-persistence-recursive>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample {
         persistence {
@@ -464,7 +464,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].view.templateRootPaths.[array] <plugin-view-templaterootpaths>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample {
         view {
@@ -497,7 +497,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].mvc.callDefaultActionIfActionCantBeResolved <plugin-mvc-calldefaultactionifactioncantberesolved>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample {
         mvc {
@@ -514,7 +514,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].mvc.throwPageNotFoundExceptionIfActionCantBeResolved <plugin-mvc-throwpagenotfoundexceptionifactioncantberesolved>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample {
         mvc {
@@ -537,7 +537,7 @@ Demonstrates:
     *   :confval:`plugin.[extension].format <plugin-format>`
 
 ..  code-block:: typoscript
-    :caption: EXT:blog_example/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:blog_example/Configuration/Sets/BlogExample/setup.typoscript
 
     plugin.tx_blogexample_rssfeedxml {
         // Use template List.xml
@@ -562,6 +562,6 @@ Demonstrates:
     *   :confval:`plugin.[extension]._LOCAL_LANG <plugin-local-lang>`
 
 ..  code-block:: typoscript
-    :caption: EXT:site_package/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:site_package/Configuration/Sets/Main/setup.typoscript
 
     plugin.tx_myextension_pi1._LOCAL_LANG.de.list_mode_1 = Der erste Modus

--- a/Documentation/UsingSetting/AccessTypoScriptWithExtensions.rst
+++ b/Documentation/UsingSetting/AccessTypoScriptWithExtensions.rst
@@ -33,7 +33,7 @@ In order to access TypoScript settings from an Extbase controller.
 #.  Use the convention of defining your TypoScript settings in :typoscript:`settings`
 
     ..  code-block:: typoscript
-        :caption: EXT:my_extension/Configuration/TypoScript/setup.typoscript
+        :caption: EXT:my_extension/Configuration/Sets/Main/setup.typoscript
 
         plugin.tx_myextension {
            view {

--- a/Documentation/UsingSetting/Constants.rst
+++ b/Documentation/UsingSetting/Constants.rst
@@ -109,7 +109,7 @@ Example
 -------
 
 ..  code-block:: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/setup.typoscript
 
     page = PAGE
     page {
@@ -123,7 +123,7 @@ For the above example to work, the constants from the last example have to be
 defined in the constants field or a file called :file:`constants.typoscript`:
 
 ..  code-block:: typoscript
-    :caption: EXT:my_sitepackage/Configuration/TypoScript/constants.typoscript
+    :caption: EXT:my_sitepackage/Configuration/Sets/Main/constants.typoscript
 
     tx_my_sitepackage {
       bgCol = bg-primary


### PR DESCRIPTION
403 captions in this manual point at
EXT:site_package/Configuration/TypoScript/setup.typoscript. Nothing
includes that file. A reader who follows the caption, creates the file
and reloads the page sees no change and has no way to tell why. A site
set is included as soon as a site lists it, so the same example placed
in Configuration/Sets/Main/setup.typoscript does what the page says it
does.

The extension keys are left as they are — site_package, my_sitepackage,
my_extension and packages/my_site_package all appear as captions in this
manual, and unifying them is a separate question from whether the path
works.

Two captions are deliberately not moved. In UsingSetting/Entering.rst
the text is about the Constants and Setup fields of a template record,
where a file inside a set would contradict it; the @import examples in
UsingSetting/AddTypoScriptWithExtensions.rst show exactly the manual
inclusion that makes the old path work, and are code, not captions.

EXT:blog_example is a real extension and had no Configuration/TypoScript
directory at all: its TypoScript is in Configuration/Sets/BlogExample/
setup.typoscript, which is what those six captions now name.

Releases: main, 14.3
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf
