### PR TITLE
[Backport 13.4] [TASK] Drop a redundant language option from two literalincludes

### DIFF
--- a/Documentation/ContentObjects/Pageview/Index.rst
+++ b/Documentation/ContentObjects/Pageview/Index.rst
@@ -371,11 +371,9 @@ Example: Make additional variables available in the Fluid template
 ------------------------------------------------------------------
 
 ..  literalinclude:: _includes/_pageWithVariables.typoscript
-    :langugage: typoscript
     :caption: EXT:my_sitepackage/Configuration/TypoScript/setup.typoscript
 
 The following variables are now available in the Fluid template:
 
 ..  literalinclude:: _includes/_PageWithVariables.html
-    :langugage: html
     :caption: EXT:my_sitepackage/Resources/Private/PageView/Pages/Default.html


### PR DESCRIPTION
Two literalinclude blocks in the PAGEVIEW chapter carry an option spelled
:langugage:. It did nothing, and the correct spelling would do nothing
either: literalinclude derives the language from the file extension, so
_pageWithVariables.typoscript renders as typoscript and
_PageWithVariables.fluid.html as xml with or without the option. The
lines are removed rather than corrected.

The misspelling is also why this sat here unnoticed — a search for
:language: does not find it.

Releases: main, 14.3, 13.4
Assisted-by: Claude Opus 5 <noreply@anthropic.com>
Signed-off-by: Lina Wolf

Backport of #1851 to 13.4.

Only the two :langugage: lines are removed. This branch keeps its own
captions and include names — Configuration/TypoScript/setup.typoscript
and _PageWithVariables.html — since neither the move onto site sets nor
the .fluid.html rename applies here. Both blocks still render as
typoscript and xml, which is the point: the option was doing nothing.
